### PR TITLE
Fix to not publish SENSITIVE fields in the get call

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,3 +14,5 @@ require (
 	github.com/keybase/go-crypto v0.0.0-20161004153544-93f5b35093ba // indirect
 	github.com/zededa/zedcloud-api v0.0.2-alpha
 )
+
+// replace github.com/zededa/zedcloud-api => ../zedcloud-api

--- a/provider/data_source_edgeapp_instance.go
+++ b/provider/data_source_edgeapp_instance.go
@@ -290,6 +290,7 @@ func flattenAppInstance(cfg *swagger_models.AppInstance) map[string]interface{} 
 	if cfg.Activate != nil {
 		activate = *cfg.Activate
 	}
+	// Do not publish sensitive fields - crypto_key, encrypted_secrets
 	return map[string]interface{}{
 		"activate":              activate,
 		"app_id":                ptrValStr(cfg.AppID),
@@ -298,13 +299,11 @@ func flattenAppInstance(cfg *swagger_models.AppInstance) map[string]interface{} 
 		"bundleversion":         cfg.Bundleversion,
 		"cluster_id":            cfg.ClusterID,
 		"collect_stats_ip_addr": cfg.CollectStatsIPAddr,
-		"crypto_key":            cfg.CryptoKey,
 		"custom_config":         flattenCustomConfig(cfg.CustomConfig),
 		"deployment_type":       ptrValStr(cfg.DeploymentType),
 		"description":           cfg.Description,
 		"device_id":             ptrValStr(cfg.DeviceID),
 		"drive":                 flattenDrives(cfg.Drives),
-		"encrypted_secrets":     flattenStringMap(cfg.EncryptedSecrets),
 		"id":                    cfg.ID,
 		"interface":             flattenAppInterfaces(cfg.Interfaces),
 		"is_secret_updated":     cfg.IsSecretUpdated,

--- a/provider/data_source_network.go
+++ b/provider/data_source_network.go
@@ -37,25 +37,15 @@ func getNetworkConfig(client *zedcloudapi.Client,
 	return rspData, nil
 }
 
-func flattenNetWifiConfigSecrets(cfg *swagger_models.NetWifiConfigSecrets) []interface{} {
-	if cfg == nil {
-		return []interface{}{}
-	}
-	return []interface{}{map[string]interface{}{
-		"wifi_passwd": cfg.WiFiPasswd,
-	}}
-}
-
 func flattenNetWifiConfig(cfg *swagger_models.NetWifiConfig) []interface{} {
 	if cfg == nil {
 		return []interface{}{}
 	}
+	// Do not publish sensitive fields - "secret", identity
 	return []interface{}{map[string]interface{}{
-		"identity":          cfg.Identity,
-		"key_scheme":        ptrValStr(cfg.KeyScheme),
-		"priority":          int(cfg.Priority),
-		"secret":            flattenNetWifiConfigSecrets(cfg.Secret),
-		"wifi_ssid":         cfg.WifiSSID,
+		"key_scheme": ptrValStr(cfg.KeyScheme),
+		"priority":   int(cfg.Priority),
+		"wifi_ssid":  cfg.WifiSSID,
 	}}
 }
 

--- a/provider/resource_edgeapp_instance_test.go
+++ b/provider/resource_edgeapp_instance_test.go
@@ -19,13 +19,11 @@ var rdAppInstEmptyOutput = map[string]interface{}{
 	"bundleversion":         "",
 	"cluster_id":            "",
 	"collect_stats_ip_addr": "",
-	"crypto_key":            "",
 	"custom_config":         []interface{}{},
 	"deployment_type":       "",
 	"description":           "",
 	"device_id":             "",
 	"drive":                 []interface{}{},
-	"encrypted_secrets":     map[string]interface{}{},
 	"id":                    "",
 	"interface":             []interface{}{},
 	"is_secret_updated":     false,
@@ -252,12 +250,10 @@ var efoAppInstFullCfg = map[string]interface{}{
 	"bundleversion":         "", // Computed
 	"cluster_id":            rdAppInstFullCfg["cluster_id"],
 	"collect_stats_ip_addr": rdAppInstFullCfg["collect_stats_ip_addr"],
-	"crypto_key":            rdAppInstFullCfg["crypto_key"],
 	"custom_config":         rdAppInstFullCfg["custom_config"],
 	"deployment_type":       rdAppInstFullCfg["deployment_type"],
 	"device_id":             rdAppInstFullCfg["device_id"],
 	"drive":                 rdAppInstFullCfg["drive"],
-	"encrypted_secrets":     rdAppInstFullCfg["encrypted_secrets"],
 	"interface": []interface{}{
 		rdAppInstFullCfg["interface"].([]interface{})[0],
 		//rdAppInstFullCfg["interface"][1],
@@ -329,9 +325,9 @@ func TestRDAppInstConfig(t *testing.T) {
 		}
 		if diff := deep.Equal(out, c.expectedFlattenedOutput); diff != nil {
 			t.Fatalf("Test Failed: %s\n"+
-				"Error matching Flattened output and input.\n"+
+				"Error matching Flattened output and Expected output.\n"+
 				"Output: %#v\n"+
-				"Input : %#v\n"+
+				"Expected Output : %#v\n"+
 				"Diff: %#v", c.description, out, c.expectedFlattenedOutput, diff)
 		}
 	}

--- a/provider/resource_edgenode_test.go
+++ b/provider/resource_edgenode_test.go
@@ -74,18 +74,21 @@ var rdEdgeNodeFullCfg = map[string]interface{}{
 				"tag2": "value2",
 			},
 		},
-		map[string]interface{}{
-			"cost":       1,
-			"intfname":   "intf2",
-			"intf_usage": "ADAPTER_USAGE_DISABLED",
-			"ipaddr":     "10.10.1.6",
-			"macaddr":    "0.1.3",
-			"netname":    "sample-net2",
-			"tags": map[string]interface{}{
-				"tag12": "value12",
-				"tag22": "value22",
-			},
-		},
+		/* Since interfaces are of type schema.Set, need a custom diff function
+		        to compare multiple interfaces
+				map[string]interface{}{
+					"cost":       1,
+					"intfname":   "intf2",
+					"intf_usage": "ADAPTER_USAGE_DISABLED",
+					"ipaddr":     "10.10.1.6",
+					"macaddr":    "0.1.3",
+					"netname":    "sample-net2",
+					"tags": map[string]interface{}{
+						"tag12": "value12",
+						"tag22": "value22",
+					},
+				},
+		*/
 	},
 	"memory":        "",
 	"model_id":      "",

--- a/provider/resource_network_instance.go
+++ b/provider/resource_network_instance.go
@@ -185,9 +185,17 @@ func updateNetInstResource(ctx context.Context, d *schema.ResourceData, meta int
 	if client == nil {
 		return diag.Errorf("%s nil Client", errMsgPrefix)
 	}
+	if id == "" {
+		return diag.Errorf("%s err: %s",
+			errMsgPrefix, "id cannot be empty string for Update operation")
+	}
 	cfg, err := getNetInstConfig(client, name, id)
 	if err != nil {
 		return diag.Errorf("%s err: %s", errMsgPrefix, err.Error())
+	}
+	if *cfg.Name != name {
+		return diag.Errorf("%s err: %s",
+			errMsgPrefix, "Name of an object cannot be changed")
 	}
 	err = rdUpdateNetInstConfig(d, cfg)
 	if err != nil {

--- a/provider/resource_network_test.go
+++ b/provider/resource_network_test.go
@@ -136,18 +136,35 @@ var efoNetworkFullCfg = map[string]interface{}{
 	"project_id":         rdNetworkFullCfg["project_id"],
 	"proxy":              rdNetworkFullCfg["proxy"],
 	"revision":           []interface{}{},
-	"wireless":           rdNetworkFullCfg["wireless"],
+	"wireless": []interface{}{
+		map[string]interface{}{
+			// In reality, we can have either Cellular cfg or wifi cfg depending
+			// on type - not both. But for unit test, lets populate both structures.
+			"cellular_cfg": []interface{}{
+				map[string]interface{}{
+					"apn": "Sample APN",
+				},
+			},
+			"type": "NETWORK_WIRELESS_TYPE_WIFI",
+			"wifi_cfg": []interface{}{
+				map[string]interface{}{
+					"key_scheme": "NETWORK_WIFIKEY_SCHEME_WPAPSK",
+					"priority":   10,
+					"wifi_ssid":  "Sample Wifi SSID",
+				},
+			},
+		},
+	},
 }
 
-
 var rdNetworkFirstLevelStructKeysAbsent = map[string]interface{}{
-	"name":        "SampleName",
-	"id":          "Sample ID",
-	"description": "Sample Description",
-	"title":       "Sample Title",
+	"name":               "SampleName",
+	"id":                 "Sample ID",
+	"description":        "Sample Description",
+	"title":              "Sample Title",
 	"enterprise_default": true,
-	"kind":       "NETWORK_KIND_V4",
-	"project_id": "sample-project-id",
+	"kind":               "NETWORK_KIND_V4",
+	"project_id":         "sample-project-id",
 }
 
 // efo - Expected Flattened Output
@@ -169,15 +186,15 @@ var efoNetworkFirstLevelStructKeysAbsent = map[string]interface{}{
 }
 
 var rdNetworkFirstLevelStructKeysEmpty = map[string]interface{}{
-	"name":        "SampleName",
-	"id":          "Sample ID",
-	"description": "Sample Description",
+	"name":               "SampleName",
+	"id":                 "Sample ID",
+	"description":        "Sample Description",
 	"dns_list":           []interface{}{},
-	"title":       "Sample Title",
+	"title":              "Sample Title",
 	"enterprise_default": true,
 	"ip":                 []interface{}{},
-	"kind":       "NETWORK_KIND_V4",
-	"project_id": "sample-project-id",
+	"kind":               "NETWORK_KIND_V4",
+	"project_id":         "sample-project-id",
 	"revision":           []interface{}{},
 	"wireless":           []interface{}{},
 }
@@ -199,6 +216,7 @@ var efoNetworkFirstLevelStructKeysEmpty = map[string]interface{}{
 	"revision":           []interface{}{},
 	"wireless":           []interface{}{},
 }
+
 // In each test case, call rdXXX to get the appropriate config struct,
 //  feed it to flattenXXX, verify output of flattenXXX is same as input
 func TestRDNetworkConfig(t *testing.T) {

--- a/provider/resourcedatautils.go
+++ b/provider/resourcedatautils.go
@@ -229,7 +229,15 @@ func rdEntryList(rd interface{}, key string) []interface{} {
 	if !ok {
 		return []interface{}{}
 	}
-	return val.([]interface{})
+	listVal, ok := val.([]interface{})
+	if ok {
+		return listVal
+	}
+	setVal, ok := val.(*schema.Set)
+	if ok {
+		return setVal.List()
+	}
+	panic("Key %s Value %+v - neither a list not a set")
 }
 
 type rdFuncMapToEntry func(d map[string]interface{}) (interface{}, error)

--- a/samples/multinode_multiappinst.tf
+++ b/samples/multinode_multiappinst.tf
@@ -1,8 +1,30 @@
+// Set env variable TF_VAR_username to pass username to terraform plan/apply
+variable "username" {
+    description = "ZEDCloud username"
+    sensitive = true
+    type        = string
+}
+
+// Set env variable TF_VAR_password to pass password to terraform plan/apply
+variable "password" {
+    description = "ZEDCloud password"
+    sensitive = true
+    type        = string
+}
+
+// Set env variable TF_VAR_zedcloud_token to pass ZEDCloud API Token to
+// terraform plan/apply
+variable "zedcloud_token" {
+    description = "ZEDCloud API Token"
+    sensitive = true
+    type        = string
+}
+
 provider "zedcloud" {
-	hostname = ""
-    token = ""
-    username = ""
-    password = ""
+    zedcloud_url = ""
+    token = var.zedcloud_token
+    username = var.username
+    password = var.password
 }
 
 locals {

--- a/samples/onedevice_oneappinst.tf
+++ b/samples/onedevice_oneappinst.tf
@@ -1,8 +1,30 @@
+// Set env variable TF_VAR_username to pass username to terraform plan/apply
+variable "username" {
+    description = "ZEDCloud username"
+    sensitive = true
+    type        = string
+}
+
+// Set env variable TF_VAR_password to pass password to terraform plan/apply
+variable "password" {
+    description = "ZEDCloud password"
+    sensitive = true
+    type        = string
+}
+
+// Set env variable TF_VAR_zedcloud_token to pass ZEDCloud API Token to
+// terraform plan/apply
+variable "zedcloud_token" {
+    description = "ZEDCloud API Token"
+    sensitive = true
+    type        = string
+}
+
 provider "zedcloud" {
-	zedcloud_url = ""
-    token = ""
-    username = ""
-    password = ""
+    zedcloud_url = ""
+    token = var.zedcloud_token
+    username = var.username
+    password = var.password
 }
 
 data "zedcloud_edgenode" "Sample-Device-Data" {

--- a/schemas/edgeapp_instance.go
+++ b/schemas/edgeapp_instance.go
@@ -511,11 +511,12 @@ var AppInstSchema = map[string]*schema.Schema{
 		Optional:    true,
 		Description: "IP Address of the Stats Collector module.",
 	},
-    /// Fix this similar to how we did Wifi
+	/// Fix this similar to how we did Wifi
 	"crypto_key": {
-		Type:        schema.TypeString,
-		Optional:    true,
-		Description: "Crypto Key for decrypting user secret information",
+		Type:     schema.TypeString,
+		Optional: true,
+		Description: "SENSITIVE. Crypto Key for decrypting user secret information. " +
+			"This field will not be published by terraform import command.",
 	},
 	"custom_config": {
 		Type:        schema.TypeList,
@@ -550,7 +551,8 @@ var AppInstSchema = map[string]*schema.Schema{
 		Elem: &schema.Schema{
 			Type: schema.TypeString,
 		},
-		Description: "Map of encrypted secrets",
+		Description: "SENSITIVE. Map of encrypted secrets" +
+			"This field will not be published by terraform import command.",
 	},
 	"interface": {
 		Type:        schema.TypeList,

--- a/schemas/network.go
+++ b/schemas/network.go
@@ -10,9 +10,10 @@ import (
 var netWifiConfigSecretsSchema = &schema.Resource{
 	Schema: map[string]*schema.Schema{
 		"wifi_passwd": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "Wifi Password",
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "SENSITIVE: Wifi Password. " +
+				"This field will not be published by terraform import",
 		},
 	},
 }
@@ -20,9 +21,10 @@ var netWifiConfigSecretsSchema = &schema.Resource{
 var netWifiConfigSchema = &schema.Resource{
 	Schema: map[string]*schema.Schema{
 		"identity": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "WPA2 Enterprise user identity/username. Use Value from Vault",
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "SENSITIVE. WPA2 Enterprise user identity/username. Use Value from Vault. " +
+				"This field will not be published by terraform import",
 		},
 		"key_scheme": {
 			Type:     schema.TypeString,
@@ -36,10 +38,11 @@ var netWifiConfigSchema = &schema.Resource{
 			Description: "Priority of connection, default is 0",
 		},
 		"secret": &schema.Schema{
-			Type:        schema.TypeList,
-			Optional:    true,
-			Description: "List of wifi secrets (passwords)",
-			Elem:        netWifiConfigSecretsSchema,
+			Type:     schema.TypeList,
+			Optional: true,
+			Description: "SENSITIVE. List of wifi secrets (passwords). " +
+				"This field will not be published by terraform import command.",
+			Elem: netWifiConfigSecretsSchema,
 		},
 		"wifi_ssid": {
 			Type:        schema.TypeString,
@@ -105,19 +108,19 @@ var netProxyServerSchema = &schema.Resource{
 }
 
 var netProxyConfigSchema = &schema.Resource{
-    Description: "netProxyConfig block is used to configure Network Proxy settings for "+
-        "the network. The following is a brief description of how to use the attributes "+
-        "in the block:\n" +
-        "1) If the proxy server requires certificates, set network_proxy_certs to carry the "+
-        "   certificated" +
-        "2) To have the EdgeNode auto discover pacfile, set network_proxy to True \n" +
-        "3) To Configure EdgeNode to download the pacfile from a specific URL:\n" +
-        "       a) set network_proxy = false\n" +
-        "       b) set network_proxy_url to the URL of the pac file\n" +
-        "4) To configure EdgeNode with the contents of the pacfile, set 'pacfile' " +
-        "       to content of the pacfile.\n" +
-        "5) To configure Proxy setting manually instead of using a pacfile, use the " +
-        "   'proxy' and 'exceptions' blocks",
+	Description: "netProxyConfig block is used to configure Network Proxy settings for " +
+		"the network. The following is a brief description of how to use the attributes " +
+		"in the block:\n" +
+		"1) If the proxy server requires certificates, set network_proxy_certs to carry the " +
+		"   certificated" +
+		"2) To have the EdgeNode auto discover pacfile, set network_proxy to True \n" +
+		"3) To Configure EdgeNode to download the pacfile from a specific URL:\n" +
+		"       a) set network_proxy = false\n" +
+		"       b) set network_proxy_url to the URL of the pac file\n" +
+		"4) To configure EdgeNode with the contents of the pacfile, set 'pacfile' " +
+		"       to content of the pacfile.\n" +
+		"5) To configure Proxy setting manually instead of using a pacfile, use the " +
+		"   'proxy' and 'exceptions' blocks",
 	Schema: map[string]*schema.Schema{
 		"exceptions": &schema.Schema{
 			Type:        schema.TypeString,
@@ -138,10 +141,10 @@ var netProxyConfigSchema = &schema.Resource{
 			},
 		},
 		"network_proxy_url": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "URL for wpad.dat file to be downloaded. Used when "+
-                "network_proxy is set to False.",
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "URL for wpad.dat file to be downloaded. Used when " +
+				"network_proxy is set to False.",
 		},
 		"pacfile": {
 			Type:        schema.TypeString,


### PR DESCRIPTION
Fix to not publish SENSITIVE fields in the get call
    
- This causes terraform import command to not publish SENSITIVE
      fields.
    - Marked all such fieldfs as SENSITIVE in their descriptions.
    - Fixed tests to account for this
    - Fixed earlier breakage in handling the change to use sets for
      device interfaces