### PR TITLE
Improved Error checking / Fix makefile / Fix Samples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,5 @@
 all: plugin
 
 plugin:
-	go mod download
 	go build -o terraform-provider-zedcloud_v0.0.0
 	chmod a+x terraform-provider-zedcloud_v0.0.0

--- a/go.mod
+++ b/go.mod
@@ -9,10 +9,10 @@ require (
 	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 // indirect
 	github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 // indirect
 	github.com/go-openapi/strfmt v0.20.2
-	github.com/go-test/deep v1.0.3
+	github.com/go-test/deep v1.0.7
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.0
 	github.com/keybase/go-crypto v0.0.0-20161004153544-93f5b35093ba // indirect
-	github.com/zededa/zedcloud-api v0.0.2-alpha
+	github.com/zededa/zedcloud-api v0.0.3-alpha
 )
 
 // replace github.com/zededa/zedcloud-api => ../zedcloud-api

--- a/go.sum
+++ b/go.sum
@@ -292,6 +292,7 @@ github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/go-test/deep v1.0.7/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
 github.com/gobuffalo/attrs v0.0.0-20190224210810-a9411de4debd h1:hSkbZ9XSyjyBirMeqSqUrK+9HboWrweVlzRNqoBi2d4=
 github.com/gobuffalo/attrs v0.0.0-20190224210810-a9411de4debd/go.mod h1:4duuawTqi2wkkpB4ePgWMaai6/Kc6WEz83bhFwpHzj0=
 github.com/gobuffalo/depgen v0.0.0-20190329151759-d478694a28d3/go.mod h1:3STtPUQYuzV0gBVOY3vy6CfMm/ljR4pABfrTeHNLHUY=
@@ -752,6 +753,8 @@ github.com/zededa/zedcloud-api v0.0.1-alpha h1:y9GCwHWNxZuvmA0B/ZD1w6Dn/56bqktMF
 github.com/zededa/zedcloud-api v0.0.1-alpha/go.mod h1:7cRGSQt6E0shSY/3yKN42Nka4i1zVm2CMJ/V6B5DNuM=
 github.com/zededa/zedcloud-api v0.0.2-alpha h1:073MaS8ufVQT5cnFYwQGjPC4H8SNalM18LSoc3Jwh1k=
 github.com/zededa/zedcloud-api v0.0.2-alpha/go.mod h1:7cRGSQt6E0shSY/3yKN42Nka4i1zVm2CMJ/V6B5DNuM=
+github.com/zededa/zedcloud-api v0.0.3-alpha h1:IWioxwJDRvukMtOqfx+0cTKI+fH7gLvtCsqv9guIdt4=
+github.com/zededa/zedcloud-api v0.0.3-alpha/go.mod h1:XxkHfpQWthD7+11O8GRijym56Jq30pF4VS76sNuU56M=
 go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=
 go.etcd.io/etcd/client/pkg/v3 v3.5.0/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v2 v2.305.0/go.mod h1:h9puh54ZTgAKtEbut2oe9P4L/oqKCVB6xsXlzd7alYQ=

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -11,34 +11,34 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	zedcloudapi "github.com/zededa/zedcloud-api"
 	zschemas "github.com/zededa/terraform-provider-zedcloud/schemas"
+	zedcloudapi "github.com/zededa/zedcloud-api"
 )
 
 var DefaultZedcloudUrl = "https://zedcontrol.zededa.net"
 
 var ProviderSchema = &schema.Provider{
 	ConfigureContextFunc: providerConfigure,
-	Schema: zschemas.ProviderSchema,
+	Schema:               zschemas.ProviderSchema,
 
 	DataSourcesMap: map[string]*schema.Resource{
 		"zedcloud_edgeapp":          getEdgeAppDataSourceSchema(),
-		"zedcloud_edgeapp_instance":  getAppInstDataSourceSchema(),
+		"zedcloud_edgeapp_instance": getAppInstDataSourceSchema(),
 		"zedcloud_edgenode":         getEdgeNodeDataSourceSchema(),
 		"zedcloud_image":            getImageDataSourceSchema(),
 		"zedcloud_network":          getNetworkDataSourceSchema(),
 		"zedcloud_network_instance": getNetInstDataSourceSchema(),
-		"zedcloud_volume_instance": getVolumeInstanceDataSourceSchema(),
+		"zedcloud_volume_instance":  getVolumeInstanceDataSourceSchema(),
 	},
 
 	ResourcesMap: map[string]*schema.Resource{
 		"zedcloud_edgeapp":          getEdgeAppResourceSchema(),
-		"zedcloud_edgeapp_instance":  getAppInstResourceSchema(),
+		"zedcloud_edgeapp_instance": getAppInstResourceSchema(),
 		"zedcloud_edgenode":         getEdgeNodeResourceSchema(),
 		"zedcloud_image":            getImageResourceSchema(),
 		"zedcloud_network":          getNetworkResourceSchema(),
 		"zedcloud_network_instance": getNetInstResourceSchema(),
-		"zedcloud_volume_instance": getVolumeInstanceResourceSchema(),
+		"zedcloud_volume_instance":  getVolumeInstanceResourceSchema(),
 	},
 }
 
@@ -54,29 +54,8 @@ type Client struct {
 	Client   *zedcloudapi.Client
 }
 
-func getErrMsgPrefix(name, id, objectType, action string) string {
-	return fmt.Sprintf("[ERROR] %s %s ( id: %s) %s Failed.",
-		objectType, name, id, action)
-}
-
 func Provider() *schema.Provider {
 	return ProviderSchema
-}
-
-// marshalData is used to ensure the data is put into a format Terraform can output
-func marshalData(d *schema.ResourceData, vals map[string]interface{}) {
-	for k, v := range vals {
-		if k == "id" {
-			d.SetId(v.(string))
-		} else {
-			str, ok := v.(string)
-			if ok {
-				d.Set(k, str)
-			} else {
-				d.Set(k, v)
-			}
-		}
-	}
 }
 
 // providerConfigure parses the config into the Terraform provider meta object
@@ -107,9 +86,9 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 
 	providerClient := Client{
 		ZedcloudUrl: zedcloudUrl,
-		Token:    token,
-		Username: username,
-		Password: password,
+		Token:       token,
+		Username:    username,
+		Password:    password,
 	}
 	var err error
 	providerClient.Client, err = zedcloudapi.NewClient(zedcloudUrl, token, username, password)

--- a/provider/resource_edgeapp.go
+++ b/provider/resource_edgeapp.go
@@ -113,6 +113,10 @@ func updateEdgeAppResource(ctx context.Context, d *schema.ResourceData, meta int
 	if err != nil {
 		return diag.Errorf("%s err: %s", errMsgPrefix, err.Error())
 	}
+	err = checkInvalidAttrForUpdate(d, *cfg.Name, cfg.ID, "")
+	if err != nil {
+		return diag.Errorf("%s err: %s", errMsgPrefix, err.Error())
+	}
 	err = rdUpdateAppCfg(cfg, d)
 	if err != nil {
 		return diag.Errorf("%s %s", errMsgPrefix, err.Error())

--- a/provider/resource_edgeapp_instance.go
+++ b/provider/resource_edgeapp_instance.go
@@ -427,6 +427,10 @@ func updateAppInstResource(ctx context.Context, d *schema.ResourceData, meta int
 	if cfg == nil {
 		return diag.Errorf("%s Failed to find App Instance", errMsgPrefix)
 	}
+	err = checkInvalidAttrForUpdate(d, *cfg.Name, cfg.ID, *cfg.ProjectID)
+	if err != nil {
+		return diag.Errorf("%s err: %s", errMsgPrefix, err.Error())
+	}
 	log.Printf("[INFO] Found AppInst: %s (ID: %s)", name, cfg.ID)
 	err = rdUpdateAppInstCfg(cfg, d)
 	if err != nil {

--- a/provider/resource_edgenode.go
+++ b/provider/resource_edgenode.go
@@ -239,6 +239,10 @@ func updateEdgeNodeResource(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.Errorf("%s Failed to find Edge Node. err: %s",
 			errMsgPrefix, err.Error())
 	}
+	err = checkInvalidAttrForUpdate(d, *cfg.Name, cfg.ID, *cfg.ProjectID)
+	if err != nil {
+		return diag.Errorf("%s err: %s", errMsgPrefix, err.Error())
+	}
 	if cfg.ID != id {
 		return diag.Errorf("%s ID of edge node changed. Expected: %s, actual: %s. "+
 			"Object in zedcontrol is not same as expected by Terraform.",

--- a/provider/resource_image.go
+++ b/provider/resource_image.go
@@ -118,6 +118,10 @@ func updateImageResource(ctx context.Context, d *schema.ResourceData, meta inter
 	if err != nil {
 		return diag.Errorf("%s err: %s", errMsgPrefix, err.Error())
 	}
+	err = checkInvalidAttrForUpdate(d, *cfg.Name, cfg.ID, "")
+	if err != nil {
+		return diag.Errorf("%s err: %s", errMsgPrefix, err.Error())
+	}
 	log.Printf("[INFO] Updating Image: %s (ID: %s)", name, cfg.ID)
 	err = updateImageCfgFromResourceData(cfg, d)
 	if err != nil {

--- a/provider/resource_network.go
+++ b/provider/resource_network.go
@@ -56,11 +56,11 @@ func rdMapNetWifiConfig(d map[string]interface{}) (interface{}, error) {
 		return nil, err
 	}
 	return &swagger_models.NetWifiConfig{
-		Identity:         rdEntryStr(d, "identity"),
-		KeyScheme:        &keyScheme,
-		Priority:         rdEntryInt32(d, "priority"),
-		Secret:           secret.(*swagger_models.NetWifiConfigSecrets),
-		WifiSSID:         rdEntryStr(d, "wifi_ssid"),
+		Identity:  rdEntryStr(d, "identity"),
+		KeyScheme: &keyScheme,
+		Priority:  rdEntryInt32(d, "priority"),
+		Secret:    secret.(*swagger_models.NetWifiConfigSecrets),
+		WifiSSID:  rdEntryStr(d, "wifi_ssid"),
 	}, nil
 }
 
@@ -225,6 +225,10 @@ func updateNetworkResource(ctx context.Context, d *schema.ResourceData, meta int
 	}
 	if cfg == nil {
 		return diag.Errorf("%s Nil Config. Failed to find Network", errMsgPrefix)
+	}
+	err = checkInvalidAttrForUpdate(d, *cfg.Name, cfg.ID, *cfg.ProjectID)
+	if err != nil {
+		return diag.Errorf("%s err: %s", errMsgPrefix, err.Error())
 	}
 	log.Printf("[INFO] Found Network: %s (ID: %s)", name, cfg.ID)
 	err = rdToNetConfig(cfg, d)

--- a/provider/resource_volume_instance.go
+++ b/provider/resource_volume_instance.go
@@ -104,6 +104,10 @@ func updateVolumeInstanceResource(ctx context.Context, d *schema.ResourceData, m
 	if err != nil {
 		return diag.Errorf("%s err: %s", errMsgPrefix, err.Error())
 	}
+	err = checkInvalidAttrForUpdate(d, cfg.Name, cfg.ID, cfg.ProjectID)
+	if err != nil {
+		return diag.Errorf("%s err: %s", errMsgPrefix, err.Error())
+	}
 	log.Printf("[INFO] Updating VolumeInstance: %s (ID: %s)", name, cfg.ID)
 	client.XRequestIdPrefix = "TF-volumeInstance-update"
 	urlExtension := getVolumeInstanceUrl(name, id, "update")

--- a/provider/resourceutils.go
+++ b/provider/resourceutils.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2018-2021 Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package provider
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func getErrMsgPrefix(name, id, objectType, action string) string {
+	return fmt.Sprintf("[ERROR] %s %s ( id: %s) %s Failed.",
+		objectType, name, id, action)
+}
+
+// marshalData is used to ensure the data is put into a format Terraform can output
+func marshalData(d *schema.ResourceData, vals map[string]interface{}) {
+	for k, v := range vals {
+		if k == "id" {
+			d.SetId(v.(string))
+		} else {
+			str, ok := v.(string)
+			if ok {
+				d.Set(k, str)
+			} else {
+				d.Set(k, v)
+			}
+		}
+	}
+}
+
+func checkInvalidAttrForUpdate(d *schema.ResourceData, name, id, projectID string) error {
+	newName := rdEntryStr(d, "name")
+	if newName != name {
+		return fmt.Errorf("Name of an object cannot be changed. current: %s, new: %s",
+            name, newName)
+	}
+	idInState := rdEntryStr(d, "id")
+	if idInState != id {
+		return fmt.Errorf("ID of the object has Changed. Cannot update the object. " +
+            "ID in state: %s, ID of Object in Cloud: %s", idInState, id)
+	}
+    if projectID != "" {
+        newProjectID := rdEntryStr(d, "project_id")
+        if newProjectID != projectID {
+            return fmt.Errorf("Project of an object cannot be changed. current: %s, new: %s",
+                projectID, newProjectID)
+        }
+    }
+    return nil
+}

--- a/samples/multinode_multiappinst.tf
+++ b/samples/multinode_multiappinst.tf
@@ -37,7 +37,7 @@ resource "zedcloud_edgenode" "sample-edge-node" {
     name = each.value
     title = format("Edge Node %s", each.value)
     description = format("Edge Node Description %s", each.value)
-    eveimage_version = "abc"
+    eve_image_version = "abc"
 }
 
 resource "zedcloud_network_instance" "default-nwinst" {
@@ -47,7 +47,7 @@ resource "zedcloud_network_instance" "default-nwinst" {
     description = format("Network Instance Description default-%s", each.value)
     device_default = true
     port = "eth0"
-    edgenode_id = zedcloud_edgenode.sample-edge-node[each.key].id
+    device_id = zedcloud_edgenode.sample-edge-node[each.key].id
 }
 
 resource "zedcloud_edgeapp" "TF-Test-ubuntu-all-ip" {
@@ -64,16 +64,15 @@ resource "zedcloud_edgeapp" "tftest-ubuntu-xenial" {
     description = "TFTest-ubuntu-xenial-16.04"
 }
 
-resource "zedcloud_edgeappinstance" "Sample-EdgeAppInstance" {
+resource "zedcloud_edgeapp_instance" "Sample-EdgeAppInstance" {
     for_each = local.node_list
     name = format("TF-Sample-EdgeAppInstance-%s", each.value)
     activate = false
-    edgeapp_type="VM"
-    edgeapp_id=zedcloud_edgeapp.TF-Test-ubuntu-all-ip.id
-    edgenode_id=zedcloud_edgenode.sample-edge-node[each.key].id
+    app_type = "APP_TYPE_VM"
+    app_id = zedcloud_edgeapp.TF-Test-ubuntu-all-ip.id
+    device_id=zedcloud_edgenode.sample-edge-node[each.key].id
     title="TerraForm Sample App Instance"
     description="TerraForm Sample App Instance"
-    network_instance=zedcloud_network_instance.default-nwinst[each.key].name
     depends_on = [
         zedcloud_edgeapp.TF-Test-ubuntu-all-ip,
         zedcloud_edgenode.sample-edge-node,

--- a/samples/onedevice_oneappinst.tf
+++ b/samples/onedevice_oneappinst.tf
@@ -41,12 +41,15 @@ resource "zedcloud_image" "TFR-app-image-1" {
     description = data.zedcloud_image.app-image-1.description
     image_arch = data.zedcloud_image.app-image-1.image_arch
     image_format = data.zedcloud_image.app-image-1.image_format
-    image_local = data.zedcloud_image.app-image-1.image_local
     image_rel_url = data.zedcloud_image.app-image-1.image_rel_url
     image_sha_256 = data.zedcloud_image.app-image-1.image_sha_256
     image_size_bytes = data.zedcloud_image.app-image-1.image_size_bytes
     image_type = data.zedcloud_image.app-image-1.image_type
     title = data.zedcloud_image.app-image-1.title
+}
+
+data "zedcloud_edgenode" "Data-Sample-Device" {
+    name = "TF-Sample-Device1"
 }
 
 resource "zedcloud_edgenode" "Sample-Device" {
@@ -67,9 +70,8 @@ resource "zedcloud_edgenode" "Sample-Device" {
     dev_location {
         city = "San Jose"
         country = "USA"
-        free_loc = ""
+        freeloc = ""
         hostname = "sample-device"
-        latlong = ""
         loc = ""
         org = "Zededa Engineering"
         postal = "95116"
@@ -80,11 +82,11 @@ resource "zedcloud_edgenode" "Sample-Device" {
     eve_image_version = "6.8.2-kvm-amd64"
 
     interface {
-      intf_name = "eth0"
+      intfname = "eth0"
       intf_usage = "ADAPTER_USAGE_MANAGEMENT"
     }
     interface {
-      intf_name = "eth1"
+      intfname = "eth1"
       intf_usage = "ADAPTER_USAGE_UNSPECIFIED"
     }
     tags = {
@@ -181,19 +183,8 @@ resource "zedcloud_network" "TF-sample-network-full-cfg" {
         }
         type = ""
         wifi_cfg {
-            crypto {
-                identity = "test identity"
-                password = "test password"
-            }
-            crypto_key = ""
-            encrypted_secret {
-                "secret1" = "value1"
-                "secret2" = "value2"
-            }
-            identity = ""
             key_scheme = ""
             priority = 5
-            secret {}
             wifi_ssid = "TF-Test-Wifi-SSID"
         }
     }
@@ -229,7 +220,7 @@ resource "zedcloud_network_instance" "default-nwinst" {
     description = "edge-node-1-ni-default-nwinst"
     device_default = true
     port = "eth1"
-    device_id = zedcloud_edgenode.Sample-Device.id
+    device_id = data.zedcloud_edgenode.Data-Sample-Device.id
 }
 
 resource "zedcloud_network_instance" "TF-Sample-test-full" {
@@ -237,7 +228,7 @@ resource "zedcloud_network_instance" "TF-Sample-test-full" {
     title = "edge-node-1-ni-TF-Sample-test-full"
     description = "edge-node-1-ni-TF-Sample-test-full"
     device_default = true
-    device_id = zedcloud_edgenode.Sample-Device.id
+    device_id = data.zedcloud_edgenode.Data-Sample-Device.id
     dns_list {
         addrs = [
             "10.1.1.1",
@@ -273,7 +264,6 @@ resource "zedcloud_network_instance" "TF-Sample-test-full" {
     }
     kind = "NETWORK_INSTANCE_KIND_LOCAL"
     network_policy_id = "tft-test-network-policy-id"
-    oconfig = "tft-test-oconfig"
     port = "eth1"
     port_tags = {
         "port-tag1" = "port-tag-value-1"
@@ -298,11 +288,11 @@ resource "zedcloud_edgeapp_instance" "Sample-EdgeAppInstance" {
     //app_user_defined_version = "5"
     description = "TerraForm Sample App Instance - TESTING Update"
     device_id = zedcloud_edgenode.Sample-Device.id
-    interfaces {
+    interface {
         intfname = "indirect"
         netinstname = zedcloud_network_instance.default-nwinst.name
         acl {
-            matches {
+            match {
                 type = "ip"
                 value = "0.0.0.0/0"
             }
@@ -310,26 +300,26 @@ resource "zedcloud_edgeapp_instance" "Sample-EdgeAppInstance" {
             name = ""
         }
         acl {
-            matches {
+            match {
                 type = "protocol"
                 value = "tcp"
             }
-            matches {
+            match {
                 type = "lport"
                 value = "8022"
             }
-            matches {
+            match {
                 type = "ip"
                 value = "0.0.0.0/0"
             }
-            actions {
+            action {
                 drop = false
                 limit = false
-                limit_rate = 0
-                limit_unit = ""
-                limit_burst = 0
+                limitrate = 0
+                limitunit = ""
+                limitburst = 0
                 portmap = true
-                map_params {
+                mapparams {
                     port = 22
                 }
             }
@@ -356,9 +346,7 @@ resource "zedcloud_volume_instance" "TF-sample-vol-inst-RO-content-tree" {
     accessmode  = "VOLUME_INSTANCE_ACCESS_MODE_READONLY"
     description = "Immutable Volume"
     device_id   = "99999999-bbbb-aaaa-1111-bbbbbbbbbbbb"
-    id          = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
     image       = "alpine-base"
-    implicit    = true
     multiattach = false
     name        = "sample-volinst-1"
     project_id  = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"


### PR DESCRIPTION
1) Added checks to all resources to fail update if Name / ProjectID are
       changed in the config.
   
changed in the config.

2) Added checks to all resources to fail update if the ID of the object
   in saved state is different from the ID of the object in Cloud.

3) Fixed Makefile NOT to do 'go mod download' for every build. When
   needed, just do it manually.

4) Moved utility routines from provider.go to a new file - resourceutils.go

5) Update zedcloud-api to v0.0.3-api to get the fix for Error message
handling

6) Fixed .tf files in samples/ dir to comply with the changes in
Schema.