### PR TITLE
Fix handling project id diff

### DIFF
--- a/provider/resource_edgeapp.go
+++ b/provider/resource_edgeapp.go
@@ -113,7 +113,7 @@ func updateEdgeAppResource(ctx context.Context, d *schema.ResourceData, meta int
 	if err != nil {
 		return diag.Errorf("%s err: %s", errMsgPrefix, err.Error())
 	}
-	err = checkInvalidAttrForUpdate(d, *cfg.Name, cfg.ID, "")
+	err = checkInvalidAttrForUpdate(d, *cfg.Name, cfg.ID)
 	if err != nil {
 		return diag.Errorf("%s err: %s", errMsgPrefix, err.Error())
 	}

--- a/provider/resource_edgeapp_instance.go
+++ b/provider/resource_edgeapp_instance.go
@@ -427,7 +427,7 @@ func updateAppInstResource(ctx context.Context, d *schema.ResourceData, meta int
 	if cfg == nil {
 		return diag.Errorf("%s Failed to find App Instance", errMsgPrefix)
 	}
-	err = checkInvalidAttrForUpdate(d, *cfg.Name, cfg.ID, *cfg.ProjectID)
+	err = checkInvalidAttrForUpdate(d, *cfg.Name, cfg.ID)
 	if err != nil {
 		return diag.Errorf("%s err: %s", errMsgPrefix, err.Error())
 	}

--- a/provider/resource_edgenode.go
+++ b/provider/resource_edgenode.go
@@ -239,7 +239,7 @@ func updateEdgeNodeResource(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.Errorf("%s Failed to find Edge Node. err: %s",
 			errMsgPrefix, err.Error())
 	}
-	err = checkInvalidAttrForUpdate(d, *cfg.Name, cfg.ID, *cfg.ProjectID)
+	err = checkInvalidAttrForUpdate(d, *cfg.Name, cfg.ID)
 	if err != nil {
 		return diag.Errorf("%s err: %s", errMsgPrefix, err.Error())
 	}

--- a/provider/resource_image.go
+++ b/provider/resource_image.go
@@ -118,7 +118,7 @@ func updateImageResource(ctx context.Context, d *schema.ResourceData, meta inter
 	if err != nil {
 		return diag.Errorf("%s err: %s", errMsgPrefix, err.Error())
 	}
-	err = checkInvalidAttrForUpdate(d, *cfg.Name, cfg.ID, "")
+	err = checkInvalidAttrForUpdate(d, *cfg.Name, cfg.ID)
 	if err != nil {
 		return diag.Errorf("%s err: %s", errMsgPrefix, err.Error())
 	}

--- a/provider/resource_network.go
+++ b/provider/resource_network.go
@@ -226,7 +226,7 @@ func updateNetworkResource(ctx context.Context, d *schema.ResourceData, meta int
 	if cfg == nil {
 		return diag.Errorf("%s Nil Config. Failed to find Network", errMsgPrefix)
 	}
-	err = checkInvalidAttrForUpdate(d, *cfg.Name, cfg.ID, *cfg.ProjectID)
+	err = checkInvalidAttrForUpdate(d, *cfg.Name, cfg.ID)
 	if err != nil {
 		return diag.Errorf("%s err: %s", errMsgPrefix, err.Error())
 	}

--- a/provider/resource_network_instance.go
+++ b/provider/resource_network_instance.go
@@ -187,7 +187,7 @@ func validateNetInstUpdateOperation(client *zedcloudapi.Client,
 	if err != nil {
 		return nil, err
 	}
-	err = checkInvalidAttrForUpdate(d, *cfg.Name, cfg.ID, cfg.ProjectID)
+	err = checkInvalidAttrForUpdate(d, *cfg.Name, cfg.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/resource_volume_instance.go
+++ b/provider/resource_volume_instance.go
@@ -104,7 +104,7 @@ func updateVolumeInstanceResource(ctx context.Context, d *schema.ResourceData, m
 	if err != nil {
 		return diag.Errorf("%s err: %s", errMsgPrefix, err.Error())
 	}
-	err = checkInvalidAttrForUpdate(d, cfg.Name, cfg.ID, cfg.ProjectID)
+	err = checkInvalidAttrForUpdate(d, cfg.Name, cfg.ID)
 	if err != nil {
 		return diag.Errorf("%s err: %s", errMsgPrefix, err.Error())
 	}

--- a/provider/resourceutils.go
+++ b/provider/resourceutils.go
@@ -29,23 +29,16 @@ func marshalData(d *schema.ResourceData, vals map[string]interface{}) {
 	}
 }
 
-func checkInvalidAttrForUpdate(d *schema.ResourceData, name, id, projectID string) error {
+func checkInvalidAttrForUpdate(d *schema.ResourceData, name, id string) error {
 	newName := rdEntryStr(d, "name")
 	if newName != name {
 		return fmt.Errorf("Name of an object cannot be changed. current: %s, new: %s",
-            name, newName)
+			name, newName)
 	}
 	idInState := rdEntryStr(d, "id")
 	if idInState != id {
-		return fmt.Errorf("ID of the object has Changed. Cannot update the object. " +
-            "ID in state: %s, ID of Object in Cloud: %s", idInState, id)
+		return fmt.Errorf("ID of the object has Changed. Cannot update the object. "+
+			"ID in state: %s, ID of Object in Cloud: %s", idInState, id)
 	}
-    if projectID != "" {
-        newProjectID := rdEntryStr(d, "project_id")
-        if newProjectID != projectID {
-            return fmt.Errorf("Project of an object cannot be changed. current: %s, new: %s",
-                projectID, newProjectID)
-        }
-    }
-    return nil
+	return nil
 }

--- a/schemas/common.go
+++ b/schemas/common.go
@@ -36,6 +36,15 @@ var projectIdSchema = &schema.Schema{
 	Type:        schema.TypeString,
 	Optional:    true,
 	Description: "ID of the project to which the Object belongs",
+	DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+		if new == "" {
+			// If new is not specified - old one was published by get.
+			// This is the case of .tf not having the project id for the object,
+			// but zedcloud setting it - may be default project id.
+			return true
+		}
+		return false
+	},
 }
 
 var tagsSchema = &schema.Schema{
@@ -64,12 +73,12 @@ var zedcloudOpsCmdSchema = &schema.Resource{
 	Schema: map[string]*schema.Schema{
 		"counter": {
 			Type:        schema.TypeInt,
-			Optional:    true,
+			Computed:    true,
 			Description: "Operation Counter",
 		},
 		"ops_time": {
 			Type:        schema.TypeString,
-			Optional:    true,
+			Computed:    true,
 			Description: "Timestamp: Operational time",
 		},
 	},
@@ -105,32 +114,32 @@ var objectRevisionSchema = &schema.Resource{
 	Schema: map[string]*schema.Schema{
 		"created_at": {
 			Type:        schema.TypeString,
-			Optional:    true,
+			Computed:    true,
 			Description: "The time, in milliseconds since the epoch, when the object was created",
 		},
 		"created_by": {
 			Type:        schema.TypeString,
-			Optional:    true,
+			Computed:    true,
 			Description: "User who Created the object",
 		},
 		"curr": {
 			Type:        schema.TypeString,
-			Optional:    true,
+			Computed:    true,
 			Description: "Current version of the object",
 		},
 		"prev": {
 			Type:        schema.TypeString,
-			Optional:    true,
+			Computed:    true,
 			Description: "Prev version of the object",
 		},
 		"updated_at": {
 			Type:        schema.TypeString,
-			Optional:    true,
+			Computed:    true,
 			Description: "The time, in milliseconds since the epoch, when the object was last updated",
 		},
 		"updated_by": {
 			Type:        schema.TypeString,
-			Optional:    true,
+			Computed:    true,
 			Description: "User who last updated the object",
 		},
 	},


### PR DESCRIPTION

    1) Revert the Project ID Change check for Object update. This is
       provided by cloud and is not needed in terraform.
    
    2) Marked the Object Revision Schema fields as Computed - these were
       wrongly marked as optional
    
    3) Added a Diff Suppress func for project-id field. This is not
        to flag an invalid diff when the cloud assigns the project id - bit
        it is not there in the .tf file.
