### PR TITLE
Fixes to handle Spurious diffs in terraform plan

### DIFF
--- a/provider/data_source_edgeapp_instance_test.go
+++ b/provider/data_source_edgeapp_instance_test.go
@@ -90,7 +90,7 @@ func appInstFullCfg() *swagger_models.AppInstance {
 				},
 			},
 		},
-		DeviceID:       strPtr("Sample Device ID"),
+		DeviceID: strPtr("Sample Device ID"),
 		Drives: []*swagger_models.Drive{
 			&swagger_models.Drive{
 				Cleartext:   true,
@@ -213,47 +213,9 @@ var outputAppInstFullCfg = map[string]interface{}{
 	"cluster_id":            "Sample Cluster ID",
 	"collect_stats_ip_addr": "10.1.1.10",
 	"custom_config": []interface{}{
-		map[string]interface{}{
-			"add":                  true,
-			"allow_storage_resize": true,
-			"field_delimiter":      ",",
-			"name":                 "Sample Custom Config",
-			"override":             true,
-			"template":             "Sample Template",
-			"variable_group": []interface{}{
-				map[string]interface{}{
-					"condition": []interface{}{
-						map[string]interface{}{
-							"name":     "SampleVGCondition",
-							"operator": "Sample Operator",
-							"value":    "Sample Operator Value",
-						},
-					},
-					"name":     "Sample VG NAME",
-					"required": true,
-					"variable": []interface{}{
-						map[string]interface{}{
-							"default":    "Sample Default Value",
-							"encode":     "Sample Encoding",
-							"format":     "Sample Format",
-							"label":      "Sample label",
-							"max_length": "10",
-							"name":       "Sample VGV Name",
-							"option": []interface{}{
-								map[string]interface{}{
-									"label": "Sample Label",
-									"value": "Sample Value",
-								},
-							},
-							"required": true,
-							"value":    "Sample Value",
-						},
-					},
-				},
-			},
-		},
+		map[string]interface{}{"add": true},
 	},
-	"device_id":       "Sample Device ID",
+	"device_id": "Sample Device ID",
 	"drive": []interface{}{
 		map[string]interface{}{
 			"cleartext":   true,
@@ -398,7 +360,7 @@ func TestFlattenAppInstance(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		out := flattenAppInstance(c.input)
+		out := flattenAppInstance(c.input, false)
 		if diff := deep.Equal(out, c.expected); diff != nil {
 			t.Fatalf("Test Failed: %s\n"+
 				"Error matching Flattened output and input.\n"+

--- a/provider/resource_edgeapp_instance.go
+++ b/provider/resource_edgeapp_instance.go
@@ -316,7 +316,7 @@ func createAppInstResource(ctx context.Context, d *schema.ResourceData, meta int
 	log.Printf("App Instance %s (ID: %s) Successfully created\n",
 		rspData.ObjectName, id)
 	d.SetId(id)
-	err = getAppInstAndPublishData(client, d, name, id)
+	err = getAppInstAndPublishData(client, d, name, id, true)
 	if err != nil {
 		log.Printf("***[ERROR]- Failed to get App Instance: %s (ID: %s) after "+
 			"creating it. Err: %s", name, id, err.Error())
@@ -361,7 +361,7 @@ func updateAppInstResource(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf("%s err: %s", errMsgPrefix, err.Error())
 	}
 	log.Printf("App Instance %s (id: %s) update SUCCESS", name, cfg.ID)
-	err = getAppInstAndPublishData(client, d, name, id)
+	err = getAppInstAndPublishData(client, d, name, id, true)
 	if err != nil {
 		log.Printf("***[ERROR]- Failed to get App Instance: %s (ID: %s) after "+
 			"updating it. Err: %s", name, id, err.Error())
@@ -398,5 +398,5 @@ func deleteAppInstResource(ctx context.Context, d *schema.ResourceData, meta int
 }
 
 func readResourceAppInst(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	return readAppInst(ctx, d, meta)
+	return readAppInst(ctx, d, meta, true)
 }

--- a/provider/resource_edgeapp_instance_test.go
+++ b/provider/resource_edgeapp_instance_test.go
@@ -19,7 +19,6 @@ var rdAppInstEmptyOutput = map[string]interface{}{
 	"bundleversion":         "",
 	"cluster_id":            "",
 	"collect_stats_ip_addr": "",
-	"custom_config":         []interface{}{},
 	"description":           "",
 	"device_id":             "",
 	"drive":                 []interface{}{},
@@ -93,8 +92,8 @@ var rdAppInstFullCfg = map[string]interface{}{
 			},
 		},
 	},
-	"device_id":       "sample-device-id",
-	"drive":           []interface{}{},
+	"device_id": "sample-device-id",
+	"drive":     []interface{}{},
 	"encrypted_secrets": map[string]interface{}{
 		"secret1": "secret-value1",
 		"secret2": "secret-value2",
@@ -246,7 +245,6 @@ var efoAppInstFullCfg = map[string]interface{}{
 	"bundleversion":         "", // Computed
 	"cluster_id":            rdAppInstFullCfg["cluster_id"],
 	"collect_stats_ip_addr": rdAppInstFullCfg["collect_stats_ip_addr"],
-	"custom_config":         rdAppInstFullCfg["custom_config"],
 	"device_id":             rdAppInstFullCfg["device_id"],
 	"drive":                 rdAppInstFullCfg["drive"],
 	"interface": []interface{}{
@@ -338,7 +336,7 @@ func TestRDAppInstConfig(t *testing.T) {
 					c.description)
 			}
 		}
-		out := flattenAppInstance(cfg)
+		out := flattenAppInstance(cfg, true)
 		err = verifyFlattenOutput(zschemas.AppInstSchema, out, c.expectAllSchemaKeys)
 		if err != nil {
 			t.Fatalf("Test Failed: %s\n Errors in flatten output. Err: %s\nout: %++v",

--- a/provider/resource_network_instance.go
+++ b/provider/resource_network_instance.go
@@ -104,7 +104,7 @@ func resourceDataToStaticDNSList(d *schema.ResourceData) ([]*swagger_models.Stat
 	for _, entry := range data {
 		dataEntry := entry.(map[string]interface{})
 		dnsEntry := &swagger_models.StaticDNSList{
-			Addrs:    rdEntryStrList(dataEntry, "addrs"),
+			Addrs:    rdEntryStrSet(dataEntry, "addrs"),
 			Hostname: rdEntryStr(dataEntry, "hostname"),
 		}
 		dnsList = append(dnsList, dnsEntry)

--- a/provider/resourcedatautils.go
+++ b/provider/resourcedatautils.go
@@ -192,6 +192,25 @@ func rdEntryStrList(rd interface{}, key string) []string {
 	return strList
 }
 
+// rdEntryStrSet
+//  Converts the specified entry of type []interface{} from ResourceData
+//      into []string
+// Params:
+//  rd can be *schema.ResourceData OR map[string]interface{}. Any other
+//      type will cause a Panic
+func rdEntryStrSet(rd interface{}, key string) []string {
+	strList := make([]string, 0)
+	ok, val := rdEntryByKey(rd, key)
+	if !ok {
+		return strList
+	}
+	rdList := (val.(*schema.Set)).List()
+	for _, val := range rdList {
+		strList = append(strList, val.(string))
+	}
+	return strList
+}
+
 // rdEntryStrMap
 //  Converts the specified entry of type map[string]interface{} from ResourceData
 //      into map[string]string

--- a/schemas/network.go
+++ b/schemas/network.go
@@ -213,9 +213,9 @@ var ipSpecResourceSchema = &schema.Resource{
 var StaticDNSEntryResourceSchema = &schema.Resource{
 	Schema: map[string]*schema.Schema{
 		"addrs": &schema.Schema{
-			Type:        schema.TypeList,
+			Type:        schema.TypeSet,
 			Optional:    true,
-			Description: "List of IP addresses for the specified hostname",
+			Description: "Set of IP addresses for the specified hostname",
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
 			},

--- a/schemas/network_instance.go
+++ b/schemas/network_instance.go
@@ -22,24 +22,6 @@ var netInstOpaqueConfigSchema = &schema.Resource{
 	},
 }
 
-var staticDNSListSchema = &schema.Resource{
-	Schema: map[string]*schema.Schema{
-		"addrs": {
-			Type:        schema.TypeList,
-			Optional:    true,
-			Description: "Addresses",
-			Elem: &schema.Schema{
-				Type: schema.TypeString,
-			},
-		},
-		"hostname": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "Host name",
-		},
-	},
-}
-
 var dhcpIpRangeSchema = &schema.Resource{
 	Schema: map[string]*schema.Schema{
 		"end": {
@@ -129,7 +111,7 @@ var NetworkInstanceSchema = map[string]*schema.Schema{
 		Type:        schema.TypeList,
 		Optional:    true,
 		Description: "List of Static DNS entries",
-		Elem:        staticDNSListSchema,
+		Elem:        StaticDNSEntryResourceSchema,
 	},
 	"ip": {
 		Type:        schema.TypeList,


### PR DESCRIPTION
Changed StaticDNSEntryResourceSchema.addrs to Set from List.
This doesn't change the syntax of the config file. And the field is
always intended to carry unique values. So this is a backward compatible
change.

Removed the duplicate structure - staticDNSListSchema. Use StaticDNSEntryResourceSchema
for both Network and Network Instance.