### PR TITLE
Fix bug in processing App Manifest

### DIFF
--- a/provider/resourcedatautils.go
+++ b/provider/resourcedatautils.go
@@ -275,7 +275,7 @@ func rdEntryList(rd interface{}, key string) []interface{} {
 	if ok {
 		return setVal.List()
 	}
-	panic("Key %s Value %+v - neither a list not a set")
+	panic("Key %s Value %+v - neither a list nor a set")
 }
 
 type rdFuncMapToEntry func(d map[string]interface{}) (interface{}, error)


### PR DESCRIPTION
Fix bug in processing App Manifest. The previous commit introduced a bug in expecting a map as opposed to an array of interfaces of "manifest" key. Fixed that.

Also fixed processing "maxsize" attribute of images.


