### PR TITLE
fix(ENG-619): do nothing if adminstate_config didn't change

### DIFF
--- a/provider/resource_edgenode.go
+++ b/provider/resource_edgenode.go
@@ -6,10 +6,11 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"log"
 	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	zschemas "github.com/zededa/terraform-provider-zedcloud/schemas"
 	zedcloudapi "github.com/zededa/zedcloud-api"
@@ -237,8 +238,10 @@ func checkAdminStateValue(d *schema.ResourceData) (string, error) {
 	}
 }
 
-func setAdminState(cfg *swagger_models.DeviceConfig,
-	d *schema.ResourceData) (string, error) {
+func setAdminState(cfg *swagger_models.DeviceConfig, d *schema.ResourceData) (string, error) {
+	if !d.HasChange("adminstate_config") {
+		return "", nil
+	}
 	action, err := checkAdminStateValue(d)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
This fixes https://zededa.atlassian.net/browse/ENG-619 temporarily until tf-provider is rewritten and we can remove `adminstate_config` hack.

Note, I would love to add tests but there are none yet except for testing the flattening. Writing tests for this old version of the code doesn't make sense imo since I rewrote the edge_node_resource already and this entire file will be replaced. The structure of the current code, makes it hard to test so I don't think it's worth the effort. I tested manually though.