### PR TITLE
fix(app instance): set interface fields as optional except for name

### DIFF
--- a/schemas/app_interface.go
+++ b/schemas/app_interface.go
@@ -222,7 +222,7 @@ func AppInterfaceSchema() map[string]*schema.Schema {
 				Schema: AppACESchema(),
 			},
 			// ConfigMode: schema.SchemaConfigModeAttr,
-			Required: true,
+			Optional: true,
 		},
 
 		"default_net_instance": {
@@ -234,7 +234,8 @@ func AppInterfaceSchema() map[string]*schema.Schema {
 		"directattach": {
 			Description: `direct attach flag`,
 			Type:        schema.TypeBool,
-			Required:    true,
+			Default:     false,
+			Optional:    true,
 		},
 
 		"eidregister": {
@@ -243,7 +244,7 @@ func AppInterfaceSchema() map[string]*schema.Schema {
 			Elem: &schema.Resource{
 				Schema: EIDRegisterSchema(),
 			},
-			Required: true,
+			Optional: true,
 		},
 
 		"intfname": {
@@ -255,7 +256,7 @@ func AppInterfaceSchema() map[string]*schema.Schema {
 		"intforder": {
 			Description: `intforder`,
 			Type:        schema.TypeInt,
-			Required:    true,
+			Optional:    true,
 		},
 
 		"io": {
@@ -264,19 +265,19 @@ func AppInterfaceSchema() map[string]*schema.Schema {
 			Elem: &schema.Resource{
 				Schema: PhyAdapterSchema(),
 			},
-			Required: true,
+			Optional: true,
 		},
 
 		"ipaddr": {
 			Description: `IP address`,
 			Type:        schema.TypeString,
-			Required:    true,
+			Optional:    true,
 		},
 
 		"macaddr": {
 			Description: `MAC address`,
 			Type:        schema.TypeString,
-			Required:    true,
+			Optional:    true,
 		},
 
 		"netinstid": {
@@ -309,7 +310,7 @@ func AppInterfaceSchema() map[string]*schema.Schema {
 		"privateip": {
 			Description: `Private IP flag`,
 			Type:        schema.TypeBool,
-			Required:    true,
+			Optional:    true,
 		},
 	}
 }


### PR DESCRIPTION
Fixed https://zededa.atlassian.net/browse/CI-129. We set io and all other field except for name as optional. When setting `directattach = false  ` we also need to set `intfname = "indirect"` or the zedcloud API will return an error like: `Bundle requires interface indirect, not found in instance`.