### PR TITLE
CI-264: Fixed the issue with object re-creation

### DIFF
--- a/schemas/application.go
+++ b/schemas/application.go
@@ -280,6 +280,7 @@ func Application() map[string]*schema.Schema {
 			Description: `User defined name of the edge application, unique across the enterprise. Once object is created, name can’t be changed`,
 			Type:        schema.TypeString,
 			Required:    true,
+			ForceNew: true,
 		},
 
 		"networks": {

--- a/schemas/application.go
+++ b/schemas/application.go
@@ -280,7 +280,7 @@ func Application() map[string]*schema.Schema {
 			Description: `User defined name of the edge application, unique across the enterprise. Once object is created, name can’t be changed`,
 			Type:        schema.TypeString,
 			Required:    true,
-			ForceNew: true,
+			ForceNew:    true,
 		},
 
 		"networks": {

--- a/schemas/application_instance.go
+++ b/schemas/application_instance.go
@@ -623,6 +623,7 @@ func ApplicationInstance() map[string]*schema.Schema {
 			Description: `User defined name of the app instance, unique across the enterprise. Once app instance is created, name can’t be changed`,
 			Type:        schema.TypeString,
 			Optional:    true,
+			ForceNew: 	 true,
 		},
 
 		"project_id": {

--- a/schemas/application_instance.go
+++ b/schemas/application_instance.go
@@ -623,7 +623,7 @@ func ApplicationInstance() map[string]*schema.Schema {
 			Description: `User defined name of the app instance, unique across the enterprise. Once app instance is created, name can’t be changed`,
 			Type:        schema.TypeString,
 			Optional:    true,
-			ForceNew: 	 true,
+			ForceNew:    true,
 		},
 
 		"project_id": {

--- a/schemas/datastore.go
+++ b/schemas/datastore.go
@@ -325,6 +325,7 @@ func Datastore() map[string]*schema.Schema {
 			Description: `User defined name of the datastore, unique across the enterprise. Once datastore is created, name can’t be changed.`,
 			Type:        schema.TypeString,
 			Required:    true,
+			ForceNew: true,
 		},
 
 		"need_clear_text": {

--- a/schemas/datastore.go
+++ b/schemas/datastore.go
@@ -325,7 +325,7 @@ func Datastore() map[string]*schema.Schema {
 			Description: `User defined name of the datastore, unique across the enterprise. Once datastore is created, name can’t be changed.`,
 			Type:        schema.TypeString,
 			Required:    true,
-			ForceNew: true,
+			ForceNew:    true,
 		},
 
 		"need_clear_text": {

--- a/schemas/image.go
+++ b/schemas/image.go
@@ -261,7 +261,7 @@ func Image() map[string]*schema.Schema {
 			Description: `User defined name of the image, unique across the enterprise. Once image is created, name can’t be changed.`,
 			Type:        schema.TypeString,
 			Required:    true,
-			ForceNew: true,
+			ForceNew:    true,
 		},
 
 		"origin_type": {

--- a/schemas/image.go
+++ b/schemas/image.go
@@ -261,6 +261,7 @@ func Image() map[string]*schema.Schema {
 			Description: `User defined name of the image, unique across the enterprise. Once image is created, name can’t be changed.`,
 			Type:        schema.TypeString,
 			Required:    true,
+			ForceNew: true,
 		},
 
 		"origin_type": {

--- a/schemas/network.go
+++ b/schemas/network.go
@@ -256,7 +256,7 @@ NETWORK_KIND_V6`,
 			Description: `User defined name of the network, unique across the enterprise. Once object is created, name can’t be changed`,
 			Type:        schema.TypeString,
 			Required:    true,
-			ForceNew: true,
+			ForceNew:    true,
 		},
 
 		"project_id": {

--- a/schemas/network.go
+++ b/schemas/network.go
@@ -256,6 +256,7 @@ NETWORK_KIND_V6`,
 			Description: `User defined name of the network, unique across the enterprise. Once object is created, name can’t be changed`,
 			Type:        schema.TypeString,
 			Required:    true,
+			ForceNew: true,
 		},
 
 		"project_id": {

--- a/schemas/network_instance.go
+++ b/schemas/network_instance.go
@@ -395,6 +395,7 @@ NETWORK_INSTANCE_KIND_HONEYPOT`,
 			Description: `User defined name of the network instance, unique across the enterprise. Once object is created, name can’t be changed`,
 			Type:        schema.TypeString,
 			Required:    true,
+			ForceNew: true,
 		},
 
 		"network_policy_id": {

--- a/schemas/network_instance.go
+++ b/schemas/network_instance.go
@@ -395,7 +395,7 @@ NETWORK_INSTANCE_KIND_HONEYPOT`,
 			Description: `User defined name of the network instance, unique across the enterprise. Once object is created, name can’t be changed`,
 			Type:        schema.TypeString,
 			Required:    true,
-			ForceNew: true,
+			ForceNew:    true,
 		},
 
 		"network_policy_id": {

--- a/schemas/node.go
+++ b/schemas/node.go
@@ -693,6 +693,7 @@ func Node() map[string]*schema.Schema {
 			Description: `user specified device name`,
 			Type:        schema.TypeString,
 			Optional:    true,
+			DiffSuppressFunc: supressNameAfterCreation("name"),
 		},
 
 		"onboarding_key": {

--- a/schemas/schema_helpers.go
+++ b/schemas/schema_helpers.go
@@ -205,7 +205,7 @@ func suppressAppInterfacesChangeAfterCreation(mapKey string) schema.SchemaDiffSu
 	}
 }
 
-// In most cases it's not allowed to change the resources' name after creatinon.
+// In most cases it's not allowed to change the resources' name after creation.
 // The function supresses any differences between names once the resource is created.
 func supressNameAfterCreation(mapKey string) schema.SchemaDiffSuppressFunc {
 	return func(key, oldValue, newValue string, d *schema.ResourceData) bool {

--- a/schemas/schema_helpers.go
+++ b/schemas/schema_helpers.go
@@ -205,6 +205,32 @@ func suppressAppInterfacesChangeAfterCreation(mapKey string) schema.SchemaDiffSu
 	}
 }
 
+// In most cases it's not allowed to change the resources' name after creatinon.
+// The function supresses any differences between names once the resource is created.
+func supressNameAfterCreation(mapKey string) schema.SchemaDiffSuppressFunc {
+	return func(key, oldValue, newValue string, d *schema.ResourceData) bool {
+		oldData, newData := d.GetChange(mapKey)
+		if newData == nil && oldData == nil {
+			return true
+		}
+
+		if oldData == nil {
+			return false
+		}
+		if newData == nil {
+			return false
+		}
+
+		o := oldData.(string)
+		n := newData.(string)
+		if o != n && o == "" {
+			return false
+		}
+
+		return true
+	}
+}
+
 func supress() schema.SchemaDiffSuppressFunc {
 	return func(key, oldValue, newValue string, d *schema.ResourceData) bool {
 		return true

--- a/schemas/volume_instance.go
+++ b/schemas/volume_instance.go
@@ -257,7 +257,7 @@ func VolumeInstance() map[string]*schema.Schema {
 			Description: `User defined name of the volume instance, unique across the enterprise. Once object is created, name can’t be changed.`,
 			Type:        schema.TypeString,
 			Optional:    true,
-			ForceNew: true,
+			ForceNew:    true,
 		},
 
 		"project_id": {

--- a/schemas/volume_instance.go
+++ b/schemas/volume_instance.go
@@ -257,6 +257,7 @@ func VolumeInstance() map[string]*schema.Schema {
 			Description: `User defined name of the volume instance, unique across the enterprise. Once object is created, name can’t be changed.`,
 			Type:        schema.TypeString,
 			Optional:    true,
+			ForceNew: true,
 		},
 
 		"project_id": {


### PR DESCRIPTION
Fixed the issue: "TF resource is not torn down and recreated correctly when the resource name is changed"

Added ForceNew to the following objects/resources:
- application
- application instance
- datastore
- image
- network
- network instance
- volume instance

Added function to the schema_helpers to ignore the name changing after creation.
Device: added suppress the name changing once the device has been created

Note: to change the name of object in the list an user needs to do the following:
- change the name of the object in the resources
- perform: terraform apply
- change the name of the object in the data sources
Warning: if an object can't be deleted by some reason the object re-creation will fail

Related issue: https://zededa.atlassian.net/browse/CI-264