### PR TITLE
ZEDCLOUD-667: Add edge-node to the list of the objects that can be re-created

### DIFF
--- a/docs/knowledge-base/schemas.md
+++ b/docs/knowledge-base/schemas.md
@@ -15,6 +15,10 @@ Starting from the version 2.2.5-beta the `name` field of the various objects was
 - network
 - network_instance
 - volume_instance
+- node
+
+CATUTION: please, be careful, the action of object re-creatione is a DESTRUCTIVE one. It means that if you decided to change the name of an object and apply the changes, the terraform provider will send a request to delete the object and its relations and after that
+a new object with new ralations will be created. `terraform plan` will ONLY show that the object to be recreated will be deleted, but will not show the objects associated with the recreated object as objects to be deleted.
 
 To process an object re-creation, the system will perform the following steps:
 

--- a/schemas/node.go
+++ b/schemas/node.go
@@ -693,7 +693,7 @@ func Node() map[string]*schema.Schema {
 			Description: `user specified device name`,
 			Type:        schema.TypeString,
 			Required:    true,
-			DiffSuppressFunc: supressNameAfterCreation("name"),
+			ForceNew: 	 true,
 		},
 
 		"onboarding_key": {


### PR DESCRIPTION
Implemented the task: "Add edge-node to the list of the objects that can be re-created"

Added edge-node to the list of objects that can be recreated
Modified schema.md to warn that recreating an object is a destructive action that cannot be undone.

Linked ticket: https://zededa.atlassian.net/browse/ZEDCLOUD-667 