### PR TITLE
CSD-51: replace onboarding_key with placeholder

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1479,7 +1479,7 @@ data "zedcloud_project" "test_tf_provider" {
 }
 
 resource "zedcloud_edgenode" "test_tf_provider" {
-  onboarding_key = "5d0767ee-0547-4569-b530-387e526f8cb9"
+  onboarding_key = "" # placeholder
   serialno       = "2293dbe8-29ce-420c-8264-962857efc46b"
   # identity = "identity"
 

--- a/main.tf.example
+++ b/main.tf.example
@@ -75,7 +75,7 @@ data "zedcloud_project" "test_tf_provider" {
 }
 
 resource "zedcloud_edgenode" "test_tf_provider" {
-    onboarding_key = "5d0767ee-0547-4569-b530-387e526f8cb9"
+    onboarding_key = "" # placeholder
 		serialno = "2293dbe8-29ce-420c-8264-962857efc46b"
     # identity = "identity"
 

--- a/resources/testdata/application_instance/create.tf
+++ b/resources/testdata/application_instance/create.tf
@@ -1,5 +1,5 @@
 resource "zedcloud_edgenode" "test_tf_provider" {
-    onboarding_key = "5d0767ee-0547-4569-b530-387e526f8cb9"
+    onboarding_key = ""
 		serialno = "2293dbe8-29ce-420c-8264-962857efc46b"
     # identity = "identity"
 

--- a/resources/testdata/node/create_all.tf
+++ b/resources/testdata/node/create_all.tf
@@ -6,7 +6,7 @@ resource "zedcloud_edgenode" "test_tf_provider" {
 		title = "test_tf_provider-title"
 
     # optional
-    onboarding_key = "5d0767ee-0547-4569-b530-387e526f8cb9"
+    onboarding_key = ""
 		serialno = "d6aebfa5-56b6-4b66-9d8e-6552b0e2b45b"
     admin_state = "ADMIN_STATE_ACTIVE"
     asset_id = "asset_id"

--- a/resources/testdata/node/create_all.yaml
+++ b/resources/testdata/node/create_all.yaml
@@ -56,7 +56,7 @@ location: ""
 memory: 0
 modelid: 2f716b55-2639-486c-9a2f-55a2e94146a6
 name: test_tf_provider
-obkey: 5d0767ee-0547-4569-b530-387e526f8cb9
+obkey: ""
 onboarding: null
 preparepoweroffcounter: 0
 preparepowerofftime: ""

--- a/resources/testdata/node/update_all.tf
+++ b/resources/testdata/node/update_all.tf
@@ -6,7 +6,7 @@ resource "zedcloud_edgenode" "test_tf_provider" {
 		title = "test_tf_provider-title"
 
     # optional
-    onboarding_key = "5d0767ee-0547-4569-b530-387e526f8cb9"
+    onboarding_key = ""
 		serialno = "d6aebfa5-56b6-4b66-9d8e-6552b0e2b45b"
     admin_state = "ADMIN_STATE_INACTIVE"
     asset_id = "asset_id"

--- a/resources/testdata/node/update_all.yaml
+++ b/resources/testdata/node/update_all.yaml
@@ -56,7 +56,7 @@ location: ""
 memory: 0
 modelid: 2f716b55-2639-486c-9a2f-55a2e94146a6
 name: test_tf_provider
-obkey: 5d0767ee-0547-4569-b530-387e526f8cb9
+obkey: ""
 onboarding: null
 preparepoweroffcounter: 0
 preparepowerofftime: ""


### PR DESCRIPTION
Removed onboarding key that is hardcoded in main.tf and test files. Replaced it with "".
Users need to update correct onboarding key while creating edge node using tf provider.

Jira ticket: https://zededa.atlassian.net/browse/CSD-51