### PR TITLE
feat: Send a request header with the tf provider version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+      - '-s -w -X main.version={{.Version}} -X github.com/zededa/terraform-provider-zedcloud/v2/resources.version={{.Version}} -X main.commit={{.Commit}}'
     goos:
       - freebsd
       - windows


### PR DESCRIPTION
Changes:
- Added a new header `x-custom-user-agent`
- Modified the existing header `user-agent`
- They both will have the value similar to: `zedcloud-terraform-provider_v1.0.0`

Tickets: 
https://zededa.atlassian.net/browse/PM-274
https://zededa.atlassian.net/browse/PM-256