### PR TITLE
fix: terraform plan always shows diff for storage field (CSD-74) 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ gen/
 terraform.log
 main.tf
 dev.tfrc
+.vscode/
+*.plan

--- a/Makefile
+++ b/Makefile
@@ -59,3 +59,10 @@ test-run:
 updatedeps:
 	go get -f -t -u ./...
 	go get -f -u ./...
+
+.PHONY: tfclean
+tfclean:
+	rm -rf ./.terraform
+	rm -f .terraform.lock.hcl
+	rm -f terraform.log
+	rm -f terraform.tfstate

--- a/v2/resources/application.go
+++ b/v2/resources/application.go
@@ -96,7 +96,7 @@ func CreateApplication(ctx context.Context, d *schema.ResourceData, m interface{
 
 	// the zedcloud API does not return the partially updated object but a custom response.
 	// thus, we need to fetch the object and populate the state.
-	if errs := ReadApplication(ctx, d, m); err != nil {
+	if errs := ReadApplication(ctx, d, m); errs != nil {
 		return append(diags, errs...)
 	}
 
@@ -247,7 +247,7 @@ func UpdateApplication(ctx context.Context, d *schema.ResourceData, m interface{
 
 	// the zedcloud API does not return the partially updated object but a custom response.
 	// thus, we need to fetch the object and populate the state.
-	if errs := ReadApplication(ctx, d, m); err != nil {
+	if errs := ReadApplication(ctx, d, m); errs != nil {
 		return append(diags, errs...)
 	}
 

--- a/v2/schemas/application.go
+++ b/v2/schemas/application.go
@@ -329,6 +329,7 @@ func Application() map[string]*schema.Schema {
 			Description: `user defined storage for bundle`,
 			Type:        schema.TypeInt,
 			Optional:    true,
+			Computed:    true,
 		},
 
 		"title": {

--- a/v2/schemas/application.go
+++ b/v2/schemas/application.go
@@ -217,7 +217,6 @@ func Application() map[string]*schema.Schema {
 		"cpus": {
 			Description: `user defined cpus for bundle`,
 			Type:        schema.TypeInt,
-			Optional:    true,
 			Computed:    true,
 		},
 
@@ -272,7 +271,6 @@ func Application() map[string]*schema.Schema {
 		"memory": {
 			Description: `user defined memory for bundle`,
 			Type:        schema.TypeInt,
-			Optional:    true,
 			Computed:    true,
 		},
 
@@ -328,7 +326,6 @@ func Application() map[string]*schema.Schema {
 		"storage": {
 			Description: `user defined storage for bundle`,
 			Type:        schema.TypeInt,
-			Optional:    true,
 			Computed:    true,
 		},
 


### PR DESCRIPTION
- The `storage` field in the `zedcloud_application` is read-only, so I marked it as `computed`.