### PR TITLE
fix: terraform plan always shows diffs for `tag_level_settings` field (CSD-97)

### DIFF
--- a/docs/data-sources/application.md
+++ b/docs/data-sources/application.md
@@ -22,24 +22,24 @@ description: |-
 
 ### Optional
 
-- `cpus` (Number) user defined cpus for bundle
 - `description` (String) Detailed description of the edge application
 - `is_imported` (Boolean) Flag to represent where app bundle is already imported
 - `manifest` (Block List, Max: 1) user defined manifest in JSON format (see [below for nested schema](#nestedblock--manifest))
 - `manifest_file` (String) path to manifest.json
-- `memory` (Number) user defined memory for bundle
 - `networks` (Number) user defined network options
 - `origin_type` (String) origin of object
 - `parent_detail` (Block List) origin and parent related details (see [below for nested schema](#nestedblock--parent_detail))
 - `project_access_list` (List of String) project access list of the app bundle
-- `storage` (Number) user defined storage for bundle
 - `user_defined_version` (String) User defined version for the given edge-app
 
 ### Read-Only
 
+- `cpus` (Number) user defined cpus for bundle
 - `drives` (Number) user defined drives
 - `id` (String) System defined universally unique Id of the edge application
+- `memory` (Number) user defined memory for bundle
 - `revision` (List of Object) system defined info (see [below for nested schema](#nestedatt--revision))
+- `storage` (Number) user defined storage for bundle
 
 <a id="nestedblock--manifest"></a>
 ### Nested Schema for `manifest`

--- a/docs/data-sources/credential.md
+++ b/docs/data-sources/credential.md
@@ -39,7 +39,7 @@ Optional:
 
 Read-Only:
 
-- `id` (String) The ID of this resource.
+- `id` (String)
 
 
 <a id="nestedblock--next"></a>

--- a/docs/data-sources/model.md
+++ b/docs/data-sources/model.md
@@ -39,7 +39,7 @@ description: |-
 ### Read-Only
 
 - `id` (String) System defined universally unique Id of the model.
-- `revision` (List of Object) Object Revision  of the model (see [below for nested schema](#nestedatt--revision))
+- `revision` (Block List) Object Revision  of the model (see [below for nested schema](#nestedblock--revision))
 
 <a id="nestedblock--io_member_list"></a>
 ### Nested Schema for `io_member_list`
@@ -112,14 +112,14 @@ Read-Only:
 - `version_of_parent_object` (Number) version of object present in parent
 
 
-<a id="nestedatt--revision"></a>
+<a id="nestedblock--revision"></a>
 ### Nested Schema for `revision`
 
 Read-Only:
 
-- `created_at` (String)
-- `created_by` (String)
-- `curr` (String)
-- `prev` (String)
-- `updated_at` (String)
-- `updated_by` (String)
+- `created_at` (String) The time, in milliseconds since the epoch, when the record was created.
+- `created_by` (String) User data: Created By
+- `curr` (String) Current Database version of the record
+- `prev` (String) Previous
+- `updated_at` (String) The time, in milliseconds since the epoch, when the record was last updated.
+- `updated_by` (String) User data: Updated By

--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -18,6 +18,7 @@ description: |-
 ### Required
 
 - `name` (String) User defined name of the resource group, unique across the enterprise. Once resource group is created, name can’t be changed.
+- `tag_level_settings` (Block List, Min: 1) tag level setting within a enterprise (see [below for nested schema](#nestedblock--tag_level_settings))
 - `title` (String) User defined title of the resource group. Title can be changed at any time.
 - `type` (String) Resource group type
 
@@ -25,11 +26,13 @@ description: |-
 
 - `app_policy` (Block List) Resource group wide policy for edge applications to be deployed on all edge nodes on this resource group (see [below for nested schema](#nestedblock--app_policy))
 - `attestation_policy` (Block List) Attestation policy to enforce on all devices of this project (see [below for nested schema](#nestedblock--attestation_policy))
+- `configuration_lock_policy` (Block List) Configuration lock prevents users to send unintentional misconfigurations (see [below for nested schema](#nestedblock--configuration_lock_policy))
 - `deployment` (Block List) Deployment template containing different types of policies (see [below for nested schema](#nestedblock--deployment))
 - `description` (String) Detailed description of the resource group.
 - `edgeview_policy` (Block List) Edgeview policy on devices of this project (see [below for nested schema](#nestedblock--edgeview_policy))
 - `local_operator_console_policy` (Block List) Local operator console policy on devices of this project (see [below for nested schema](#nestedblock--local_operator_console_policy))
 - `network_policy` (Block List) Network policy to enforce on all devices of this project (see [below for nested schema](#nestedblock--network_policy))
+- `tags` (Map of String) Tags are name/value pairs that enable you to categorize resources. Tag names are case insensitive with max_length 512 and min_length 3. Tag values are case sensitive with max_length 256 and min_length 3.
 
 ### Read-Only
 
@@ -39,6 +42,15 @@ description: |-
 - `module_policy` (List of Object) Resource group wide policy for Azure module configuration to be applied to all edge applications (see [below for nested schema](#nestedatt--module_policy))
 - `numdevices` (Number) Number of edge nodes in this resource group
 - `revision` (List of Object) system defined info (see [below for nested schema](#nestedatt--revision))
+
+<a id="nestedblock--tag_level_settings"></a>
+### Nested Schema for `tag_level_settings`
+
+Required:
+
+- `flow_log_transmission` (String) Flow log transmission setting for the network instances, it has two possible values NETWORK_INSTANCE_FLOW_LOG_TRANSMISSION_DISABLED or NETWORK_INSTANCE_FLOW_LOG_TRANSMISSION_ENABLED
+- `interface_ordering` (String) interface ordering for app instances, it has two possible values INTERFACE_ORDERING_DISABLED or INTERFACE_ORDERING_ENABLED
+
 
 <a id="nestedblock--app_policy"></a>
 ### Nested Schema for `app_policy`
@@ -50,6 +62,7 @@ Optional:
 - `attr` (Map of String) Mapping of policy  variable keys and policy variable values
 - `azure_policy` (Block List) azure policy, which is used in configuring azure iot-edge. (see [below for nested schema](#nestedblock--app_policy--azure_policy))
 - `cluster_policy` (Block List) cluster policy to bring up cluster on devices in this project (see [below for nested schema](#nestedblock--app_policy--cluster_policy))
+- `configuration_lock_policy` (Block List) configuration lock policy to enforce on all devices in this project (see [below for nested schema](#nestedblock--app_policy--configuration_lock_policy))
 - `description` (String) Detailed description of the policy
 - `edgeview_policy` (Block List) edgeview policy on devices of this project (see [below for nested schema](#nestedblock--app_policy--edgeview_policy))
 - `local_operator_console_policy` (Block List) local operator console policy to enforce on all devices in this project (see [below for nested schema](#nestedblock--app_policy--local_operator_console_policy))
@@ -781,6 +794,18 @@ Optional:
 
 - `min_nodes_required` (Number)
 
+
+
+<a id="nestedblock--app_policy--configuration_lock_policy"></a>
+### Nested Schema for `app_policy.configuration_lock_policy`
+
+Required:
+
+- `config_lock` (String) configuration lock setting
+
+Read-Only:
+
+- `id` (String) unique policy id
 
 
 <a id="nestedblock--app_policy--edgeview_policy"></a>
@@ -2331,6 +2356,7 @@ Optional:
 - `attr` (Map of String) Mapping of policy  variable keys and policy variable values
 - `azure_policy` (Block List) azure policy, which is used in configuring azure iot-edge. (see [below for nested schema](#nestedblock--attestation_policy--azure_policy))
 - `cluster_policy` (Block List) cluster policy to bring up cluster on devices in this project (see [below for nested schema](#nestedblock--attestation_policy--cluster_policy))
+- `configuration_lock_policy` (Block List) configuration lock policy to enforce on all devices in this project (see [below for nested schema](#nestedblock--attestation_policy--configuration_lock_policy))
 - `description` (String) Detailed description of the policy
 - `edgeview_policy` (Block List) edgeview policy on devices of this project (see [below for nested schema](#nestedblock--attestation_policy--edgeview_policy))
 - `local_operator_console_policy` (Block List) local operator console policy to enforce on all devices in this project (see [below for nested schema](#nestedblock--attestation_policy--local_operator_console_policy))
@@ -3062,6 +3088,18 @@ Optional:
 
 - `min_nodes_required` (Number)
 
+
+
+<a id="nestedblock--attestation_policy--configuration_lock_policy"></a>
+### Nested Schema for `attestation_policy.configuration_lock_policy`
+
+Required:
+
+- `config_lock` (String) configuration lock setting
+
+Read-Only:
+
+- `id` (String) unique policy id
 
 
 <a id="nestedblock--attestation_policy--edgeview_policy"></a>
@@ -4602,6 +4640,2300 @@ Read-Only:
 
 
 
+<a id="nestedblock--configuration_lock_policy"></a>
+### Nested Schema for `configuration_lock_policy`
+
+Optional:
+
+- `app_policy` (Block List) app policy, which is used in auto app instance deployment (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy))
+- `attestation_policy` (Block List) attestation policy to enforce on all devices in this project (see [below for nested schema](#nestedblock--configuration_lock_policy--attestation_policy))
+- `attr` (Map of String) Mapping of policy  variable keys and policy variable values
+- `azure_policy` (Block List) azure policy, which is used in configuring azure iot-edge. (see [below for nested schema](#nestedblock--configuration_lock_policy--azure_policy))
+- `cluster_policy` (Block List) cluster policy to bring up cluster on devices in this project (see [below for nested schema](#nestedblock--configuration_lock_policy--cluster_policy))
+- `configuration_lock_policy` (Block List) configuration lock policy to enforce on all devices in this project (see [below for nested schema](#nestedblock--configuration_lock_policy--configuration_lock_policy))
+- `description` (String) Detailed description of the policy
+- `edgeview_policy` (Block List) edgeview policy on devices of this project (see [below for nested schema](#nestedblock--configuration_lock_policy--edgeview_policy))
+- `local_operator_console_policy` (Block List) local operator console policy to enforce on all devices in this project (see [below for nested schema](#nestedblock--configuration_lock_policy--local_operator_console_policy))
+- `module_policy` (Block List) module policy, which is used in auto module deployment (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy))
+- `name` (String) User defined name of the policy request, unique across the enterprise. Once object is created, name can’t be changed
+- `network_policy` (Block List) network policy to enforce on all devices in this project (see [below for nested schema](#nestedblock--configuration_lock_policy--network_policy))
+- `title` (String) User defined title of the policy. Title can be changed at any time
+- `type` (String) type of policy
+
+Read-Only:
+
+- `id` (String) System defined universally unique Id of the policy request
+- `revision` (List of Object) system defined info (see [below for nested schema](#nestedatt--configuration_lock_policy--revision))
+- `status` (String) status of the policy
+- `status_message` (String) Detailed status message of the policy
+
+<a id="nestedblock--configuration_lock_policy--app_policy"></a>
+### Nested Schema for `configuration_lock_policy.app_policy`
+
+Required:
+
+- `apps` (Block List, Min: 1) list of app details that will be provisioned on all the devices of the project to which this policy is attached (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps))
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps`
+
+Required:
+
+- `cpus` (Number) user defined cpus for bundle
+- `manifest_json` (Block List, Min: 1) Manifest data (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--manifest_json))
+- `memory` (Number) user defined memory for bundle
+- `name` (String) User defined name of the edge application, unique across the enterprise. Once object is created, name can’t be changed
+- `networks` (Number) user defined network options
+- `origin_type` (String) origin of object
+- `title` (String) User defined title of the edge application. Title can be changed at any time
+
+Optional:
+
+- `app_id` (String) User defined name of the edge app, unique across the enterprise. Once app name is created, name can’t be changed
+- `app_version` (String) Current version of the attached bundle
+- `description` (String) Detailed description of the edge application
+- `interfaces` (Block List) application interfaces (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--interfaces))
+- `name_app_part` (String) User provided name part  for the auto deployed app
+- `name_project_part` (String) User provided name part  for the auto deployed app
+- `naming_scheme` (String) app naming scheme
+- `parent_detail` (Block List) origin and parent related details (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--parent_detail))
+- `start_delay_in_seconds` (Number) start delay is the time in seconds EVE should wait after boot before starting the application instance
+- `storage` (Number) user defined storage for bundle
+- `tags` (Map of String) Tags are name/value pairs that enable you to categorize resources. Tag names are case insensitive with max_length 512 and min_length 3. Tag values are case sensitive with max_length 256 and min_length 3.
+
+Read-Only:
+
+- `drives` (Number) user defined drives
+- `id` (String) System defined universally unique Id of the edge application
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--manifest_json"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.manifest_json`
+
+Required:
+
+- `ac_kind` (String) UI map: N/A - not exposed to users
+- `ac_version` (String) UI map: N/A - not exposed to users
+- `name` (String) UI map: AppEditPage:IdentityPane:Name_Field, AppDetailsPage:IdentityPane:Name_Field
+
+Optional:
+
+- `app_type` (String) bundle type, eg: vm, container, module
+- `configuration` (Block List) Template for Custom Configuration. Used for Cloud-Init (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--configuration))
+- `container_detail` (Block List) Create options direct the creation of the Docker container (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--container_detail))
+- `cpu_pinning_enabled` (Boolean) Enable CpuPinning
+- `deployment_type` (String) type of deployment for the app, eg: azure, k3s, standalone
+- `desc` (Block List) Description of the application (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--desc))
+- `description` (String) UI map: AppDetailsPage:IdentityPane:DescriptionField, AppMarketplacePage:AppCard:DescriptionField
+- `display_name` (String) UI map: AppEditPage:IdentityPane:Title_Field, AppDetailsPage:IdentityPane:Title_Field
+- `enablevnc` (Boolean) UI map: AppEditPage:IdentityPane:VNC_Field, AppDetailsPage:IdentityPane:VNC_Field
+- `images` (Block List) UI map: AppEditPage:DrivesPane, AppDetailsPage:DrivesPane (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--images))
+- `interfaces` (Block List) UI map: AppEditPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--interfaces))
+- `module` (Block List) Azure module specific details like module twin, environment variable, routes (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--module))
+- `owner` (Block List) Owner of the application (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--owner))
+- `permissions` (Block List) (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--permissions))
+- `resources` (Block List) UI map: AppEditPage:ResourcesPane, AppDetailsPage:ResourcesPane (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--resources))
+- `vmmode` (String) UI map: AppEditPage:IdentityPane:VM_Mode_Field, AppDetailsPage:IdentityPane:VM_Mode_Field
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--configuration"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.manifest_json.configuration`
+
+Optional:
+
+- `custom_config` (Block List) (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--configuration--custom_config))
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--configuration--custom_config"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.manifest_json.configuration.custom_config`
+
+Optional:
+
+- `add` (Boolean) Add the Custom Config to App Instance (Optional. Default: False)
+- `allow_storage_resize` (Boolean) Allow Appinstance storage to be resized after app instance is created. (Optional. Default: False)
+- `field_delimiter` (String) Field delimiter used in specifying variables in template. (Required)
+- `name` (String) Name of CustomConfig (Required)
+- `override` (Boolean) Override existing custom config from App Bundle Manifest (Optional. Default: False)
+- `template` (String) base64 encrypted template string. (Optional)
+- `variable_groups` (Block List) List of Variable groups. (Required) (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups))
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.manifest_json.configuration.custom_config.variable_groups`
+
+Optional:
+
+- `condition` (Block List) Condition to apply the variable group. (Optional. Default: None) (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--condition))
+- `name` (String) Name of the Variable Group(Required)
+- `required` (Boolean) Indicates if the variable group is required to be specified for the App Instance. (Optional. Default:False)
+- `variables` (Block List) List of variables(Required) (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables))
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--condition"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.manifest_json.configuration.custom_config.variable_groups.condition`
+
+Optional:
+
+- `name` (String)
+- `operator` (String)
+- `value` (String)
+
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.manifest_json.configuration.custom_config.variable_groups.variables`
+
+Required:
+
+- `format` (String) Format of the user variable. (Required)
+- `label` (String) Label for the variable (Required)
+- `name` (String) Name of the Variable (Required)
+- `required` (Boolean) This variable MUST be specified when creating an App Instance. (Optional. Default: False)
+
+Optional:
+
+- `default` (String) Default value of the variable. (Optional. Default: <Default value based on type>)
+- `encode` (String) Encoding of file content. Applicable if format is VARIABLE_FORMAT_FILE
+- `max_length` (String) Max length of the value of the variable(Optional. Default: 1024)
+- `options` (Block List) Key-Value pair of options. Applicable if format is VARIABLE_FORMAT_DROPDOWN (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables--options))
+- `process_input` (String)
+- `type` (String)
+- `value` (String) User-specified value of the variable.(Required if required is true. Optional otherwise)
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables--options"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.manifest_json.configuration.custom_config.variable_groups.variables.options`
+
+Optional:
+
+- `label` (String) Display label of the key in User-Agent
+- `value` (String) Value of the key to be used
+
+
+
+
+
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--container_detail"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.manifest_json.container_detail`
+
+Optional:
+
+- `container_create_option` (String) Create options direct the creation of the Docker container
+
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--desc"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.manifest_json.desc`
+
+Required:
+
+- `app_category` (String)
+
+Optional:
+
+- `agreement_list` (Map of String) UI map: AppEditPage:DeveloperPane:Developer_Agreement_Field, AppDetailsPage:DeveloperPane:Developer_Agreement_Field
+- `category` (String) UI map: AppMarketplacePage:AppCard:DescriptionField, AppEditPage:IdentityPane:CategoryField, AppDetailsPage:IdentityPane:CategoryField
+- `license_list` (Map of String) UI map: AppMarketplacePage:AppCard:License, AppEditPage:IdentityPane:License, AppDetailsPage:IdentityPane:License
+- `logo` (Map of String) UI map: AppEditPage:IdentityPane:Logo, AppDetailsPage:IdentityPane:Logo
+- `os` (String)
+- `screenshot_list` (Map of String) UI map: AppEditPage:IdentityPane:Screenshot_Fields, AppDetailsPage:IdentityPane:Screenshot_Fields
+- `support` (String) UI map: AppEditPage:DeveloperPane:Support_Description_Field, AppDetailsPage:DeveloperPane:Support_Description_Field
+
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--images"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.manifest_json.images`
+
+Optional:
+
+- `cleartext` (Boolean) UI map: AppEditPage:DrivesPane:Cleartext, AppDetailsPage:DrivesPane:ClearText_Field
+- `drvtype` (String) UI map: AppEditPage:DrivesPane:Drive_Type_Field, AppDetailsPage:DrivesPane:Drive_Type_Field
+- `ignorepurge` (Boolean) UI map: AppEditPage:DrivesPane:Ignorepurge, AppDetailsPage:DrivesPane:Ignorepurgee_Field
+- `imageformat` (String) UI map: AppEditPage:DrivesPane:Image_Format_Field, AppDetailsPage:DrivesPane:Image_Format_Field
+- `imageid` (String) UI map: AppEditPage:DrivesPane:Image_ID_Field, AppDetailsPage:DrivesPane:Image_ID_Field
+- `imagename` (String) UI map: AppEditPage:DrivesPane:Image_Name_Field, AppDetailsPage:DrivesPane:Image_Name_Field
+- `maxsize` (String) UI map: AppEditPage:DrivesPane:Max_Size_Field, AppDetailsPage:DrivesPane:Max_Size_Field
+- `mountpath` (String) UI map: AppEditPage:DrivesPane:Mountpath, AppDetailsPage:DrivesPane:Mountpath_Field
+- `params` (Block List) (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--images--params))
+- `preserve` (Boolean) UI map: AppEditPage:DrivesPane:Preserve_Field, AppDetailsPage:DrivesPane:Preserve_Field
+- `readonly` (Boolean)
+- `target` (String) UI map: AppEditPage:DrivesPane:Target_Field, AppDetailsPage:DrivesPane:Target_Field
+- `volumelabel` (String) UI map: AppEditPage:DrivesPane:Volume_Label, AppDetailsPage:DrivesPane:Volume_Label
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--images--params"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.manifest_json.images.params`
+
+Optional:
+
+- `name` (String) Name of the Parameter (Required)
+- `value` (String) Value of the parameter (Required)
+
+
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--interfaces"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.manifest_json.interfaces`
+
+Optional:
+
+- `acls` (Block List) Traffic access control rules for this interface. Applicable only when "direct attach" flag is false. (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--interfaces--acls))
+- `directattach` (Boolean) If true, a physical adapter is assigned to the edge application directly. If false, a network instance is assigned to the edge application.
+- `name` (String) Interface name used by the edge application
+- `optional` (Boolean) Indicates if the interface is optional for edge application.
+- `privateip` (Boolean) If true, DHCP network can't be assigned and user needs to provide a static IP address.
+- `type` (String) Physical Adapter type for this interface. Applicable only when "direct attach" flag is true.
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--interfaces--acls"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.manifest_json.interfaces.acls`
+
+Optional:
+
+- `actions` (Block List) Chain of actions to be taken on matching network traffic (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--interfaces--acls--actions))
+- `matches` (Block List) Network traffic matching criteria consistngs of one or more of source IP address, destination IP address, protocol, source port and destination port (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--interfaces--acls--matches))
+- `name` (String) Name of the Access Control List
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--interfaces--acls--actions"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.manifest_json.interfaces.acls.actions`
+
+Optional:
+
+- `drop` (Boolean) Drop the packet
+- `limit` (Boolean) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+- `limit_value` (Block List) Value to be used for limit action (Required if limit is true) (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--interfaces--acls--actions--limit_value))
+- `limitburst` (Number) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+- `limitrate` (Number) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+- `limitunit` (String) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+- `portmap` (Boolean) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+- `portmapto` (Block List) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--interfaces--acls--actions--portmapto))
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--interfaces--acls--actions--limit_value"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.manifest_json.interfaces.acls.actions.limit_value`
+
+Optional:
+
+- `limitburst` (Number) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+- `limitrate` (Number) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+- `limitunit` (String) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--interfaces--acls--actions--portmapto"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.manifest_json.interfaces.acls.actions.portmapto`
+
+Optional:
+
+- `app_port` (Number) Application Port value
+
+
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--interfaces--acls--matches"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.manifest_json.interfaces.acls.matches`
+
+Optional:
+
+- `type` (String) Type of Match (Required)
+- `value` (String) Value of match (Required)
+
+
+
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--module"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.manifest_json.module`
+
+Optional:
+
+- `environment` (Map of String) Extra information to module to make configuration easier
+- `module_type` (String) Type of modules
+- `routes` (Map of String) Send messages between modules or send messages from modules to iot hub
+- `twin_detail` (String) Base64 encoded module twin details, desired properties of the module will be updated to reflect these values
+
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--owner"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.manifest_json.owner`
+
+Optional:
+
+- `company` (String) UI map: AppEditPage:IdentityPane:Category_Field, AppDetailsPage:IdentityPane:Category_Field
+- `email` (String) UI map: AppEditPage:DeveloperPane:Email_Field, AppDetailsPage:DeveloperPane:Email_Field
+- `group` (String)
+- `user` (String) UI map: AppEditPage:DeveloperPane:Name_Field, AppDetailsPage:DeveloperPane:Name_Field
+- `website` (String) UI map: AppEditPage:DeveloperPane:Website_Field, AppDetailsPage:DeveloperPane:Website_Field
+
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--permissions"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.manifest_json.permissions`
+
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--manifest_json--resources"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.manifest_json.resources`
+
+Optional:
+
+- `name` (String) Name of the Resource (Required)
+- `value` (String) Value of Resource (Required)
+
+
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--interfaces"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.interfaces`
+
+Required:
+
+- `intfname` (String) intf Name
+- `netinstname` (String) Network Instance name to be matched for interface assignment. Applicable only when "direct attach" flag is false
+- `privateip` (Boolean) Private IP flag
+
+Optional:
+
+- `access_vlan_id` (Number) access port VLAN ID, vlan id of zero will be treated as trunk port and vlan id 1 is implicitly used by linux bridges
+- `acls` (Block List) app Acls (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--interfaces--acls))
+- `default_net_instance` (Boolean) default instance flag
+- `directattach` (Boolean) direct attach flag
+- `eidregister` (Block List) EID register details (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--interfaces--eidregister))
+- `intforder` (Number) intforder
+- `io` (Block List) Physical Adapter to be matched for interface assignment. Applicable only when "direct attach" flag is true (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--interfaces--io))
+- `ipaddr` (String) IP address
+- `macaddr` (String) MAC address
+- `netinsttag` (Map of String) Network Instance tag to be matched for interface assignment. Applicable only when "direct attach" flag is false
+- `netname` (String) network name: will be deprecated in future, use netinstname
+
+Read-Only:
+
+- `netinstid` (String) Network Instance id to be matched for interface assignment.
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--interfaces--acls"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.interfaces.acls`
+
+Optional:
+
+- `actions` (Block List) app ACE actions (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--interfaces--acls--actions))
+- `matches` (Block List) app ACE match (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--interfaces--acls--matches))
+- `name` (String) User defined name of the app ACE, unique across the enterprise. Once object is created, name can’t be changed
+
+Read-Only:
+
+- `id` (Number) app ACE id
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--interfaces--acls--actions"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.interfaces.acls.actions`
+
+Optional:
+
+- `drop` (Boolean) ACE drop flag
+- `limit` (Boolean) ACE limit flag
+- `limitburst` (Number) ACE limit burst
+- `limitrate` (Number) ACE limit rate
+- `limitunit` (String) ACE limit unit
+- `mapparams` (Block List) Application map params (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--interfaces--acls--actions--mapparams))
+- `portmap` (Boolean) application port map flag
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--interfaces--acls--actions--mapparams"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.interfaces.acls.actions.mapparams`
+
+Optional:
+
+- `port` (Number) Application port
+
+
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--interfaces--acls--matches"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.interfaces.acls.matches`
+
+Optional:
+
+- `type` (String) Type
+- `value` (String) Value
+
+
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--interfaces--eidregister"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.interfaces.eidregister`
+
+Required:
+
+- `display_name` (String) Display name
+- `e_id` (String) EID
+- `e_id_hash_len` (Number) EID hash length
+- `lisp_instance` (Number) Lisp Instance
+- `lisp_map_servers` (Block List, Min: 1) Lisp Map Server (see [below for nested schema](#nestedblock--configuration_lock_policy--app_policy--apps--interfaces--eidregister--lisp_map_servers))
+- `lisp_signature` (String) Lisp Signature
+- `uuid` (String) UUID
+
+Read-Only:
+
+- `app_cert` (String) app certificate
+- `app_private_key` (String) App private key
+- `app_public_key` (String) App public key
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--interfaces--eidregister--lisp_map_servers"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.interfaces.eidregister.lisp_map_servers`
+
+Required:
+
+- `credential` (String, Sensitive) lisp credential
+- `name_or_ip` (String) name/IP
+
+
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--interfaces--io"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.interfaces.io`
+
+Optional:
+
+- `name` (String) Physical Adapter name
+- `tags` (Map of String) Tags are name/value pairs that enable you to categorize resources. Tag names are case insensitive with max_length 512 and min_length 3. Tag values are case sensitive with max_length 256 and min_length 3.
+- `type` (String) IoType specifies the type of the Input output of the device
+
+
+
+<a id="nestedblock--configuration_lock_policy--app_policy--apps--parent_detail"></a>
+### Nested Schema for `configuration_lock_policy.app_policy.apps.parent_detail`
+
+Optional:
+
+- `reference_exists` (Boolean) Relation with child and parent object exists or not
+- `update_available` (Boolean) Update required flag
+
+Read-Only:
+
+- `id_of_parent_object` (String) system defined unique id of parent object
+- `version_of_parent_object` (Number) version of object present in parent
+
+
+
+
+<a id="nestedblock--configuration_lock_policy--attestation_policy"></a>
+### Nested Schema for `configuration_lock_policy.attestation_policy`
+
+Required:
+
+- `type` (String) Attestation policy type
+
+Read-Only:
+
+- `id` (String) unique policy id
+
+
+<a id="nestedblock--configuration_lock_policy--azure_policy"></a>
+### Nested Schema for `configuration_lock_policy.azure_policy`
+
+Required:
+
+- `app_id` (String) app id for rbac
+- `app_password` (String) app password for rbac
+- `tenant_id` (String) tenant id for rbac
+
+Optional:
+
+- `azure_resource_and_services` (Block List) azure resource and service the policy will be interested in (see [below for nested schema](#nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services))
+- `certificate` (Block List) Certificate object holds the details of certificate like encryption type, validity, subject etc (see [below for nested schema](#nestedblock--configuration_lock_policy--azure_policy--certificate))
+- `crypto_key` (String) key to decrypt AppPassword
+- `custom_deployment_managed` (Boolean)
+- `encrypted_secrets` (Map of String) encrypted AppPassword
+
+<a id="nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services"></a>
+### Nested Schema for `configuration_lock_policy.azure_policy.azure_resource_and_services`
+
+Required:
+
+- `dps_service` (Block List, Min: 1) dps service attached to cloud policy (see [below for nested schema](#nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services--dps_service))
+- `iot_hub_service` (Block List, Min: 1) list of iothubs attached to cloud policy (see [below for nested schema](#nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services--iot_hub_service))
+- `resource_group` (Block List, Min: 1) list of resource groups attached to cloud policy (see [below for nested schema](#nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services--resource_group))
+
+<a id="nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services--dps_service"></a>
+### Nested Schema for `configuration_lock_policy.azure_policy.azure_resource_and_services.dps_service`
+
+Optional:
+
+- `enrollment` (Block List) (see [below for nested schema](#nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services--dps_service--enrollment))
+- `service_detail` (Block List) (see [below for nested schema](#nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services--dps_service--service_detail))
+
+<a id="nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services--dps_service--enrollment"></a>
+### Nested Schema for `configuration_lock_policy.azure_policy.azure_resource_and_services.dps_service.enrollment`
+
+Optional:
+
+- `allocation_policy` (String)
+- `attached_iot_hubs_name` (List of String)
+- `certificate_enrollment` (Block List) (see [below for nested schema](#nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--certificate_enrollment))
+- `enable_iot_edge_device` (Boolean)
+- `mechanism` (String)
+- `symmetric_key_enrollment` (Block List) (see [below for nested schema](#nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment))
+- `tags` (Map of String)
+- `tpm_enrollment` (Block List) (see [below for nested schema](#nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--tpm_enrollment))
+
+<a id="nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--certificate_enrollment"></a>
+### Nested Schema for `configuration_lock_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.certificate_enrollment`
+
+Optional:
+
+- `group_certificate_enrollment` (Block List) (see [below for nested schema](#nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--certificate_enrollment--group_certificate_enrollment))
+- `individual_certificate_enrollment` (String)
+- `type` (String)
+
+<a id="nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--certificate_enrollment--group_certificate_enrollment"></a>
+### Nested Schema for `configuration_lock_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.certificate_enrollment.group_certificate_enrollment`
+
+Optional:
+
+- `group_name` (String)
+
+
+
+<a id="nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment"></a>
+### Nested Schema for `configuration_lock_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.symmetric_key_enrollment`
+
+Optional:
+
+- `group_symmetric_key_enrollment` (Block List) (see [below for nested schema](#nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment--group_symmetric_key_enrollment))
+- `individual_symmetric_key_enrollment` (Block List) (see [below for nested schema](#nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment--individual_symmetric_key_enrollment))
+- `type` (String)
+
+<a id="nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment--group_symmetric_key_enrollment"></a>
+### Nested Schema for `configuration_lock_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.symmetric_key_enrollment.group_symmetric_key_enrollment`
+
+Optional:
+
+- `group_name` (String)
+
+
+<a id="nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment--individual_symmetric_key_enrollment"></a>
+### Nested Schema for `configuration_lock_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.symmetric_key_enrollment.individual_symmetric_key_enrollment`
+
+Optional:
+
+- `registration_id` (String)
+
+
+
+<a id="nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--tpm_enrollment"></a>
+### Nested Schema for `configuration_lock_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.tpm_enrollment`
+
+Optional:
+
+- `type` (String)
+
+
+
+<a id="nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services--dps_service--service_detail"></a>
+### Nested Schema for `configuration_lock_policy.azure_policy.azure_resource_and_services.dps_service.service_detail`
+
+Optional:
+
+- `create_by_default` (Boolean)
+- `name` (String)
+- `region` (String)
+- `resource_group_name` (String)
+- `s_k_u` (Block List) (see [below for nested schema](#nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services--dps_service--service_detail--s_k_u))
+- `subscription_id` (String)
+
+<a id="nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services--dps_service--service_detail--s_k_u"></a>
+### Nested Schema for `configuration_lock_policy.azure_policy.azure_resource_and_services.dps_service.service_detail.s_k_u`
+
+Optional:
+
+- `capacity` (String)
+- `name` (String)
+- `tier` (String)
+
+
+
+
+<a id="nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services--iot_hub_service"></a>
+### Nested Schema for `configuration_lock_policy.azure_policy.azure_resource_and_services.iot_hub_service`
+
+Optional:
+
+- `service_detail` (Block List) (see [below for nested schema](#nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services--iot_hub_service--service_detail))
+
+<a id="nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services--iot_hub_service--service_detail"></a>
+### Nested Schema for `configuration_lock_policy.azure_policy.azure_resource_and_services.iot_hub_service.service_detail`
+
+Optional:
+
+- `create_by_default` (Boolean)
+- `name` (String)
+- `region` (String)
+- `resource_group_name` (String)
+- `s_k_u` (Block List) (see [below for nested schema](#nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services--iot_hub_service--service_detail--s_k_u))
+- `subscription_id` (String)
+
+<a id="nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services--iot_hub_service--service_detail--s_k_u"></a>
+### Nested Schema for `configuration_lock_policy.azure_policy.azure_resource_and_services.iot_hub_service.service_detail.s_k_u`
+
+Optional:
+
+- `capacity` (String)
+- `name` (String)
+- `tier` (String)
+
+
+
+
+<a id="nestedblock--configuration_lock_policy--azure_policy--azure_resource_and_services--resource_group"></a>
+### Nested Schema for `configuration_lock_policy.azure_policy.azure_resource_and_services.resource_group`
+
+Required:
+
+- `name` (String) resource group name
+- `subscription_id` (String) azure subscription id to which resource group is attached
+
+Optional:
+
+- `region` (String) resource group region
+
+
+
+<a id="nestedblock--configuration_lock_policy--azure_policy--certificate"></a>
+### Nested Schema for `configuration_lock_policy.azure_policy.certificate`
+
+Optional:
+
+- `basic_contraints_valid` (Boolean) This fields tells the basic constraints like isCA are correct.
+- `cert` (String) base64 string of the parent certificate
+- `crypto_key` (String) Crypto Key for decrypting user secret information
+- `ecdsa_encryption` (Block List) ECDSA encryption algorithm of the certificate (see [below for nested schema](#nestedblock--configuration_lock_policy--azure_policy--certificate--ecdsa_encryption))
+- `encrypted_secrets` (Map of String) user encrypted secrets map
+- `exportable` (Boolean) Indicates if the private key can be exported.
+- `extended_key_usage` (List of String) Sequence of extended key usages.
+- `issuer` (Block List) Parameters for the issuer of the X509 component of a certificate. (see [below for nested schema](#nestedblock--configuration_lock_policy--azure_policy--certificate--issuer))
+- `key_usage` (Number) Key usage extensions define the purpose of the public key contained in a certificate.
+- `pass_phrase` (String) pass phase for the pvt key, this has to be filled if pvt key is encrypted with a pass phrase
+- `public_key` (String) base63 string of the public key
+- `public_key_algorithm` (String) Public key algorithm.
+- `pvt_key` (String) base64 string of the parent pvt key
+- `reuse_key` (Boolean) Indicates if the same key pair will be used on certificate renewal.
+- `rsa_ecryption` (Block List) RSA encryption algorithm of the certificate (see [below for nested schema](#nestedblock--configuration_lock_policy--azure_policy--certificate--rsa_ecryption))
+- `san_values` (Block List) This holds the alternative name values like URIs, domain names IPs etc. (see [below for nested schema](#nestedblock--configuration_lock_policy--azure_policy--certificate--san_values))
+- `serial_number` (String) Unique identifier for each Certificate generated by an Certificate Issuer.
+- `signature_algorithm` (String)
+- `subject` (Block List) Parameters for the subject of the X509 component of a certificate. (see [below for nested schema](#nestedblock--configuration_lock_policy--azure_policy--certificate--subject))
+- `valid_from` (String) Certificate validatity start time
+- `valid_till` (String) Certificate validatity start time
+
+<a id="nestedblock--configuration_lock_policy--azure_policy--certificate--ecdsa_encryption"></a>
+### Nested Schema for `configuration_lock_policy.azure_policy.certificate.ecdsa_encryption`
+
+Optional:
+
+- `curve` (String) ECDSA curve to be used while signing the certificate.
+
+
+<a id="nestedblock--configuration_lock_policy--azure_policy--certificate--issuer"></a>
+### Nested Schema for `configuration_lock_policy.azure_policy.certificate.issuer`
+
+Optional:
+
+- `common_name` (String) Certificate common name.
+- `country` (List of String) List of countries.
+- `locality` (List of String) List of locallity.
+- `organization` (List of String) List of organization.
+- `organizational_unit` (List of String) List of Organizational Unit.
+- `postal_code` (List of String) List of Postal codes.
+- `province` (List of String) List of List of Prvince.
+- `serial_number` (String) Subject cerial number
+
+
+<a id="nestedblock--configuration_lock_policy--azure_policy--certificate--rsa_ecryption"></a>
+### Nested Schema for `configuration_lock_policy.azure_policy.certificate.rsa_ecryption`
+
+Optional:
+
+- `rsa_bits` (String) RSA Encryption Key bit size.
+
+
+<a id="nestedblock--configuration_lock_policy--azure_policy--certificate--san_values"></a>
+### Nested Schema for `configuration_lock_policy.azure_policy.certificate.san_values`
+
+Optional:
+
+- `dns` (List of String) List of permitted DNS names.
+- `emaild_ids` (List of String) List of permitted email addresses.
+- `hosts` (List of String) List of permitted hosts.
+- `ips` (List of String) List of permitted IP addresses.
+- `upns` (List of String) List of permitted User principal names.
+- `uris` (List of String) List of permitted URIs.
+
+
+<a id="nestedblock--configuration_lock_policy--azure_policy--certificate--subject"></a>
+### Nested Schema for `configuration_lock_policy.azure_policy.certificate.subject`
+
+Optional:
+
+- `common_name` (String) Certificate common name.
+- `country` (List of String) List of countries.
+- `locality` (List of String) List of locallity.
+- `organization` (List of String) List of organization.
+- `organizational_unit` (List of String) List of Organizational Unit.
+- `postal_code` (List of String) List of Postal codes.
+- `province` (List of String) List of List of Prvince.
+- `serial_number` (String) Subject cerial number
+
+
+
+
+<a id="nestedblock--configuration_lock_policy--cluster_policy"></a>
+### Nested Schema for `configuration_lock_policy.cluster_policy`
+
+Required:
+
+- `app_policy_id` (String) UUID of the app policy linked to this cluster policy
+- `network_policy_id` (String) UUID of the network policy linked to this cluster policy
+- `type` (String) Type of cluster
+
+Optional:
+
+- `cluster_config` (Block List) Cluster Policy Parameters (see [below for nested schema](#nestedblock--configuration_lock_policy--cluster_policy--cluster_config))
+
+<a id="nestedblock--configuration_lock_policy--cluster_policy--cluster_config"></a>
+### Nested Schema for `configuration_lock_policy.cluster_policy.cluster_config`
+
+Optional:
+
+- `min_nodes_required` (Number)
+
+
+
+<a id="nestedblock--configuration_lock_policy--configuration_lock_policy"></a>
+### Nested Schema for `configuration_lock_policy.configuration_lock_policy`
+
+Required:
+
+- `config_lock` (String) configuration lock setting
+
+Read-Only:
+
+- `id` (String) unique policy id
+
+
+<a id="nestedblock--configuration_lock_policy--edgeview_policy"></a>
+### Nested Schema for `configuration_lock_policy.edgeview_policy`
+
+Optional:
+
+- `access_allow_change` (Boolean) Allow inherit instance to change access policy
+- `edgeview_allow` (Boolean) Allow device to enable Edgeview in this project
+- `edgeviewcfg` (Block List) Edgeview configuration and policies (see [below for nested schema](#nestedblock--configuration_lock_policy--edgeview_policy--edgeviewcfg))
+- `max_expire_sec` (Number) Maximum seconds allowed for Edgeview session
+- `max_inst` (Number) Maximum instances allowed for Edgeview
+
+<a id="nestedblock--configuration_lock_policy--edgeview_policy--edgeviewcfg"></a>
+### Nested Schema for `configuration_lock_policy.edgeview_policy.edgeviewcfg`
+
+Optional:
+
+- `app_policy` (Block List) (see [below for nested schema](#nestedblock--configuration_lock_policy--edgeview_policy--edgeviewcfg--app_policy))
+- `dev_policy` (Block List) (see [below for nested schema](#nestedblock--configuration_lock_policy--edgeview_policy--edgeviewcfg--dev_policy))
+- `ext_policy` (Block List) (see [below for nested schema](#nestedblock--configuration_lock_policy--edgeview_policy--edgeviewcfg--ext_policy))
+- `generation_id` (Number)
+- `jwt_info` (Block List) (see [below for nested schema](#nestedblock--configuration_lock_policy--edgeview_policy--edgeviewcfg--jwt_info))
+- `token` (String)
+
+<a id="nestedblock--configuration_lock_policy--edgeview_policy--edgeviewcfg--app_policy"></a>
+### Nested Schema for `configuration_lock_policy.edgeview_policy.edgeviewcfg.app_policy`
+
+Optional:
+
+- `allow_app` (Boolean)
+
+
+<a id="nestedblock--configuration_lock_policy--edgeview_policy--edgeviewcfg--dev_policy"></a>
+### Nested Schema for `configuration_lock_policy.edgeview_policy.edgeviewcfg.dev_policy`
+
+Optional:
+
+- `allow_dev` (Boolean)
+
+
+<a id="nestedblock--configuration_lock_policy--edgeview_policy--edgeviewcfg--ext_policy"></a>
+### Nested Schema for `configuration_lock_policy.edgeview_policy.edgeviewcfg.ext_policy`
+
+Optional:
+
+- `allow_ext` (Boolean)
+
+
+<a id="nestedblock--configuration_lock_policy--edgeview_policy--edgeviewcfg--jwt_info"></a>
+### Nested Schema for `configuration_lock_policy.edgeview_policy.edgeviewcfg.jwt_info`
+
+Optional:
+
+- `allow_sec` (Number)
+- `disp_url` (String)
+- `encrypt` (Boolean)
+- `expire_sec` (String)
+- `num_inst` (Number)
+
+
+
+
+<a id="nestedblock--configuration_lock_policy--local_operator_console_policy"></a>
+### Nested Schema for `configuration_lock_policy.local_operator_console_policy`
+
+Required:
+
+- `loc_url` (String) Local operator console URL
+
+Read-Only:
+
+- `id` (String) unique policy id
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy"></a>
+### Nested Schema for `configuration_lock_policy.module_policy`
+
+Required:
+
+- `apps` (Block List, Min: 1) list of app details that will be provisioned on all the devices of the project to which this policy is attached (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps))
+- `priority` (Number) deployment priority of module manifest
+
+Optional:
+
+- `azure_edge_agent` (Block List) app that describes the azure edge agent to be deployed on the Azure runtime (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent))
+- `azure_edge_hub` (Block List) app that describes the azure edge hub to be deployed on the Azure runtime (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub))
+- `etag` (String) etag for deployment
+- `labels` (Map of String) Mapping of label variable keys and value
+- `metrics` (Block List) custom metrics for deployment (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--metrics))
+- `routes` (Map of String) Mapping of routes variable keys and value
+- `target_condition` (String) target condition for deployment that matches single device or group of devices
+- `target_condition_new` (Map of String) target condition for deployment that matches single device or group of devices
+
+Read-Only:
+
+- `id` (String) unique id for deployment
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps`
+
+Required:
+
+- `cpus` (Number) user defined cpus for bundle
+- `manifest_json` (Block List, Min: 1) Manifest data (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--manifest_json))
+- `memory` (Number) user defined memory for bundle
+- `name` (String) User defined name of the edge application, unique across the enterprise. Once object is created, name can’t be changed
+- `networks` (Number) user defined network options
+- `origin_type` (String) origin of object
+- `title` (String) User defined title of the edge application. Title can be changed at any time
+
+Optional:
+
+- `app_id` (String) User defined name of the edge app, unique across the enterprise. Once app name is created, name can’t be changed
+- `app_version` (String) Current version of the attached bundle
+- `description` (String) Detailed description of the edge application
+- `interfaces` (Block List) application interfaces (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--interfaces))
+- `name_app_part` (String) User provided name part  for the auto deployed app
+- `name_project_part` (String) User provided name part  for the auto deployed app
+- `naming_scheme` (String) app naming scheme
+- `parent_detail` (Block List) origin and parent related details (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--parent_detail))
+- `start_delay_in_seconds` (Number) start delay is the time in seconds EVE should wait after boot before starting the application instance
+- `storage` (Number) user defined storage for bundle
+- `tags` (Map of String) Tags are name/value pairs that enable you to categorize resources. Tag names are case insensitive with max_length 512 and min_length 3. Tag values are case sensitive with max_length 256 and min_length 3.
+
+Read-Only:
+
+- `drives` (Number) user defined drives
+- `id` (String) System defined universally unique Id of the edge application
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--manifest_json"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.manifest_json`
+
+Required:
+
+- `ac_kind` (String) UI map: N/A - not exposed to users
+- `ac_version` (String) UI map: N/A - not exposed to users
+- `name` (String) UI map: AppEditPage:IdentityPane:Name_Field, AppDetailsPage:IdentityPane:Name_Field
+
+Optional:
+
+- `app_type` (String) bundle type, eg: vm, container, module
+- `configuration` (Block List) Template for Custom Configuration. Used for Cloud-Init (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--configuration))
+- `container_detail` (Block List) Create options direct the creation of the Docker container (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--container_detail))
+- `cpu_pinning_enabled` (Boolean) Enable CpuPinning
+- `deployment_type` (String) type of deployment for the app, eg: azure, k3s, standalone
+- `desc` (Block List) Description of the application (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--desc))
+- `description` (String) UI map: AppDetailsPage:IdentityPane:DescriptionField, AppMarketplacePage:AppCard:DescriptionField
+- `display_name` (String) UI map: AppEditPage:IdentityPane:Title_Field, AppDetailsPage:IdentityPane:Title_Field
+- `enablevnc` (Boolean) UI map: AppEditPage:IdentityPane:VNC_Field, AppDetailsPage:IdentityPane:VNC_Field
+- `images` (Block List) UI map: AppEditPage:DrivesPane, AppDetailsPage:DrivesPane (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--images))
+- `interfaces` (Block List) UI map: AppEditPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--interfaces))
+- `module` (Block List) Azure module specific details like module twin, environment variable, routes (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--module))
+- `owner` (Block List) Owner of the application (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--owner))
+- `permissions` (Block List) (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--permissions))
+- `resources` (Block List) UI map: AppEditPage:ResourcesPane, AppDetailsPage:ResourcesPane (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--resources))
+- `vmmode` (String) UI map: AppEditPage:IdentityPane:VM_Mode_Field, AppDetailsPage:IdentityPane:VM_Mode_Field
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--configuration"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.manifest_json.configuration`
+
+Optional:
+
+- `custom_config` (Block List) (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--configuration--custom_config))
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--configuration--custom_config"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.manifest_json.configuration.custom_config`
+
+Optional:
+
+- `add` (Boolean) Add the Custom Config to App Instance (Optional. Default: False)
+- `allow_storage_resize` (Boolean) Allow Appinstance storage to be resized after app instance is created. (Optional. Default: False)
+- `field_delimiter` (String) Field delimiter used in specifying variables in template. (Required)
+- `name` (String) Name of CustomConfig (Required)
+- `override` (Boolean) Override existing custom config from App Bundle Manifest (Optional. Default: False)
+- `template` (String) base64 encrypted template string. (Optional)
+- `variable_groups` (Block List) List of Variable groups. (Required) (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups))
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.manifest_json.configuration.custom_config.variable_groups`
+
+Optional:
+
+- `condition` (Block List) Condition to apply the variable group. (Optional. Default: None) (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--condition))
+- `name` (String) Name of the Variable Group(Required)
+- `required` (Boolean) Indicates if the variable group is required to be specified for the App Instance. (Optional. Default:False)
+- `variables` (Block List) List of variables(Required) (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables))
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--condition"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.manifest_json.configuration.custom_config.variable_groups.condition`
+
+Optional:
+
+- `name` (String)
+- `operator` (String)
+- `value` (String)
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.manifest_json.configuration.custom_config.variable_groups.variables`
+
+Required:
+
+- `format` (String) Format of the user variable. (Required)
+- `label` (String) Label for the variable (Required)
+- `name` (String) Name of the Variable (Required)
+- `required` (Boolean) This variable MUST be specified when creating an App Instance. (Optional. Default: False)
+
+Optional:
+
+- `default` (String) Default value of the variable. (Optional. Default: <Default value based on type>)
+- `encode` (String) Encoding of file content. Applicable if format is VARIABLE_FORMAT_FILE
+- `max_length` (String) Max length of the value of the variable(Optional. Default: 1024)
+- `options` (Block List) Key-Value pair of options. Applicable if format is VARIABLE_FORMAT_DROPDOWN (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables--options))
+- `process_input` (String)
+- `type` (String)
+- `value` (String) User-specified value of the variable.(Required if required is true. Optional otherwise)
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables--options"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.manifest_json.configuration.custom_config.variable_groups.variables.options`
+
+Optional:
+
+- `label` (String) Display label of the key in User-Agent
+- `value` (String) Value of the key to be used
+
+
+
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--container_detail"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.manifest_json.container_detail`
+
+Optional:
+
+- `container_create_option` (String) Create options direct the creation of the Docker container
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--desc"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.manifest_json.desc`
+
+Required:
+
+- `app_category` (String)
+
+Optional:
+
+- `agreement_list` (Map of String) UI map: AppEditPage:DeveloperPane:Developer_Agreement_Field, AppDetailsPage:DeveloperPane:Developer_Agreement_Field
+- `category` (String) UI map: AppMarketplacePage:AppCard:DescriptionField, AppEditPage:IdentityPane:CategoryField, AppDetailsPage:IdentityPane:CategoryField
+- `license_list` (Map of String) UI map: AppMarketplacePage:AppCard:License, AppEditPage:IdentityPane:License, AppDetailsPage:IdentityPane:License
+- `logo` (Map of String) UI map: AppEditPage:IdentityPane:Logo, AppDetailsPage:IdentityPane:Logo
+- `os` (String)
+- `screenshot_list` (Map of String) UI map: AppEditPage:IdentityPane:Screenshot_Fields, AppDetailsPage:IdentityPane:Screenshot_Fields
+- `support` (String) UI map: AppEditPage:DeveloperPane:Support_Description_Field, AppDetailsPage:DeveloperPane:Support_Description_Field
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--images"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.manifest_json.images`
+
+Optional:
+
+- `cleartext` (Boolean) UI map: AppEditPage:DrivesPane:Cleartext, AppDetailsPage:DrivesPane:ClearText_Field
+- `drvtype` (String) UI map: AppEditPage:DrivesPane:Drive_Type_Field, AppDetailsPage:DrivesPane:Drive_Type_Field
+- `ignorepurge` (Boolean) UI map: AppEditPage:DrivesPane:Ignorepurge, AppDetailsPage:DrivesPane:Ignorepurgee_Field
+- `imageformat` (String) UI map: AppEditPage:DrivesPane:Image_Format_Field, AppDetailsPage:DrivesPane:Image_Format_Field
+- `imageid` (String) UI map: AppEditPage:DrivesPane:Image_ID_Field, AppDetailsPage:DrivesPane:Image_ID_Field
+- `imagename` (String) UI map: AppEditPage:DrivesPane:Image_Name_Field, AppDetailsPage:DrivesPane:Image_Name_Field
+- `maxsize` (String) UI map: AppEditPage:DrivesPane:Max_Size_Field, AppDetailsPage:DrivesPane:Max_Size_Field
+- `mountpath` (String) UI map: AppEditPage:DrivesPane:Mountpath, AppDetailsPage:DrivesPane:Mountpath_Field
+- `params` (Block List) (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--images--params))
+- `preserve` (Boolean) UI map: AppEditPage:DrivesPane:Preserve_Field, AppDetailsPage:DrivesPane:Preserve_Field
+- `readonly` (Boolean)
+- `target` (String) UI map: AppEditPage:DrivesPane:Target_Field, AppDetailsPage:DrivesPane:Target_Field
+- `volumelabel` (String) UI map: AppEditPage:DrivesPane:Volume_Label, AppDetailsPage:DrivesPane:Volume_Label
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--images--params"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.manifest_json.images.params`
+
+Optional:
+
+- `name` (String) Name of the Parameter (Required)
+- `value` (String) Value of the parameter (Required)
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--interfaces"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.manifest_json.interfaces`
+
+Optional:
+
+- `acls` (Block List) Traffic access control rules for this interface. Applicable only when "direct attach" flag is false. (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--interfaces--acls))
+- `directattach` (Boolean) If true, a physical adapter is assigned to the edge application directly. If false, a network instance is assigned to the edge application.
+- `name` (String) Interface name used by the edge application
+- `optional` (Boolean) Indicates if the interface is optional for edge application.
+- `privateip` (Boolean) If true, DHCP network can't be assigned and user needs to provide a static IP address.
+- `type` (String) Physical Adapter type for this interface. Applicable only when "direct attach" flag is true.
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--interfaces--acls"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.manifest_json.interfaces.acls`
+
+Optional:
+
+- `actions` (Block List) Chain of actions to be taken on matching network traffic (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--interfaces--acls--actions))
+- `matches` (Block List) Network traffic matching criteria consistngs of one or more of source IP address, destination IP address, protocol, source port and destination port (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--interfaces--acls--matches))
+- `name` (String) Name of the Access Control List
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--interfaces--acls--actions"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.manifest_json.interfaces.acls.actions`
+
+Optional:
+
+- `drop` (Boolean) Drop the packet
+- `limit` (Boolean) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+- `limit_value` (Block List) Value to be used for limit action (Required if limit is true) (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--interfaces--acls--actions--limit_value))
+- `limitburst` (Number) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+- `limitrate` (Number) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+- `limitunit` (String) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+- `portmap` (Boolean) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+- `portmapto` (Block List) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--interfaces--acls--actions--portmapto))
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--interfaces--acls--actions--limit_value"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.manifest_json.interfaces.acls.actions.limit_value`
+
+Optional:
+
+- `limitburst` (Number) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+- `limitrate` (Number) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+- `limitunit` (String) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--interfaces--acls--actions--portmapto"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.manifest_json.interfaces.acls.actions.portmapto`
+
+Optional:
+
+- `app_port` (Number) Application Port value
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--interfaces--acls--matches"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.manifest_json.interfaces.acls.matches`
+
+Optional:
+
+- `type` (String) Type of Match (Required)
+- `value` (String) Value of match (Required)
+
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--module"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.manifest_json.module`
+
+Optional:
+
+- `environment` (Map of String) Extra information to module to make configuration easier
+- `module_type` (String) Type of modules
+- `routes` (Map of String) Send messages between modules or send messages from modules to iot hub
+- `twin_detail` (String) Base64 encoded module twin details, desired properties of the module will be updated to reflect these values
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--owner"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.manifest_json.owner`
+
+Optional:
+
+- `company` (String) UI map: AppEditPage:IdentityPane:Category_Field, AppDetailsPage:IdentityPane:Category_Field
+- `email` (String) UI map: AppEditPage:DeveloperPane:Email_Field, AppDetailsPage:DeveloperPane:Email_Field
+- `group` (String)
+- `user` (String) UI map: AppEditPage:DeveloperPane:Name_Field, AppDetailsPage:DeveloperPane:Name_Field
+- `website` (String) UI map: AppEditPage:DeveloperPane:Website_Field, AppDetailsPage:DeveloperPane:Website_Field
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--permissions"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.manifest_json.permissions`
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--manifest_json--resources"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.manifest_json.resources`
+
+Optional:
+
+- `name` (String) Name of the Resource (Required)
+- `value` (String) Value of Resource (Required)
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--interfaces"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.interfaces`
+
+Required:
+
+- `intfname` (String) intf Name
+- `netinstname` (String) Network Instance name to be matched for interface assignment. Applicable only when "direct attach" flag is false
+- `privateip` (Boolean) Private IP flag
+
+Optional:
+
+- `access_vlan_id` (Number) access port VLAN ID, vlan id of zero will be treated as trunk port and vlan id 1 is implicitly used by linux bridges
+- `acls` (Block List) app Acls (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--interfaces--acls))
+- `default_net_instance` (Boolean) default instance flag
+- `directattach` (Boolean) direct attach flag
+- `eidregister` (Block List) EID register details (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--interfaces--eidregister))
+- `intforder` (Number) intforder
+- `io` (Block List) Physical Adapter to be matched for interface assignment. Applicable only when "direct attach" flag is true (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--interfaces--io))
+- `ipaddr` (String) IP address
+- `macaddr` (String) MAC address
+- `netinsttag` (Map of String) Network Instance tag to be matched for interface assignment. Applicable only when "direct attach" flag is false
+- `netname` (String) network name: will be deprecated in future, use netinstname
+
+Read-Only:
+
+- `netinstid` (String) Network Instance id to be matched for interface assignment.
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--interfaces--acls"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.interfaces.acls`
+
+Optional:
+
+- `actions` (Block List) app ACE actions (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--interfaces--acls--actions))
+- `matches` (Block List) app ACE match (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--interfaces--acls--matches))
+- `name` (String) User defined name of the app ACE, unique across the enterprise. Once object is created, name can’t be changed
+
+Read-Only:
+
+- `id` (Number) app ACE id
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--interfaces--acls--actions"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.interfaces.acls.actions`
+
+Optional:
+
+- `drop` (Boolean) ACE drop flag
+- `limit` (Boolean) ACE limit flag
+- `limitburst` (Number) ACE limit burst
+- `limitrate` (Number) ACE limit rate
+- `limitunit` (String) ACE limit unit
+- `mapparams` (Block List) Application map params (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--interfaces--acls--actions--mapparams))
+- `portmap` (Boolean) application port map flag
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--interfaces--acls--actions--mapparams"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.interfaces.acls.actions.mapparams`
+
+Optional:
+
+- `port` (Number) Application port
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--interfaces--acls--matches"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.interfaces.acls.matches`
+
+Optional:
+
+- `type` (String) Type
+- `value` (String) Value
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--interfaces--eidregister"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.interfaces.eidregister`
+
+Required:
+
+- `display_name` (String) Display name
+- `e_id` (String) EID
+- `e_id_hash_len` (Number) EID hash length
+- `lisp_instance` (Number) Lisp Instance
+- `lisp_map_servers` (Block List, Min: 1) Lisp Map Server (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--apps--interfaces--eidregister--lisp_map_servers))
+- `lisp_signature` (String) Lisp Signature
+- `uuid` (String) UUID
+
+Read-Only:
+
+- `app_cert` (String) app certificate
+- `app_private_key` (String) App private key
+- `app_public_key` (String) App public key
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--interfaces--eidregister--lisp_map_servers"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.interfaces.eidregister.lisp_map_servers`
+
+Required:
+
+- `credential` (String, Sensitive) lisp credential
+- `name_or_ip` (String) name/IP
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--interfaces--io"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.interfaces.io`
+
+Optional:
+
+- `name` (String) Physical Adapter name
+- `tags` (Map of String) Tags are name/value pairs that enable you to categorize resources. Tag names are case insensitive with max_length 512 and min_length 3. Tag values are case sensitive with max_length 256 and min_length 3.
+- `type` (String) IoType specifies the type of the Input output of the device
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--apps--parent_detail"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.apps.parent_detail`
+
+Optional:
+
+- `reference_exists` (Boolean) Relation with child and parent object exists or not
+- `update_available` (Boolean) Update required flag
+
+Read-Only:
+
+- `id_of_parent_object` (String) system defined unique id of parent object
+- `version_of_parent_object` (Number) version of object present in parent
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent`
+
+Required:
+
+- `cpus` (Number) user defined cpus for bundle
+- `manifest_json` (Block List, Min: 1) Manifest data (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json))
+- `memory` (Number) user defined memory for bundle
+- `name` (String) User defined name of the edge application, unique across the enterprise. Once object is created, name can’t be changed
+- `networks` (Number) user defined network options
+- `origin_type` (String) origin of object
+- `title` (String) User defined title of the edge application. Title can be changed at any time
+
+Optional:
+
+- `app_id` (String) User defined name of the edge app, unique across the enterprise. Once app name is created, name can’t be changed
+- `app_version` (String) Current version of the attached bundle
+- `description` (String) Detailed description of the edge application
+- `interfaces` (Block List) application interfaces (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--interfaces))
+- `name_app_part` (String) User provided name part  for the auto deployed app
+- `name_project_part` (String) User provided name part  for the auto deployed app
+- `naming_scheme` (String) app naming scheme
+- `parent_detail` (Block List) origin and parent related details (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--parent_detail))
+- `start_delay_in_seconds` (Number) start delay is the time in seconds EVE should wait after boot before starting the application instance
+- `storage` (Number) user defined storage for bundle
+- `tags` (Map of String) Tags are name/value pairs that enable you to categorize resources. Tag names are case insensitive with max_length 512 and min_length 3. Tag values are case sensitive with max_length 256 and min_length 3.
+
+Read-Only:
+
+- `drives` (Number) user defined drives
+- `id` (String) System defined universally unique Id of the edge application
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.manifest_json`
+
+Required:
+
+- `ac_kind` (String) UI map: N/A - not exposed to users
+- `ac_version` (String) UI map: N/A - not exposed to users
+- `name` (String) UI map: AppEditPage:IdentityPane:Name_Field, AppDetailsPage:IdentityPane:Name_Field
+
+Optional:
+
+- `app_type` (String) bundle type, eg: vm, container, module
+- `configuration` (Block List) Template for Custom Configuration. Used for Cloud-Init (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--configuration))
+- `container_detail` (Block List) Create options direct the creation of the Docker container (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--container_detail))
+- `cpu_pinning_enabled` (Boolean) Enable CpuPinning
+- `deployment_type` (String) type of deployment for the app, eg: azure, k3s, standalone
+- `desc` (Block List) Description of the application (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--desc))
+- `description` (String) UI map: AppDetailsPage:IdentityPane:DescriptionField, AppMarketplacePage:AppCard:DescriptionField
+- `display_name` (String) UI map: AppEditPage:IdentityPane:Title_Field, AppDetailsPage:IdentityPane:Title_Field
+- `enablevnc` (Boolean) UI map: AppEditPage:IdentityPane:VNC_Field, AppDetailsPage:IdentityPane:VNC_Field
+- `images` (Block List) UI map: AppEditPage:DrivesPane, AppDetailsPage:DrivesPane (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--images))
+- `interfaces` (Block List) UI map: AppEditPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--interfaces))
+- `module` (Block List) Azure module specific details like module twin, environment variable, routes (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--module))
+- `owner` (Block List) Owner of the application (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--owner))
+- `permissions` (Block List) (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--permissions))
+- `resources` (Block List) UI map: AppEditPage:ResourcesPane, AppDetailsPage:ResourcesPane (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--resources))
+- `vmmode` (String) UI map: AppEditPage:IdentityPane:VM_Mode_Field, AppDetailsPage:IdentityPane:VM_Mode_Field
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--configuration"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.manifest_json.configuration`
+
+Optional:
+
+- `custom_config` (Block List) (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config))
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.manifest_json.configuration.custom_config`
+
+Optional:
+
+- `add` (Boolean) Add the Custom Config to App Instance (Optional. Default: False)
+- `allow_storage_resize` (Boolean) Allow Appinstance storage to be resized after app instance is created. (Optional. Default: False)
+- `field_delimiter` (String) Field delimiter used in specifying variables in template. (Required)
+- `name` (String) Name of CustomConfig (Required)
+- `override` (Boolean) Override existing custom config from App Bundle Manifest (Optional. Default: False)
+- `template` (String) base64 encrypted template string. (Optional)
+- `variable_groups` (Block List) List of Variable groups. (Required) (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups))
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.manifest_json.configuration.custom_config.variable_groups`
+
+Optional:
+
+- `condition` (Block List) Condition to apply the variable group. (Optional. Default: None) (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--condition))
+- `name` (String) Name of the Variable Group(Required)
+- `required` (Boolean) Indicates if the variable group is required to be specified for the App Instance. (Optional. Default:False)
+- `variables` (Block List) List of variables(Required) (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--variables))
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--condition"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.manifest_json.configuration.custom_config.variable_groups.condition`
+
+Optional:
+
+- `name` (String)
+- `operator` (String)
+- `value` (String)
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--variables"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.manifest_json.configuration.custom_config.variable_groups.variables`
+
+Required:
+
+- `format` (String) Format of the user variable. (Required)
+- `label` (String) Label for the variable (Required)
+- `name` (String) Name of the Variable (Required)
+- `required` (Boolean) This variable MUST be specified when creating an App Instance. (Optional. Default: False)
+
+Optional:
+
+- `default` (String) Default value of the variable. (Optional. Default: <Default value based on type>)
+- `encode` (String) Encoding of file content. Applicable if format is VARIABLE_FORMAT_FILE
+- `max_length` (String) Max length of the value of the variable(Optional. Default: 1024)
+- `options` (Block List) Key-Value pair of options. Applicable if format is VARIABLE_FORMAT_DROPDOWN (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--variables--options))
+- `process_input` (String)
+- `type` (String)
+- `value` (String) User-specified value of the variable.(Required if required is true. Optional otherwise)
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--variables--options"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.manifest_json.configuration.custom_config.variable_groups.variables.options`
+
+Optional:
+
+- `label` (String) Display label of the key in User-Agent
+- `value` (String) Value of the key to be used
+
+
+
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--container_detail"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.manifest_json.container_detail`
+
+Optional:
+
+- `container_create_option` (String) Create options direct the creation of the Docker container
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--desc"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.manifest_json.desc`
+
+Required:
+
+- `app_category` (String)
+
+Optional:
+
+- `agreement_list` (Map of String) UI map: AppEditPage:DeveloperPane:Developer_Agreement_Field, AppDetailsPage:DeveloperPane:Developer_Agreement_Field
+- `category` (String) UI map: AppMarketplacePage:AppCard:DescriptionField, AppEditPage:IdentityPane:CategoryField, AppDetailsPage:IdentityPane:CategoryField
+- `license_list` (Map of String) UI map: AppMarketplacePage:AppCard:License, AppEditPage:IdentityPane:License, AppDetailsPage:IdentityPane:License
+- `logo` (Map of String) UI map: AppEditPage:IdentityPane:Logo, AppDetailsPage:IdentityPane:Logo
+- `os` (String)
+- `screenshot_list` (Map of String) UI map: AppEditPage:IdentityPane:Screenshot_Fields, AppDetailsPage:IdentityPane:Screenshot_Fields
+- `support` (String) UI map: AppEditPage:DeveloperPane:Support_Description_Field, AppDetailsPage:DeveloperPane:Support_Description_Field
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--images"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.manifest_json.images`
+
+Optional:
+
+- `cleartext` (Boolean) UI map: AppEditPage:DrivesPane:Cleartext, AppDetailsPage:DrivesPane:ClearText_Field
+- `drvtype` (String) UI map: AppEditPage:DrivesPane:Drive_Type_Field, AppDetailsPage:DrivesPane:Drive_Type_Field
+- `ignorepurge` (Boolean) UI map: AppEditPage:DrivesPane:Ignorepurge, AppDetailsPage:DrivesPane:Ignorepurgee_Field
+- `imageformat` (String) UI map: AppEditPage:DrivesPane:Image_Format_Field, AppDetailsPage:DrivesPane:Image_Format_Field
+- `imageid` (String) UI map: AppEditPage:DrivesPane:Image_ID_Field, AppDetailsPage:DrivesPane:Image_ID_Field
+- `imagename` (String) UI map: AppEditPage:DrivesPane:Image_Name_Field, AppDetailsPage:DrivesPane:Image_Name_Field
+- `maxsize` (String) UI map: AppEditPage:DrivesPane:Max_Size_Field, AppDetailsPage:DrivesPane:Max_Size_Field
+- `mountpath` (String) UI map: AppEditPage:DrivesPane:Mountpath, AppDetailsPage:DrivesPane:Mountpath_Field
+- `params` (Block List) (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--images--params))
+- `preserve` (Boolean) UI map: AppEditPage:DrivesPane:Preserve_Field, AppDetailsPage:DrivesPane:Preserve_Field
+- `readonly` (Boolean)
+- `target` (String) UI map: AppEditPage:DrivesPane:Target_Field, AppDetailsPage:DrivesPane:Target_Field
+- `volumelabel` (String) UI map: AppEditPage:DrivesPane:Volume_Label, AppDetailsPage:DrivesPane:Volume_Label
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--images--params"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.manifest_json.images.params`
+
+Optional:
+
+- `name` (String) Name of the Parameter (Required)
+- `value` (String) Value of the parameter (Required)
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--interfaces"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.manifest_json.interfaces`
+
+Optional:
+
+- `acls` (Block List) Traffic access control rules for this interface. Applicable only when "direct attach" flag is false. (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls))
+- `directattach` (Boolean) If true, a physical adapter is assigned to the edge application directly. If false, a network instance is assigned to the edge application.
+- `name` (String) Interface name used by the edge application
+- `optional` (Boolean) Indicates if the interface is optional for edge application.
+- `privateip` (Boolean) If true, DHCP network can't be assigned and user needs to provide a static IP address.
+- `type` (String) Physical Adapter type for this interface. Applicable only when "direct attach" flag is true.
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.manifest_json.interfaces.acls`
+
+Optional:
+
+- `actions` (Block List) Chain of actions to be taken on matching network traffic (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions))
+- `matches` (Block List) Network traffic matching criteria consistngs of one or more of source IP address, destination IP address, protocol, source port and destination port (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--matches))
+- `name` (String) Name of the Access Control List
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.manifest_json.interfaces.acls.actions`
+
+Optional:
+
+- `drop` (Boolean) Drop the packet
+- `limit` (Boolean) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+- `limit_value` (Block List) Value to be used for limit action (Required if limit is true) (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions--limit_value))
+- `limitburst` (Number) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+- `limitrate` (Number) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+- `limitunit` (String) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+- `portmap` (Boolean) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+- `portmapto` (Block List) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions--portmapto))
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions--limit_value"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.manifest_json.interfaces.acls.actions.limit_value`
+
+Optional:
+
+- `limitburst` (Number) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+- `limitrate` (Number) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+- `limitunit` (String) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions--portmapto"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.manifest_json.interfaces.acls.actions.portmapto`
+
+Optional:
+
+- `app_port` (Number) Application Port value
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--matches"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.manifest_json.interfaces.acls.matches`
+
+Optional:
+
+- `type` (String) Type of Match (Required)
+- `value` (String) Value of match (Required)
+
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--module"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.manifest_json.module`
+
+Optional:
+
+- `environment` (Map of String) Extra information to module to make configuration easier
+- `module_type` (String) Type of modules
+- `routes` (Map of String) Send messages between modules or send messages from modules to iot hub
+- `twin_detail` (String) Base64 encoded module twin details, desired properties of the module will be updated to reflect these values
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--owner"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.manifest_json.owner`
+
+Optional:
+
+- `company` (String) UI map: AppEditPage:IdentityPane:Category_Field, AppDetailsPage:IdentityPane:Category_Field
+- `email` (String) UI map: AppEditPage:DeveloperPane:Email_Field, AppDetailsPage:DeveloperPane:Email_Field
+- `group` (String)
+- `user` (String) UI map: AppEditPage:DeveloperPane:Name_Field, AppDetailsPage:DeveloperPane:Name_Field
+- `website` (String) UI map: AppEditPage:DeveloperPane:Website_Field, AppDetailsPage:DeveloperPane:Website_Field
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--permissions"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.manifest_json.permissions`
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--manifest_json--resources"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.manifest_json.resources`
+
+Optional:
+
+- `name` (String) Name of the Resource (Required)
+- `value` (String) Value of Resource (Required)
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--interfaces"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.interfaces`
+
+Required:
+
+- `intfname` (String) intf Name
+- `netinstname` (String) Network Instance name to be matched for interface assignment. Applicable only when "direct attach" flag is false
+- `privateip` (Boolean) Private IP flag
+
+Optional:
+
+- `access_vlan_id` (Number) access port VLAN ID, vlan id of zero will be treated as trunk port and vlan id 1 is implicitly used by linux bridges
+- `acls` (Block List) app Acls (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--interfaces--acls))
+- `default_net_instance` (Boolean) default instance flag
+- `directattach` (Boolean) direct attach flag
+- `eidregister` (Block List) EID register details (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--interfaces--eidregister))
+- `intforder` (Number) intforder
+- `io` (Block List) Physical Adapter to be matched for interface assignment. Applicable only when "direct attach" flag is true (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--interfaces--io))
+- `ipaddr` (String) IP address
+- `macaddr` (String) MAC address
+- `netinsttag` (Map of String) Network Instance tag to be matched for interface assignment. Applicable only when "direct attach" flag is false
+- `netname` (String) network name: will be deprecated in future, use netinstname
+
+Read-Only:
+
+- `netinstid` (String) Network Instance id to be matched for interface assignment.
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--interfaces--acls"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.interfaces.acls`
+
+Optional:
+
+- `actions` (Block List) app ACE actions (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--interfaces--acls--actions))
+- `matches` (Block List) app ACE match (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--interfaces--acls--matches))
+- `name` (String) User defined name of the app ACE, unique across the enterprise. Once object is created, name can’t be changed
+
+Read-Only:
+
+- `id` (Number) app ACE id
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--interfaces--acls--actions"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.interfaces.acls.actions`
+
+Optional:
+
+- `drop` (Boolean) ACE drop flag
+- `limit` (Boolean) ACE limit flag
+- `limitburst` (Number) ACE limit burst
+- `limitrate` (Number) ACE limit rate
+- `limitunit` (String) ACE limit unit
+- `mapparams` (Block List) Application map params (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--interfaces--acls--actions--mapparams))
+- `portmap` (Boolean) application port map flag
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--interfaces--acls--actions--mapparams"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.interfaces.acls.actions.mapparams`
+
+Optional:
+
+- `port` (Number) Application port
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--interfaces--acls--matches"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.interfaces.acls.matches`
+
+Optional:
+
+- `type` (String) Type
+- `value` (String) Value
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--interfaces--eidregister"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.interfaces.eidregister`
+
+Required:
+
+- `display_name` (String) Display name
+- `e_id` (String) EID
+- `e_id_hash_len` (Number) EID hash length
+- `lisp_instance` (Number) Lisp Instance
+- `lisp_map_servers` (Block List, Min: 1) Lisp Map Server (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--interfaces--eidregister--lisp_map_servers))
+- `lisp_signature` (String) Lisp Signature
+- `uuid` (String) UUID
+
+Read-Only:
+
+- `app_cert` (String) app certificate
+- `app_private_key` (String) App private key
+- `app_public_key` (String) App public key
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--interfaces--eidregister--lisp_map_servers"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.interfaces.eidregister.lisp_map_servers`
+
+Required:
+
+- `credential` (String, Sensitive) lisp credential
+- `name_or_ip` (String) name/IP
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--interfaces--io"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.interfaces.io`
+
+Optional:
+
+- `name` (String) Physical Adapter name
+- `tags` (Map of String) Tags are name/value pairs that enable you to categorize resources. Tag names are case insensitive with max_length 512 and min_length 3. Tag values are case sensitive with max_length 256 and min_length 3.
+- `type` (String) IoType specifies the type of the Input output of the device
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_agent--parent_detail"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_agent.parent_detail`
+
+Optional:
+
+- `reference_exists` (Boolean) Relation with child and parent object exists or not
+- `update_available` (Boolean) Update required flag
+
+Read-Only:
+
+- `id_of_parent_object` (String) system defined unique id of parent object
+- `version_of_parent_object` (Number) version of object present in parent
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub`
+
+Required:
+
+- `cpus` (Number) user defined cpus for bundle
+- `manifest_json` (Block List, Min: 1) Manifest data (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json))
+- `memory` (Number) user defined memory for bundle
+- `name` (String) User defined name of the edge application, unique across the enterprise. Once object is created, name can’t be changed
+- `networks` (Number) user defined network options
+- `origin_type` (String) origin of object
+- `title` (String) User defined title of the edge application. Title can be changed at any time
+
+Optional:
+
+- `app_id` (String) User defined name of the edge app, unique across the enterprise. Once app name is created, name can’t be changed
+- `app_version` (String) Current version of the attached bundle
+- `description` (String) Detailed description of the edge application
+- `interfaces` (Block List) application interfaces (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--interfaces))
+- `name_app_part` (String) User provided name part  for the auto deployed app
+- `name_project_part` (String) User provided name part  for the auto deployed app
+- `naming_scheme` (String) app naming scheme
+- `parent_detail` (Block List) origin and parent related details (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--parent_detail))
+- `start_delay_in_seconds` (Number) start delay is the time in seconds EVE should wait after boot before starting the application instance
+- `storage` (Number) user defined storage for bundle
+- `tags` (Map of String) Tags are name/value pairs that enable you to categorize resources. Tag names are case insensitive with max_length 512 and min_length 3. Tag values are case sensitive with max_length 256 and min_length 3.
+
+Read-Only:
+
+- `drives` (Number) user defined drives
+- `id` (String) System defined universally unique Id of the edge application
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.manifest_json`
+
+Required:
+
+- `ac_kind` (String) UI map: N/A - not exposed to users
+- `ac_version` (String) UI map: N/A - not exposed to users
+- `name` (String) UI map: AppEditPage:IdentityPane:Name_Field, AppDetailsPage:IdentityPane:Name_Field
+
+Optional:
+
+- `app_type` (String) bundle type, eg: vm, container, module
+- `configuration` (Block List) Template for Custom Configuration. Used for Cloud-Init (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--configuration))
+- `container_detail` (Block List) Create options direct the creation of the Docker container (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--container_detail))
+- `cpu_pinning_enabled` (Boolean) Enable CpuPinning
+- `deployment_type` (String) type of deployment for the app, eg: azure, k3s, standalone
+- `desc` (Block List) Description of the application (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--desc))
+- `description` (String) UI map: AppDetailsPage:IdentityPane:DescriptionField, AppMarketplacePage:AppCard:DescriptionField
+- `display_name` (String) UI map: AppEditPage:IdentityPane:Title_Field, AppDetailsPage:IdentityPane:Title_Field
+- `enablevnc` (Boolean) UI map: AppEditPage:IdentityPane:VNC_Field, AppDetailsPage:IdentityPane:VNC_Field
+- `images` (Block List) UI map: AppEditPage:DrivesPane, AppDetailsPage:DrivesPane (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--images))
+- `interfaces` (Block List) UI map: AppEditPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--interfaces))
+- `module` (Block List) Azure module specific details like module twin, environment variable, routes (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--module))
+- `owner` (Block List) Owner of the application (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--owner))
+- `permissions` (Block List) (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--permissions))
+- `resources` (Block List) UI map: AppEditPage:ResourcesPane, AppDetailsPage:ResourcesPane (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--resources))
+- `vmmode` (String) UI map: AppEditPage:IdentityPane:VM_Mode_Field, AppDetailsPage:IdentityPane:VM_Mode_Field
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--configuration"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.manifest_json.configuration`
+
+Optional:
+
+- `custom_config` (Block List) (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config))
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.manifest_json.configuration.custom_config`
+
+Optional:
+
+- `add` (Boolean) Add the Custom Config to App Instance (Optional. Default: False)
+- `allow_storage_resize` (Boolean) Allow Appinstance storage to be resized after app instance is created. (Optional. Default: False)
+- `field_delimiter` (String) Field delimiter used in specifying variables in template. (Required)
+- `name` (String) Name of CustomConfig (Required)
+- `override` (Boolean) Override existing custom config from App Bundle Manifest (Optional. Default: False)
+- `template` (String) base64 encrypted template string. (Optional)
+- `variable_groups` (Block List) List of Variable groups. (Required) (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups))
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.manifest_json.configuration.custom_config.variable_groups`
+
+Optional:
+
+- `condition` (Block List) Condition to apply the variable group. (Optional. Default: None) (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--condition))
+- `name` (String) Name of the Variable Group(Required)
+- `required` (Boolean) Indicates if the variable group is required to be specified for the App Instance. (Optional. Default:False)
+- `variables` (Block List) List of variables(Required) (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--variables))
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--condition"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.manifest_json.configuration.custom_config.variable_groups.condition`
+
+Optional:
+
+- `name` (String)
+- `operator` (String)
+- `value` (String)
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--variables"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.manifest_json.configuration.custom_config.variable_groups.variables`
+
+Required:
+
+- `format` (String) Format of the user variable. (Required)
+- `label` (String) Label for the variable (Required)
+- `name` (String) Name of the Variable (Required)
+- `required` (Boolean) This variable MUST be specified when creating an App Instance. (Optional. Default: False)
+
+Optional:
+
+- `default` (String) Default value of the variable. (Optional. Default: <Default value based on type>)
+- `encode` (String) Encoding of file content. Applicable if format is VARIABLE_FORMAT_FILE
+- `max_length` (String) Max length of the value of the variable(Optional. Default: 1024)
+- `options` (Block List) Key-Value pair of options. Applicable if format is VARIABLE_FORMAT_DROPDOWN (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--variables--options))
+- `process_input` (String)
+- `type` (String)
+- `value` (String) User-specified value of the variable.(Required if required is true. Optional otherwise)
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--variables--options"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.manifest_json.configuration.custom_config.variable_groups.variables.options`
+
+Optional:
+
+- `label` (String) Display label of the key in User-Agent
+- `value` (String) Value of the key to be used
+
+
+
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--container_detail"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.manifest_json.container_detail`
+
+Optional:
+
+- `container_create_option` (String) Create options direct the creation of the Docker container
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--desc"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.manifest_json.desc`
+
+Required:
+
+- `app_category` (String)
+
+Optional:
+
+- `agreement_list` (Map of String) UI map: AppEditPage:DeveloperPane:Developer_Agreement_Field, AppDetailsPage:DeveloperPane:Developer_Agreement_Field
+- `category` (String) UI map: AppMarketplacePage:AppCard:DescriptionField, AppEditPage:IdentityPane:CategoryField, AppDetailsPage:IdentityPane:CategoryField
+- `license_list` (Map of String) UI map: AppMarketplacePage:AppCard:License, AppEditPage:IdentityPane:License, AppDetailsPage:IdentityPane:License
+- `logo` (Map of String) UI map: AppEditPage:IdentityPane:Logo, AppDetailsPage:IdentityPane:Logo
+- `os` (String)
+- `screenshot_list` (Map of String) UI map: AppEditPage:IdentityPane:Screenshot_Fields, AppDetailsPage:IdentityPane:Screenshot_Fields
+- `support` (String) UI map: AppEditPage:DeveloperPane:Support_Description_Field, AppDetailsPage:DeveloperPane:Support_Description_Field
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--images"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.manifest_json.images`
+
+Optional:
+
+- `cleartext` (Boolean) UI map: AppEditPage:DrivesPane:Cleartext, AppDetailsPage:DrivesPane:ClearText_Field
+- `drvtype` (String) UI map: AppEditPage:DrivesPane:Drive_Type_Field, AppDetailsPage:DrivesPane:Drive_Type_Field
+- `ignorepurge` (Boolean) UI map: AppEditPage:DrivesPane:Ignorepurge, AppDetailsPage:DrivesPane:Ignorepurgee_Field
+- `imageformat` (String) UI map: AppEditPage:DrivesPane:Image_Format_Field, AppDetailsPage:DrivesPane:Image_Format_Field
+- `imageid` (String) UI map: AppEditPage:DrivesPane:Image_ID_Field, AppDetailsPage:DrivesPane:Image_ID_Field
+- `imagename` (String) UI map: AppEditPage:DrivesPane:Image_Name_Field, AppDetailsPage:DrivesPane:Image_Name_Field
+- `maxsize` (String) UI map: AppEditPage:DrivesPane:Max_Size_Field, AppDetailsPage:DrivesPane:Max_Size_Field
+- `mountpath` (String) UI map: AppEditPage:DrivesPane:Mountpath, AppDetailsPage:DrivesPane:Mountpath_Field
+- `params` (Block List) (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--images--params))
+- `preserve` (Boolean) UI map: AppEditPage:DrivesPane:Preserve_Field, AppDetailsPage:DrivesPane:Preserve_Field
+- `readonly` (Boolean)
+- `target` (String) UI map: AppEditPage:DrivesPane:Target_Field, AppDetailsPage:DrivesPane:Target_Field
+- `volumelabel` (String) UI map: AppEditPage:DrivesPane:Volume_Label, AppDetailsPage:DrivesPane:Volume_Label
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--images--params"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.manifest_json.images.params`
+
+Optional:
+
+- `name` (String) Name of the Parameter (Required)
+- `value` (String) Value of the parameter (Required)
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--interfaces"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.manifest_json.interfaces`
+
+Optional:
+
+- `acls` (Block List) Traffic access control rules for this interface. Applicable only when "direct attach" flag is false. (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls))
+- `directattach` (Boolean) If true, a physical adapter is assigned to the edge application directly. If false, a network instance is assigned to the edge application.
+- `name` (String) Interface name used by the edge application
+- `optional` (Boolean) Indicates if the interface is optional for edge application.
+- `privateip` (Boolean) If true, DHCP network can't be assigned and user needs to provide a static IP address.
+- `type` (String) Physical Adapter type for this interface. Applicable only when "direct attach" flag is true.
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.manifest_json.interfaces.acls`
+
+Optional:
+
+- `actions` (Block List) Chain of actions to be taken on matching network traffic (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions))
+- `matches` (Block List) Network traffic matching criteria consistngs of one or more of source IP address, destination IP address, protocol, source port and destination port (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--matches))
+- `name` (String) Name of the Access Control List
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.manifest_json.interfaces.acls.actions`
+
+Optional:
+
+- `drop` (Boolean) Drop the packet
+- `limit` (Boolean) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+- `limit_value` (Block List) Value to be used for limit action (Required if limit is true) (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions--limit_value))
+- `limitburst` (Number) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+- `limitrate` (Number) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+- `limitunit` (String) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+- `portmap` (Boolean) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+- `portmapto` (Block List) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions--portmapto))
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions--limit_value"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.manifest_json.interfaces.acls.actions.limit_value`
+
+Optional:
+
+- `limitburst` (Number) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+- `limitrate` (Number) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+- `limitunit` (String) UI map: AppDetailsPage:EnvironmentsPane, AppDetailsPage:EnvironmentsPane
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions--portmapto"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.manifest_json.interfaces.acls.actions.portmapto`
+
+Optional:
+
+- `app_port` (Number) Application Port value
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--matches"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.manifest_json.interfaces.acls.matches`
+
+Optional:
+
+- `type` (String) Type of Match (Required)
+- `value` (String) Value of match (Required)
+
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--module"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.manifest_json.module`
+
+Optional:
+
+- `environment` (Map of String) Extra information to module to make configuration easier
+- `module_type` (String) Type of modules
+- `routes` (Map of String) Send messages between modules or send messages from modules to iot hub
+- `twin_detail` (String) Base64 encoded module twin details, desired properties of the module will be updated to reflect these values
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--owner"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.manifest_json.owner`
+
+Optional:
+
+- `company` (String) UI map: AppEditPage:IdentityPane:Category_Field, AppDetailsPage:IdentityPane:Category_Field
+- `email` (String) UI map: AppEditPage:DeveloperPane:Email_Field, AppDetailsPage:DeveloperPane:Email_Field
+- `group` (String)
+- `user` (String) UI map: AppEditPage:DeveloperPane:Name_Field, AppDetailsPage:DeveloperPane:Name_Field
+- `website` (String) UI map: AppEditPage:DeveloperPane:Website_Field, AppDetailsPage:DeveloperPane:Website_Field
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--permissions"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.manifest_json.permissions`
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--manifest_json--resources"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.manifest_json.resources`
+
+Optional:
+
+- `name` (String) Name of the Resource (Required)
+- `value` (String) Value of Resource (Required)
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--interfaces"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.interfaces`
+
+Required:
+
+- `intfname` (String) intf Name
+- `netinstname` (String) Network Instance name to be matched for interface assignment. Applicable only when "direct attach" flag is false
+- `privateip` (Boolean) Private IP flag
+
+Optional:
+
+- `access_vlan_id` (Number) access port VLAN ID, vlan id of zero will be treated as trunk port and vlan id 1 is implicitly used by linux bridges
+- `acls` (Block List) app Acls (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--interfaces--acls))
+- `default_net_instance` (Boolean) default instance flag
+- `directattach` (Boolean) direct attach flag
+- `eidregister` (Block List) EID register details (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--interfaces--eidregister))
+- `intforder` (Number) intforder
+- `io` (Block List) Physical Adapter to be matched for interface assignment. Applicable only when "direct attach" flag is true (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--interfaces--io))
+- `ipaddr` (String) IP address
+- `macaddr` (String) MAC address
+- `netinsttag` (Map of String) Network Instance tag to be matched for interface assignment. Applicable only when "direct attach" flag is false
+- `netname` (String) network name: will be deprecated in future, use netinstname
+
+Read-Only:
+
+- `netinstid` (String) Network Instance id to be matched for interface assignment.
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--interfaces--acls"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.interfaces.acls`
+
+Optional:
+
+- `actions` (Block List) app ACE actions (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--interfaces--acls--actions))
+- `matches` (Block List) app ACE match (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--interfaces--acls--matches))
+- `name` (String) User defined name of the app ACE, unique across the enterprise. Once object is created, name can’t be changed
+
+Read-Only:
+
+- `id` (Number) app ACE id
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--interfaces--acls--actions"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.interfaces.acls.actions`
+
+Optional:
+
+- `drop` (Boolean) ACE drop flag
+- `limit` (Boolean) ACE limit flag
+- `limitburst` (Number) ACE limit burst
+- `limitrate` (Number) ACE limit rate
+- `limitunit` (String) ACE limit unit
+- `mapparams` (Block List) Application map params (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--interfaces--acls--actions--mapparams))
+- `portmap` (Boolean) application port map flag
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--interfaces--acls--actions--mapparams"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.interfaces.acls.actions.mapparams`
+
+Optional:
+
+- `port` (Number) Application port
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--interfaces--acls--matches"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.interfaces.acls.matches`
+
+Optional:
+
+- `type` (String) Type
+- `value` (String) Value
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--interfaces--eidregister"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.interfaces.eidregister`
+
+Required:
+
+- `display_name` (String) Display name
+- `e_id` (String) EID
+- `e_id_hash_len` (Number) EID hash length
+- `lisp_instance` (Number) Lisp Instance
+- `lisp_map_servers` (Block List, Min: 1) Lisp Map Server (see [below for nested schema](#nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--interfaces--eidregister--lisp_map_servers))
+- `lisp_signature` (String) Lisp Signature
+- `uuid` (String) UUID
+
+Read-Only:
+
+- `app_cert` (String) app certificate
+- `app_private_key` (String) App private key
+- `app_public_key` (String) App public key
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--interfaces--eidregister--lisp_map_servers"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.interfaces.eidregister.lisp_map_servers`
+
+Required:
+
+- `credential` (String, Sensitive) lisp credential
+- `name_or_ip` (String) name/IP
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--interfaces--io"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.interfaces.io`
+
+Optional:
+
+- `name` (String) Physical Adapter name
+- `tags` (Map of String) Tags are name/value pairs that enable you to categorize resources. Tag names are case insensitive with max_length 512 and min_length 3. Tag values are case sensitive with max_length 256 and min_length 3.
+- `type` (String) IoType specifies the type of the Input output of the device
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--azure_edge_hub--parent_detail"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.azure_edge_hub.parent_detail`
+
+Optional:
+
+- `reference_exists` (Boolean) Relation with child and parent object exists or not
+- `update_available` (Boolean) Update required flag
+
+Read-Only:
+
+- `id_of_parent_object` (String) system defined unique id of parent object
+- `version_of_parent_object` (Number) version of object present in parent
+
+
+
+<a id="nestedblock--configuration_lock_policy--module_policy--metrics"></a>
+### Nested Schema for `configuration_lock_policy.module_policy.metrics`
+
+Optional:
+
+- `queries` (Map of String) Mapping of queries variable keys and value
+- `results` (Map of String) Mapping of results variable keys and value
+
+
+
+<a id="nestedblock--configuration_lock_policy--network_policy"></a>
+### Nested Schema for `configuration_lock_policy.network_policy`
+
+Required:
+
+- `net_instance_config` (Block List, Min: 1) list of network details that will be created on all the devices of the project to which this policy is attached (see [below for nested schema](#nestedblock--configuration_lock_policy--network_policy--net_instance_config))
+
+<a id="nestedblock--configuration_lock_policy--network_policy--net_instance_config"></a>
+### Nested Schema for `configuration_lock_policy.network_policy.net_instance_config`
+
+Required:
+
+- `device_id` (String) ID of the device on which network instance is created
+- `kind` (String) Kind of Network Instance:
+NETWORK_INSTANCE_KIND_UNSPECIFIED
+NETWORK_INSTANCE_KIND_TRANSPARENT
+NETWORK_INSTANCE_KIND_SWITCH
+NETWORK_INSTANCE_KIND_LOCAL
+NETWORK_INSTANCE_KIND_CLOUD
+NETWORK_INSTANCE_KIND_MESH
+NETWORK_INSTANCE_KIND_HONEYPOT
+- `name` (String) User defined name of the network instance, unique across the enterprise. Once object is created, name can’t be changed
+- `title` (String) User defined title of the network instance. Title can be changed at any time
+
+Optional:
+
+- `cluster_id` (String) ID of the Cluster in which the network instance is configured
+- `description` (String) Detailed description of the network instance
+- `device_default` (Boolean) Flag to indicate if this is the default network instance for the device
+- `dhcp` (Boolean) Deprecated
+- `dns_list` (Block List) List of Static DNS entries (see [below for nested schema](#nestedblock--configuration_lock_policy--network_policy--net_instance_config--dns_list))
+- `ip` (Block List) DHCP Server Configuration (see [below for nested schema](#nestedblock--configuration_lock_policy--network_policy--net_instance_config--ip))
+- `mtu` (Number) Maximum transmission unit (MTU) to set for the network instance and all application interfaces connected to it
+- `network_policy_id` (String) id of the network policy to be attached to this network instance
+- `oconfig` (String)
+- `opaque` (Block List) Service specific Config (see [below for nested schema](#nestedblock--configuration_lock_policy--network_policy--net_instance_config--opaque))
+- `port` (String) name of port mapping in the model
+- `port_tags` (Map of String) Tags are name/value pairs that enable you to categorize resources. Tag names are case insensitive with max_length 512 and min_length 3. Tag values are case sensitive with max_length 256 and min_length 3.
+- `project_id` (String) id of the project in which network instance is created
+- `propagate_connected_routes` (Boolean) Automatically propagate connected routes
+- `static_routes` (Block List) List of Static IP routes (see [below for nested schema](#nestedblock--configuration_lock_policy--network_policy--net_instance_config--static_routes))
+- `tags` (Map of String) Tags are name/value pairs that enable you to categorize resources. Tag names are case insensitive with max_length 512 and min_length 3. Tag values are case sensitive with max_length 256 and min_length 3.
+- `type` (String) Type of DHCP for this Network Instance:
+NETWORK_INSTANCE_DHCP_TYPE_V4
+NETWORK_INSTANCE_DHCP_TYPE_V6
+NETWORK_INSTANCE_DHCP_TYPE_CRYPTOEID
+NETWORK_INSTANCE_DHCP_TYPE_CRYPTOV4
+NETWORK_INSTANCE_DHCP_TYPE_CRYPTOV6
+
+Read-Only:
+
+- `id` (String) System defined universally unique ID of the network instance
+- `lisp` (List of Object) Lisp Config : read only for now. Deprecated. (see [below for nested schema](#nestedatt--configuration_lock_policy--network_policy--net_instance_config--lisp))
+- `revision` (List of Object) system defined info for the object (see [below for nested schema](#nestedatt--configuration_lock_policy--network_policy--net_instance_config--revision))
+
+<a id="nestedblock--configuration_lock_policy--network_policy--net_instance_config--dns_list"></a>
+### Nested Schema for `configuration_lock_policy.network_policy.net_instance_config.dns_list`
+
+Optional:
+
+- `addrs` (List of String) Addresses
+- `hostname` (String) Host name
+
+
+<a id="nestedblock--configuration_lock_policy--network_policy--net_instance_config--ip"></a>
+### Nested Schema for `configuration_lock_policy.network_policy.net_instance_config.ip`
+
+Optional:
+
+- `dhcp_range` (Block List) Range of IP addresses to be used for DHCP (see [below for nested schema](#nestedblock--configuration_lock_policy--network_policy--net_instance_config--ip--dhcp_range))
+- `dns` (List of String) IP Addresses of DNS servers
+- `domain` (String) Network domain
+- `gateway` (String) IP Address of Network Gateway
+- `mask` (String) Subnet Mask
+- `ntp` (String) IP Address of NTP Server
+- `subnet` (String) Subnet address
+
+<a id="nestedblock--configuration_lock_policy--network_policy--net_instance_config--ip--dhcp_range"></a>
+### Nested Schema for `configuration_lock_policy.network_policy.net_instance_config.ip.dhcp_range`
+
+Optional:
+
+- `end` (String) ending IP
+- `start` (String) starting IP
+
+
+
+<a id="nestedblock--configuration_lock_policy--network_policy--net_instance_config--opaque"></a>
+### Nested Schema for `configuration_lock_policy.network_policy.net_instance_config.opaque`
+
+Optional:
+
+- `lisp` (Block List) Deprecated - Lisp config (see [below for nested schema](#nestedblock--configuration_lock_policy--network_policy--net_instance_config--opaque--lisp))
+- `oconfig` (String) base64 encoded string of opaque config
+- `type` (String) type of Opaque config
+
+<a id="nestedblock--configuration_lock_policy--network_policy--net_instance_config--opaque--lisp"></a>
+### Nested Schema for `configuration_lock_policy.network_policy.net_instance_config.opaque.lisp`
+
+Optional:
+
+- `allocate` (Boolean) Allocate flag
+- `allocationprefix` (String) Allocation Prefix
+- `allocationprefixlen` (Number) Allocation Prefix Length
+- `exportprivate` (Boolean) Export Private flag
+- `lispiid` (Number) lisp id
+- `sp` (Block List) Service Point List (see [below for nested schema](#nestedblock--configuration_lock_policy--network_policy--net_instance_config--opaque--lisp--sp))
+
+<a id="nestedblock--configuration_lock_policy--network_policy--net_instance_config--opaque--lisp--sp"></a>
+### Nested Schema for `configuration_lock_policy.network_policy.net_instance_config.opaque.lisp.sp`
+
+Optional:
+
+- `credential` (String) Service credentials
+- `name_or_ip` (String) Service name/ service name
+- `type` (String) Service Point Type
+
+
+
+
+<a id="nestedblock--configuration_lock_policy--network_policy--net_instance_config--static_routes"></a>
+### Nested Schema for `configuration_lock_policy.network_policy.net_instance_config.static_routes`
+
+Optional:
+
+- `gateway` (String) Gateway IP
+- `prefix` (String) IP Prefix
+
+
+<a id="nestedatt--configuration_lock_policy--network_policy--net_instance_config--lisp"></a>
+### Nested Schema for `configuration_lock_policy.network_policy.net_instance_config.lisp`
+
+Read-Only:
+
+- `allocate` (Boolean)
+- `allocationprefix` (String)
+- `allocationprefixlen` (Number)
+- `exportprivate` (Boolean)
+- `lispiid` (Number)
+- `sp` (List of Object) (see [below for nested schema](#nestedobjatt--configuration_lock_policy--network_policy--net_instance_config--lisp--sp))
+
+<a id="nestedobjatt--configuration_lock_policy--network_policy--net_instance_config--lisp--sp"></a>
+### Nested Schema for `configuration_lock_policy.network_policy.net_instance_config.lisp.sp`
+
+Read-Only:
+
+- `credential` (String)
+- `name_or_ip` (String)
+- `type` (String)
+
+
+
+<a id="nestedatt--configuration_lock_policy--network_policy--net_instance_config--revision"></a>
+### Nested Schema for `configuration_lock_policy.network_policy.net_instance_config.revision`
+
+Read-Only:
+
+- `created_at` (String)
+- `created_by` (String)
+- `curr` (String)
+- `prev` (String)
+- `updated_at` (String)
+- `updated_by` (String)
+
+
+
+
+<a id="nestedatt--configuration_lock_policy--revision"></a>
+### Nested Schema for `configuration_lock_policy.revision`
+
+Read-Only:
+
+- `created_at` (String)
+- `created_by` (String)
+- `curr` (String)
+- `prev` (String)
+- `updated_at` (String)
+- `updated_by` (String)
+
+
+
 <a id="nestedblock--deployment"></a>
 ### Nested Schema for `deployment`
 
@@ -5106,12 +7438,12 @@ Read-Only:
 
 Optional:
 
+- `id` (String)
 - `name` (String)
 - `title` (String)
 
 Read-Only:
 
-- `id` (String) The ID of this resource.
 - `revision` (Block List) (see [below for nested schema](#nestedblock--deployment--cluster_policy--revision))
 
 <a id="nestedblock--deployment--cluster_policy--revision"></a>
@@ -5180,12 +7512,12 @@ Read-Only:
 
 Optional:
 
+- `id` (String)
 - `name` (String)
 - `title` (String)
 
 Read-Only:
 
-- `id` (String) The ID of this resource.
 - `revision` (Block List) (see [below for nested schema](#nestedblock--deployment--integration_policy--revision))
 
 <a id="nestedblock--deployment--integration_policy--revision"></a>
@@ -5504,6 +7836,7 @@ Optional:
 - `attr` (Map of String) Mapping of policy  variable keys and policy variable values
 - `azure_policy` (Block List) azure policy, which is used in configuring azure iot-edge. (see [below for nested schema](#nestedblock--edgeview_policy--azure_policy))
 - `cluster_policy` (Block List) cluster policy to bring up cluster on devices in this project (see [below for nested schema](#nestedblock--edgeview_policy--cluster_policy))
+- `configuration_lock_policy` (Block List) configuration lock policy to enforce on all devices in this project (see [below for nested schema](#nestedblock--edgeview_policy--configuration_lock_policy))
 - `description` (String) Detailed description of the policy
 - `edgeview_policy` (Block List) edgeview policy on devices of this project (see [below for nested schema](#nestedblock--edgeview_policy--edgeview_policy))
 - `local_operator_console_policy` (Block List) local operator console policy to enforce on all devices in this project (see [below for nested schema](#nestedblock--edgeview_policy--local_operator_console_policy))
@@ -6235,6 +8568,18 @@ Optional:
 
 - `min_nodes_required` (Number)
 
+
+
+<a id="nestedblock--edgeview_policy--configuration_lock_policy"></a>
+### Nested Schema for `edgeview_policy.configuration_lock_policy`
+
+Required:
+
+- `config_lock` (String) configuration lock setting
+
+Read-Only:
+
+- `id` (String) unique policy id
 
 
 <a id="nestedblock--edgeview_policy--edgeview_policy"></a>
@@ -7785,6 +10130,7 @@ Optional:
 - `attr` (Map of String) Mapping of policy  variable keys and policy variable values
 - `azure_policy` (Block List) azure policy, which is used in configuring azure iot-edge. (see [below for nested schema](#nestedblock--local_operator_console_policy--azure_policy))
 - `cluster_policy` (Block List) cluster policy to bring up cluster on devices in this project (see [below for nested schema](#nestedblock--local_operator_console_policy--cluster_policy))
+- `configuration_lock_policy` (Block List) configuration lock policy to enforce on all devices in this project (see [below for nested schema](#nestedblock--local_operator_console_policy--configuration_lock_policy))
 - `description` (String) Detailed description of the policy
 - `edgeview_policy` (Block List) edgeview policy on devices of this project (see [below for nested schema](#nestedblock--local_operator_console_policy--edgeview_policy))
 - `local_operator_console_policy` (Block List) local operator console policy to enforce on all devices in this project (see [below for nested schema](#nestedblock--local_operator_console_policy--local_operator_console_policy))
@@ -8516,6 +10862,18 @@ Optional:
 
 - `min_nodes_required` (Number)
 
+
+
+<a id="nestedblock--local_operator_console_policy--configuration_lock_policy"></a>
+### Nested Schema for `local_operator_console_policy.configuration_lock_policy`
+
+Required:
+
+- `config_lock` (String) configuration lock setting
+
+Read-Only:
+
+- `id` (String) unique policy id
 
 
 <a id="nestedblock--local_operator_console_policy--edgeview_policy"></a>
@@ -10066,6 +12424,7 @@ Optional:
 - `attr` (Map of String) Mapping of policy  variable keys and policy variable values
 - `azure_policy` (Block List) azure policy, which is used in configuring azure iot-edge. (see [below for nested schema](#nestedblock--network_policy--azure_policy))
 - `cluster_policy` (Block List) cluster policy to bring up cluster on devices in this project (see [below for nested schema](#nestedblock--network_policy--cluster_policy))
+- `configuration_lock_policy` (Block List) configuration lock policy to enforce on all devices in this project (see [below for nested schema](#nestedblock--network_policy--configuration_lock_policy))
 - `description` (String) Detailed description of the policy
 - `edgeview_policy` (Block List) edgeview policy on devices of this project (see [below for nested schema](#nestedblock--network_policy--edgeview_policy))
 - `local_operator_console_policy` (Block List) local operator console policy to enforce on all devices in this project (see [below for nested schema](#nestedblock--network_policy--local_operator_console_policy))
@@ -10797,6 +13156,18 @@ Optional:
 
 - `min_nodes_required` (Number)
 
+
+
+<a id="nestedblock--network_policy--configuration_lock_policy"></a>
+### Nested Schema for `network_policy.configuration_lock_policy`
+
+Required:
+
+- `config_lock` (String) configuration lock setting
+
+Read-Only:
+
+- `id` (String) unique policy id
 
 
 <a id="nestedblock--network_policy--edgeview_policy"></a>
@@ -12347,6 +14718,7 @@ Read-Only:
 - `attr` (Map of String)
 - `azure_policy` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy))
 - `cluster_policy` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--cluster_policy))
+- `configuration_lock_policy` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--configuration_lock_policy))
 - `description` (String)
 - `edgeview_policy` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--edgeview_policy))
 - `id` (String)
@@ -12394,18 +14766,18 @@ Read-Only:
 - `title` (String)
 
 <a id="nestedobjatt--cloud_policy--app_policy--apps--interfaces"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title`
+### Nested Schema for `cloud_policy.app_policy.apps.interfaces`
 
 Read-Only:
 
 - `access_vlan_id` (Number)
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--interfaces--acls))
 - `default_net_instance` (Boolean)
 - `directattach` (Boolean)
-- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--eidregister))
+- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--interfaces--eidregister))
 - `intfname` (String)
 - `intforder` (Number)
-- `io` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--io))
+- `io` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--interfaces--io))
 - `ipaddr` (String)
 - `macaddr` (String)
 - `netinstid` (String)
@@ -12414,18 +14786,18 @@ Read-Only:
 - `netname` (String)
 - `privateip` (Boolean)
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--acls"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.acls`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--interfaces--acls"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--acls--actions))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--interfaces--acls--actions))
 - `id` (Number)
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--acls--matches))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--acls--actions"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.acls.name`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--interfaces--acls--actions"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.interfaces.acls.actions`
 
 Read-Only:
 
@@ -12434,11 +14806,11 @@ Read-Only:
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
-- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--acls--name--mapparams))
+- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--interfaces--acls--actions--mapparams))
 - `portmap` (Boolean)
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--acls--name--mapparams"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.acls.name.portmap`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--interfaces--acls--actions--mapparams"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.interfaces.acls.actions.mapparams`
 
 Read-Only:
 
@@ -12446,8 +14818,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--acls--matches"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.acls.name`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--interfaces--acls--matches"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.interfaces.acls.matches`
 
 Read-Only:
 
@@ -12456,8 +14828,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--eidregister"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.eidregister`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--interfaces--eidregister"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.interfaces.eidregister`
 
 Read-Only:
 
@@ -12468,12 +14840,12 @@ Read-Only:
 - `e_id` (String)
 - `e_id_hash_len` (Number)
 - `lisp_instance` (Number)
-- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--eidregister--lisp_map_servers))
+- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--interfaces--eidregister--lisp_map_servers))
 - `lisp_signature` (String)
 - `uuid` (String)
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--eidregister--lisp_map_servers"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.eidregister.uuid`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--interfaces--eidregister--lisp_map_servers"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.interfaces.eidregister.lisp_map_servers`
 
 Read-Only:
 
@@ -12482,8 +14854,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--io"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.io`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--interfaces--io"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.interfaces.io`
 
 Read-Only:
 
@@ -12494,39 +14866,39 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title`
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json`
 
 Read-Only:
 
 - `ac_kind` (String)
 - `ac_version` (String)
 - `app_type` (String)
-- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--configuration))
-- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--container_detail))
+- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--configuration))
+- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--container_detail))
 - `cpu_pinning_enabled` (Boolean)
 - `deployment_type` (String)
-- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--desc))
+- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--desc))
 - `description` (String)
 - `display_name` (String)
 - `enablevnc` (Boolean)
-- `images` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--images))
-- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--interfaces))
-- `module` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--module))
+- `images` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--images))
+- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--interfaces))
+- `module` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--module))
 - `name` (String)
-- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--owner))
-- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--permissions))
-- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--resources))
+- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--owner))
+- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--permissions))
+- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--resources))
 - `vmmode` (String)
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--configuration"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.configuration`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--configuration"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.configuration`
 
 Read-Only:
 
-- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--configuration--custom_config))
+- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--configuration--custom_config))
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--configuration--custom_config"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.configuration.custom_config`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--configuration--custom_config"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.configuration.custom_config`
 
 Read-Only:
 
@@ -12536,20 +14908,20 @@ Read-Only:
 - `name` (String)
 - `override` (Boolean)
 - `template` (String)
-- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--configuration--custom_config--variable_groups))
+- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups))
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--configuration--custom_config--variable_groups"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.configuration.custom_config.variable_groups`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.configuration.custom_config.variable_groups`
 
 Read-Only:
 
-- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--configuration--custom_config--variable_groups--condition))
+- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--condition))
 - `name` (String)
 - `required` (Boolean)
-- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--configuration--custom_config--variable_groups--variables))
+- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables))
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--configuration--custom_config--variable_groups--condition"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--condition"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.configuration.custom_config.variable_groups.condition`
 
 Read-Only:
 
@@ -12558,8 +14930,8 @@ Read-Only:
 - `value` (String)
 
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--configuration--custom_config--variable_groups--variables"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.configuration.custom_config.variable_groups.variables`
 
 Read-Only:
 
@@ -12569,14 +14941,14 @@ Read-Only:
 - `label` (String)
 - `max_length` (String)
 - `name` (String)
-- `options` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--configuration--custom_config--variable_groups--variables--options))
+- `options` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables--options))
 - `process_input` (String)
 - `required` (Boolean)
 - `type` (String)
 - `value` (String)
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--configuration--custom_config--variable_groups--variables--options"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.configuration.custom_config.variable_groups.variables.options`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables--options"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.configuration.custom_config.variable_groups.variables.options`
 
 Read-Only:
 
@@ -12588,16 +14960,16 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--container_detail"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.container_detail`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--container_detail"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.container_detail`
 
 Read-Only:
 
 - `container_create_option` (String)
 
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--desc"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.desc`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--desc"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.desc`
 
 Read-Only:
 
@@ -12611,8 +14983,8 @@ Read-Only:
 - `support` (String)
 
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--images"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.images`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--images"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.images`
 
 Read-Only:
 
@@ -12624,14 +14996,14 @@ Read-Only:
 - `imagename` (String)
 - `maxsize` (String)
 - `mountpath` (String)
-- `params` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--images--params))
+- `params` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--images--params))
 - `preserve` (Boolean)
 - `readonly` (Boolean)
 - `target` (String)
 - `volumelabel` (String)
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--images--params"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.images.volumelabel`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--images--params"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.images.params`
 
 Read-Only:
 
@@ -12640,43 +15012,43 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--interfaces"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.interfaces`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--interfaces"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.interfaces`
 
 Read-Only:
 
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--interfaces--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--interfaces--acls))
 - `directattach` (Boolean)
 - `name` (String)
 - `optional` (Boolean)
 - `privateip` (Boolean)
 - `type` (String)
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--interfaces--acls"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.interfaces.type`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--interfaces--acls"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--interfaces--type--actions))
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--interfaces--type--matches))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--interfaces--acls--actions))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--interfaces--type--actions"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.interfaces.type.name`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--interfaces--acls--actions"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.interfaces.acls.actions`
 
 Read-Only:
 
 - `drop` (Boolean)
 - `limit` (Boolean)
-- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--interfaces--type--name--limit_value))
+- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--interfaces--acls--actions--limit_value))
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
 - `portmap` (Boolean)
-- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--interfaces--type--name--portmapto))
+- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--interfaces--acls--actions--portmapto))
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--interfaces--type--name--limit_value"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--interfaces--acls--actions--limit_value"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.interfaces.acls.actions.limit_value`
 
 Read-Only:
 
@@ -12685,8 +15057,8 @@ Read-Only:
 - `limitunit` (String)
 
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--interfaces--type--name--portmapto"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--interfaces--acls--actions--portmapto"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.interfaces.acls.actions.portmapto`
 
 Read-Only:
 
@@ -12694,8 +15066,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--interfaces--type--matches"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.interfaces.type.name`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--interfaces--acls--matches"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.interfaces.acls.matches`
 
 Read-Only:
 
@@ -12705,8 +15077,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--module"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.module`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--module"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.module`
 
 Read-Only:
 
@@ -12716,8 +15088,8 @@ Read-Only:
 - `twin_detail` (String)
 
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--owner"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.owner`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--owner"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.owner`
 
 Read-Only:
 
@@ -12728,15 +15100,15 @@ Read-Only:
 - `website` (String)
 
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--permissions"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.permissions`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--permissions"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.permissions`
 
 Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--resources"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.resources`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--resources"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.resources`
 
 Read-Only:
 
@@ -12746,7 +15118,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--app_policy--apps--parent_detail"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title`
+### Nested Schema for `cloud_policy.app_policy.apps.parent_detail`
 
 Read-Only:
 
@@ -12791,38 +15163,38 @@ Read-Only:
 - `resource_group` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group))
 
 <a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service"></a>
-### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.resource_group`
+### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.dps_service`
 
 Read-Only:
 
-- `enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--enrollment))
-- `service_detail` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--service_detail))
+- `enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--enrollment))
+- `service_detail` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--service_detail))
 
-<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--enrollment"></a>
-### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.resource_group.enrollment`
+<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--enrollment"></a>
+### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.dps_service.enrollment`
 
 Read-Only:
 
 - `allocation_policy` (String)
 - `attached_iot_hubs_name` (List of String)
-- `certificate_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--certificate_enrollment))
+- `certificate_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--certificate_enrollment))
 - `enable_iot_edge_device` (Boolean)
 - `mechanism` (String)
-- `symmetric_key_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--symmetric_key_enrollment))
+- `symmetric_key_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment))
 - `tags` (Map of String)
-- `tpm_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment))
+- `tpm_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--tpm_enrollment))
 
-<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--certificate_enrollment"></a>
-### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.resource_group.enrollment.tpm_enrollment`
+<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--certificate_enrollment"></a>
+### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.certificate_enrollment`
 
 Read-Only:
 
-- `group_certificate_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment--group_certificate_enrollment))
+- `group_certificate_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--certificate_enrollment--group_certificate_enrollment))
 - `individual_certificate_enrollment` (String)
 - `type` (String)
 
-<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment--group_certificate_enrollment"></a>
-### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.resource_group.enrollment.tpm_enrollment.type`
+<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--certificate_enrollment--group_certificate_enrollment"></a>
+### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.certificate_enrollment.group_certificate_enrollment`
 
 Read-Only:
 
@@ -12830,25 +15202,25 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--symmetric_key_enrollment"></a>
-### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.resource_group.enrollment.tpm_enrollment`
+<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment"></a>
+### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.symmetric_key_enrollment`
 
 Read-Only:
 
-- `group_symmetric_key_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment--group_symmetric_key_enrollment))
-- `individual_symmetric_key_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment--individual_symmetric_key_enrollment))
+- `group_symmetric_key_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment--group_symmetric_key_enrollment))
+- `individual_symmetric_key_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment--individual_symmetric_key_enrollment))
 - `type` (String)
 
-<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment--group_symmetric_key_enrollment"></a>
-### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.resource_group.enrollment.tpm_enrollment.type`
+<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment--group_symmetric_key_enrollment"></a>
+### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.symmetric_key_enrollment.group_symmetric_key_enrollment`
 
 Read-Only:
 
 - `group_name` (String)
 
 
-<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment--individual_symmetric_key_enrollment"></a>
-### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.resource_group.enrollment.tpm_enrollment.type`
+<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment--individual_symmetric_key_enrollment"></a>
+### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.symmetric_key_enrollment.individual_symmetric_key_enrollment`
 
 Read-Only:
 
@@ -12856,8 +15228,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment"></a>
-### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.resource_group.enrollment.tpm_enrollment`
+<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--tpm_enrollment"></a>
+### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.tpm_enrollment`
 
 Read-Only:
 
@@ -12865,8 +15237,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--service_detail"></a>
-### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.resource_group.service_detail`
+<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--service_detail"></a>
+### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.dps_service.service_detail`
 
 Read-Only:
 
@@ -12874,11 +15246,11 @@ Read-Only:
 - `name` (String)
 - `region` (String)
 - `resource_group_name` (String)
-- `s_k_u` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--service_detail--s_k_u))
+- `s_k_u` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--service_detail--s_k_u))
 - `subscription_id` (String)
 
-<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--service_detail--s_k_u"></a>
-### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.resource_group.service_detail.subscription_id`
+<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--service_detail--s_k_u"></a>
+### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.dps_service.service_detail.s_k_u`
 
 Read-Only:
 
@@ -12890,14 +15262,14 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--iot_hub_service"></a>
-### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.resource_group`
+### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.iot_hub_service`
 
 Read-Only:
 
-- `service_detail` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--service_detail))
+- `service_detail` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--iot_hub_service--service_detail))
 
-<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--service_detail"></a>
-### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.resource_group.service_detail`
+<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--iot_hub_service--service_detail"></a>
+### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.iot_hub_service.service_detail`
 
 Read-Only:
 
@@ -12905,11 +15277,11 @@ Read-Only:
 - `name` (String)
 - `region` (String)
 - `resource_group_name` (String)
-- `s_k_u` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--service_detail--s_k_u))
+- `s_k_u` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--iot_hub_service--service_detail--s_k_u))
 - `subscription_id` (String)
 
-<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--service_detail--s_k_u"></a>
-### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.resource_group.service_detail.subscription_id`
+<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--iot_hub_service--service_detail--s_k_u"></a>
+### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.iot_hub_service.service_detail.s_k_u`
 
 Read-Only:
 
@@ -12959,7 +15331,7 @@ Read-Only:
 - `valid_till` (String)
 
 <a id="nestedobjatt--cloud_policy--azure_policy--certificate--ecdsa_encryption"></a>
-### Nested Schema for `cloud_policy.azure_policy.certificate.valid_till`
+### Nested Schema for `cloud_policy.azure_policy.certificate.ecdsa_encryption`
 
 Read-Only:
 
@@ -12967,7 +15339,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--azure_policy--certificate--issuer"></a>
-### Nested Schema for `cloud_policy.azure_policy.certificate.valid_till`
+### Nested Schema for `cloud_policy.azure_policy.certificate.issuer`
 
 Read-Only:
 
@@ -12982,7 +15354,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--azure_policy--certificate--rsa_ecryption"></a>
-### Nested Schema for `cloud_policy.azure_policy.certificate.valid_till`
+### Nested Schema for `cloud_policy.azure_policy.certificate.rsa_ecryption`
 
 Read-Only:
 
@@ -12990,7 +15362,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--azure_policy--certificate--san_values"></a>
-### Nested Schema for `cloud_policy.azure_policy.certificate.valid_till`
+### Nested Schema for `cloud_policy.azure_policy.certificate.san_values`
 
 Read-Only:
 
@@ -13003,7 +15375,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--azure_policy--certificate--subject"></a>
-### Nested Schema for `cloud_policy.azure_policy.certificate.valid_till`
+### Nested Schema for `cloud_policy.azure_policy.certificate.subject`
 
 Read-Only:
 
@@ -13038,6 +15410,15 @@ Read-Only:
 
 
 
+<a id="nestedobjatt--cloud_policy--configuration_lock_policy"></a>
+### Nested Schema for `cloud_policy.configuration_lock_policy`
+
+Read-Only:
+
+- `config_lock` (String)
+- `id` (String)
+
+
 <a id="nestedobjatt--cloud_policy--edgeview_policy"></a>
 ### Nested Schema for `cloud_policy.edgeview_policy`
 
@@ -13062,7 +15443,7 @@ Read-Only:
 - `token` (String)
 
 <a id="nestedobjatt--cloud_policy--edgeview_policy--edgeviewcfg--app_policy"></a>
-### Nested Schema for `cloud_policy.edgeview_policy.edgeviewcfg.token`
+### Nested Schema for `cloud_policy.edgeview_policy.edgeviewcfg.app_policy`
 
 Read-Only:
 
@@ -13070,7 +15451,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--edgeview_policy--edgeviewcfg--dev_policy"></a>
-### Nested Schema for `cloud_policy.edgeview_policy.edgeviewcfg.token`
+### Nested Schema for `cloud_policy.edgeview_policy.edgeviewcfg.dev_policy`
 
 Read-Only:
 
@@ -13078,7 +15459,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--edgeview_policy--edgeviewcfg--ext_policy"></a>
-### Nested Schema for `cloud_policy.edgeview_policy.edgeviewcfg.token`
+### Nested Schema for `cloud_policy.edgeview_policy.edgeviewcfg.ext_policy`
 
 Read-Only:
 
@@ -13086,7 +15467,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--edgeview_policy--edgeviewcfg--jwt_info"></a>
-### Nested Schema for `cloud_policy.edgeview_policy.edgeviewcfg.token`
+### Nested Schema for `cloud_policy.edgeview_policy.edgeviewcfg.jwt_info`
 
 Read-Only:
 
@@ -13152,18 +15533,18 @@ Read-Only:
 - `title` (String)
 
 <a id="nestedobjatt--cloud_policy--module_policy--apps--interfaces"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title`
+### Nested Schema for `cloud_policy.module_policy.apps.interfaces`
 
 Read-Only:
 
 - `access_vlan_id` (Number)
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--interfaces--acls))
 - `default_net_instance` (Boolean)
 - `directattach` (Boolean)
-- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--eidregister))
+- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--interfaces--eidregister))
 - `intfname` (String)
 - `intforder` (Number)
-- `io` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--io))
+- `io` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--interfaces--io))
 - `ipaddr` (String)
 - `macaddr` (String)
 - `netinstid` (String)
@@ -13172,18 +15553,18 @@ Read-Only:
 - `netname` (String)
 - `privateip` (Boolean)
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--acls"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.acls`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--interfaces--acls"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--acls--actions))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--interfaces--acls--actions))
 - `id` (Number)
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--acls--matches))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--acls--actions"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.acls.name`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--interfaces--acls--actions"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.interfaces.acls.actions`
 
 Read-Only:
 
@@ -13192,11 +15573,11 @@ Read-Only:
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
-- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--acls--name--mapparams))
+- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--interfaces--acls--actions--mapparams))
 - `portmap` (Boolean)
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--acls--name--mapparams"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.acls.name.portmap`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--interfaces--acls--actions--mapparams"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.interfaces.acls.actions.mapparams`
 
 Read-Only:
 
@@ -13204,8 +15585,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--acls--matches"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.acls.name`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--interfaces--acls--matches"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.interfaces.acls.matches`
 
 Read-Only:
 
@@ -13214,8 +15595,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--eidregister"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.eidregister`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--interfaces--eidregister"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.interfaces.eidregister`
 
 Read-Only:
 
@@ -13226,12 +15607,12 @@ Read-Only:
 - `e_id` (String)
 - `e_id_hash_len` (Number)
 - `lisp_instance` (Number)
-- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--eidregister--lisp_map_servers))
+- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--interfaces--eidregister--lisp_map_servers))
 - `lisp_signature` (String)
 - `uuid` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--eidregister--lisp_map_servers"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.eidregister.uuid`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--interfaces--eidregister--lisp_map_servers"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.interfaces.eidregister.lisp_map_servers`
 
 Read-Only:
 
@@ -13240,8 +15621,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--io"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.io`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--interfaces--io"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.interfaces.io`
 
 Read-Only:
 
@@ -13252,39 +15633,39 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title`
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json`
 
 Read-Only:
 
 - `ac_kind` (String)
 - `ac_version` (String)
 - `app_type` (String)
-- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--configuration))
-- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--container_detail))
+- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--configuration))
+- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--container_detail))
 - `cpu_pinning_enabled` (Boolean)
 - `deployment_type` (String)
-- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--desc))
+- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--desc))
 - `description` (String)
 - `display_name` (String)
 - `enablevnc` (Boolean)
-- `images` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--images))
-- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--interfaces))
-- `module` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--module))
+- `images` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--images))
+- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--interfaces))
+- `module` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--module))
 - `name` (String)
-- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--owner))
-- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--permissions))
-- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--resources))
+- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--owner))
+- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--permissions))
+- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--resources))
 - `vmmode` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--configuration"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.configuration`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--configuration"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.configuration`
 
 Read-Only:
 
-- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--configuration--custom_config))
+- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--configuration--custom_config))
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--configuration--custom_config"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.configuration.custom_config`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--configuration--custom_config"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.configuration.custom_config`
 
 Read-Only:
 
@@ -13294,20 +15675,20 @@ Read-Only:
 - `name` (String)
 - `override` (Boolean)
 - `template` (String)
-- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--configuration--custom_config--variable_groups))
+- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups))
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--configuration--custom_config--variable_groups"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.configuration.custom_config.variable_groups`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.configuration.custom_config.variable_groups`
 
 Read-Only:
 
-- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--configuration--custom_config--variable_groups--condition))
+- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--condition))
 - `name` (String)
 - `required` (Boolean)
-- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--configuration--custom_config--variable_groups--variables))
+- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables))
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--configuration--custom_config--variable_groups--condition"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--condition"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.configuration.custom_config.variable_groups.condition`
 
 Read-Only:
 
@@ -13316,8 +15697,8 @@ Read-Only:
 - `value` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--configuration--custom_config--variable_groups--variables"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.configuration.custom_config.variable_groups.variables`
 
 Read-Only:
 
@@ -13327,14 +15708,14 @@ Read-Only:
 - `label` (String)
 - `max_length` (String)
 - `name` (String)
-- `options` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--configuration--custom_config--variable_groups--variables--options))
+- `options` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables--options))
 - `process_input` (String)
 - `required` (Boolean)
 - `type` (String)
 - `value` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--configuration--custom_config--variable_groups--variables--options"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.configuration.custom_config.variable_groups.variables.options`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables--options"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.configuration.custom_config.variable_groups.variables.options`
 
 Read-Only:
 
@@ -13346,16 +15727,16 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--container_detail"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.container_detail`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--container_detail"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.container_detail`
 
 Read-Only:
 
 - `container_create_option` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--desc"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.desc`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--desc"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.desc`
 
 Read-Only:
 
@@ -13369,8 +15750,8 @@ Read-Only:
 - `support` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--images"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.images`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--images"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.images`
 
 Read-Only:
 
@@ -13382,14 +15763,14 @@ Read-Only:
 - `imagename` (String)
 - `maxsize` (String)
 - `mountpath` (String)
-- `params` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--images--params))
+- `params` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--images--params))
 - `preserve` (Boolean)
 - `readonly` (Boolean)
 - `target` (String)
 - `volumelabel` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--images--params"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.images.volumelabel`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--images--params"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.images.params`
 
 Read-Only:
 
@@ -13398,43 +15779,43 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--interfaces"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.interfaces`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--interfaces"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.interfaces`
 
 Read-Only:
 
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--interfaces--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--interfaces--acls))
 - `directattach` (Boolean)
 - `name` (String)
 - `optional` (Boolean)
 - `privateip` (Boolean)
 - `type` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--interfaces--acls"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.interfaces.type`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--interfaces--acls"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--interfaces--type--actions))
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--interfaces--type--matches))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--interfaces--acls--actions))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--interfaces--type--actions"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.interfaces.type.name`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--interfaces--acls--actions"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.interfaces.acls.actions`
 
 Read-Only:
 
 - `drop` (Boolean)
 - `limit` (Boolean)
-- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--interfaces--type--name--limit_value))
+- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--interfaces--acls--actions--limit_value))
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
 - `portmap` (Boolean)
-- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--interfaces--type--name--portmapto))
+- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--interfaces--acls--actions--portmapto))
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--interfaces--type--name--limit_value"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--interfaces--acls--actions--limit_value"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.interfaces.acls.actions.limit_value`
 
 Read-Only:
 
@@ -13443,8 +15824,8 @@ Read-Only:
 - `limitunit` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--interfaces--type--name--portmapto"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--interfaces--acls--actions--portmapto"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.interfaces.acls.actions.portmapto`
 
 Read-Only:
 
@@ -13452,8 +15833,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--interfaces--type--matches"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.interfaces.type.name`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--interfaces--acls--matches"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.interfaces.acls.matches`
 
 Read-Only:
 
@@ -13463,8 +15844,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--module"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.module`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--module"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.module`
 
 Read-Only:
 
@@ -13474,8 +15855,8 @@ Read-Only:
 - `twin_detail` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--owner"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.owner`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--owner"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.owner`
 
 Read-Only:
 
@@ -13486,15 +15867,15 @@ Read-Only:
 - `website` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--permissions"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.permissions`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--permissions"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.permissions`
 
 Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--resources"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.resources`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--resources"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.resources`
 
 Read-Only:
 
@@ -13504,7 +15885,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--module_policy--apps--parent_detail"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title`
+### Nested Schema for `cloud_policy.module_policy.apps.parent_detail`
 
 Read-Only:
 
@@ -13542,18 +15923,18 @@ Read-Only:
 - `title` (String)
 
 <a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title`
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.interfaces`
 
 Read-Only:
 
 - `access_vlan_id` (Number)
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces--acls))
 - `default_net_instance` (Boolean)
 - `directattach` (Boolean)
-- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--eidregister))
+- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces--eidregister))
 - `intfname` (String)
 - `intforder` (Number)
-- `io` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--io))
+- `io` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces--io))
 - `ipaddr` (String)
 - `macaddr` (String)
 - `netinstid` (String)
@@ -13562,18 +15943,18 @@ Read-Only:
 - `netname` (String)
 - `privateip` (Boolean)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--acls"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.acls`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces--acls"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--acls--actions))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces--acls--actions))
 - `id` (Number)
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--acls--matches))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--acls--actions"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.acls.name`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces--acls--actions"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.interfaces.acls.actions`
 
 Read-Only:
 
@@ -13582,11 +15963,11 @@ Read-Only:
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
-- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--acls--name--mapparams))
+- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces--acls--actions--mapparams))
 - `portmap` (Boolean)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--acls--name--mapparams"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.acls.name.portmap`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces--acls--actions--mapparams"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.interfaces.acls.actions.mapparams`
 
 Read-Only:
 
@@ -13594,8 +15975,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--acls--matches"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.acls.name`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces--acls--matches"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.interfaces.acls.matches`
 
 Read-Only:
 
@@ -13604,8 +15985,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--eidregister"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.eidregister`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces--eidregister"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.interfaces.eidregister`
 
 Read-Only:
 
@@ -13616,12 +15997,12 @@ Read-Only:
 - `e_id` (String)
 - `e_id_hash_len` (Number)
 - `lisp_instance` (Number)
-- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--eidregister--lisp_map_servers))
+- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces--eidregister--lisp_map_servers))
 - `lisp_signature` (String)
 - `uuid` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--eidregister--lisp_map_servers"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.eidregister.uuid`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces--eidregister--lisp_map_servers"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.interfaces.eidregister.lisp_map_servers`
 
 Read-Only:
 
@@ -13630,8 +16011,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--io"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.io`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces--io"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.interfaces.io`
 
 Read-Only:
 
@@ -13642,39 +16023,39 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title`
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json`
 
 Read-Only:
 
 - `ac_kind` (String)
 - `ac_version` (String)
 - `app_type` (String)
-- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--configuration))
-- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--container_detail))
+- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--configuration))
+- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--container_detail))
 - `cpu_pinning_enabled` (Boolean)
 - `deployment_type` (String)
-- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--desc))
+- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--desc))
 - `description` (String)
 - `display_name` (String)
 - `enablevnc` (Boolean)
-- `images` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--images))
-- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--interfaces))
-- `module` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--module))
+- `images` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--images))
+- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--interfaces))
+- `module` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--module))
 - `name` (String)
-- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--owner))
-- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--permissions))
-- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--resources))
+- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--owner))
+- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--permissions))
+- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--resources))
 - `vmmode` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--configuration"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.configuration`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--configuration"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.configuration`
 
 Read-Only:
 
-- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--configuration--custom_config))
+- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config))
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--configuration--custom_config"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.configuration.custom_config`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.configuration.custom_config`
 
 Read-Only:
 
@@ -13684,20 +16065,20 @@ Read-Only:
 - `name` (String)
 - `override` (Boolean)
 - `template` (String)
-- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups))
+- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups))
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.configuration.custom_config.variable_groups`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.configuration.custom_config.variable_groups`
 
 Read-Only:
 
-- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups--condition))
+- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--condition))
 - `name` (String)
 - `required` (Boolean)
-- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups--variables))
+- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--variables))
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups--condition"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--condition"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.configuration.custom_config.variable_groups.condition`
 
 Read-Only:
 
@@ -13706,8 +16087,8 @@ Read-Only:
 - `value` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups--variables"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--variables"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.configuration.custom_config.variable_groups.variables`
 
 Read-Only:
 
@@ -13717,14 +16098,14 @@ Read-Only:
 - `label` (String)
 - `max_length` (String)
 - `name` (String)
-- `options` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups--variables--options))
+- `options` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--variables--options))
 - `process_input` (String)
 - `required` (Boolean)
 - `type` (String)
 - `value` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups--variables--options"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.configuration.custom_config.variable_groups.variables.options`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--variables--options"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.configuration.custom_config.variable_groups.variables.options`
 
 Read-Only:
 
@@ -13736,16 +16117,16 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--container_detail"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.container_detail`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--container_detail"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.container_detail`
 
 Read-Only:
 
 - `container_create_option` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--desc"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.desc`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--desc"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.desc`
 
 Read-Only:
 
@@ -13759,8 +16140,8 @@ Read-Only:
 - `support` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--images"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.images`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--images"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.images`
 
 Read-Only:
 
@@ -13772,14 +16153,14 @@ Read-Only:
 - `imagename` (String)
 - `maxsize` (String)
 - `mountpath` (String)
-- `params` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--images--params))
+- `params` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--images--params))
 - `preserve` (Boolean)
 - `readonly` (Boolean)
 - `target` (String)
 - `volumelabel` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--images--params"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.images.volumelabel`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--images--params"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.images.params`
 
 Read-Only:
 
@@ -13788,43 +16169,43 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--interfaces"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.interfaces`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--interfaces"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.interfaces`
 
 Read-Only:
 
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--interfaces--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls))
 - `directattach` (Boolean)
 - `name` (String)
 - `optional` (Boolean)
 - `privateip` (Boolean)
 - `type` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--interfaces--acls"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.interfaces.type`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--interfaces--type--actions))
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--interfaces--type--matches))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--interfaces--type--actions"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.interfaces.type.name`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.interfaces.acls.actions`
 
 Read-Only:
 
 - `drop` (Boolean)
 - `limit` (Boolean)
-- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--interfaces--type--name--limit_value))
+- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions--limit_value))
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
 - `portmap` (Boolean)
-- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--interfaces--type--name--portmapto))
+- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions--portmapto))
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--interfaces--type--name--limit_value"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions--limit_value"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.interfaces.acls.actions.limit_value`
 
 Read-Only:
 
@@ -13833,8 +16214,8 @@ Read-Only:
 - `limitunit` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--interfaces--type--name--portmapto"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions--portmapto"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.interfaces.acls.actions.portmapto`
 
 Read-Only:
 
@@ -13842,8 +16223,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--interfaces--type--matches"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.interfaces.type.name`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--matches"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.interfaces.acls.matches`
 
 Read-Only:
 
@@ -13853,8 +16234,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--module"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.module`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--module"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.module`
 
 Read-Only:
 
@@ -13864,8 +16245,8 @@ Read-Only:
 - `twin_detail` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--owner"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.owner`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--owner"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.owner`
 
 Read-Only:
 
@@ -13876,15 +16257,15 @@ Read-Only:
 - `website` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--permissions"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.permissions`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--permissions"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.permissions`
 
 Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--resources"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.resources`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--resources"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.resources`
 
 Read-Only:
 
@@ -13894,7 +16275,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--parent_detail"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title`
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.parent_detail`
 
 Read-Only:
 
@@ -13932,18 +16313,18 @@ Read-Only:
 - `title` (String)
 
 <a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title`
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.interfaces`
 
 Read-Only:
 
 - `access_vlan_id` (Number)
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces--acls))
 - `default_net_instance` (Boolean)
 - `directattach` (Boolean)
-- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--eidregister))
+- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces--eidregister))
 - `intfname` (String)
 - `intforder` (Number)
-- `io` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--io))
+- `io` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces--io))
 - `ipaddr` (String)
 - `macaddr` (String)
 - `netinstid` (String)
@@ -13952,18 +16333,18 @@ Read-Only:
 - `netname` (String)
 - `privateip` (Boolean)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--acls"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.acls`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces--acls"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--acls--actions))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces--acls--actions))
 - `id` (Number)
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--acls--matches))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--acls--actions"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.acls.name`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces--acls--actions"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.interfaces.acls.actions`
 
 Read-Only:
 
@@ -13972,11 +16353,11 @@ Read-Only:
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
-- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--acls--name--mapparams))
+- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces--acls--actions--mapparams))
 - `portmap` (Boolean)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--acls--name--mapparams"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.acls.name.portmap`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces--acls--actions--mapparams"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.interfaces.acls.actions.mapparams`
 
 Read-Only:
 
@@ -13984,8 +16365,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--acls--matches"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.acls.name`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces--acls--matches"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.interfaces.acls.matches`
 
 Read-Only:
 
@@ -13994,8 +16375,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--eidregister"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.eidregister`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces--eidregister"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.interfaces.eidregister`
 
 Read-Only:
 
@@ -14006,12 +16387,12 @@ Read-Only:
 - `e_id` (String)
 - `e_id_hash_len` (Number)
 - `lisp_instance` (Number)
-- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--eidregister--lisp_map_servers))
+- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces--eidregister--lisp_map_servers))
 - `lisp_signature` (String)
 - `uuid` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--eidregister--lisp_map_servers"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.eidregister.uuid`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces--eidregister--lisp_map_servers"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.interfaces.eidregister.lisp_map_servers`
 
 Read-Only:
 
@@ -14020,8 +16401,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--io"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.io`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces--io"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.interfaces.io`
 
 Read-Only:
 
@@ -14032,39 +16413,39 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title`
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json`
 
 Read-Only:
 
 - `ac_kind` (String)
 - `ac_version` (String)
 - `app_type` (String)
-- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--configuration))
-- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--container_detail))
+- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--configuration))
+- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--container_detail))
 - `cpu_pinning_enabled` (Boolean)
 - `deployment_type` (String)
-- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--desc))
+- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--desc))
 - `description` (String)
 - `display_name` (String)
 - `enablevnc` (Boolean)
-- `images` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--images))
-- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--interfaces))
-- `module` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--module))
+- `images` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--images))
+- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--interfaces))
+- `module` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--module))
 - `name` (String)
-- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--owner))
-- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--permissions))
-- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--resources))
+- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--owner))
+- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--permissions))
+- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--resources))
 - `vmmode` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--configuration"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.configuration`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--configuration"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.configuration`
 
 Read-Only:
 
-- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--configuration--custom_config))
+- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config))
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--configuration--custom_config"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.configuration.custom_config`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.configuration.custom_config`
 
 Read-Only:
 
@@ -14074,20 +16455,20 @@ Read-Only:
 - `name` (String)
 - `override` (Boolean)
 - `template` (String)
-- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups))
+- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups))
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.configuration.custom_config.variable_groups`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.configuration.custom_config.variable_groups`
 
 Read-Only:
 
-- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups--condition))
+- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--condition))
 - `name` (String)
 - `required` (Boolean)
-- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups--variables))
+- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--variables))
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups--condition"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--condition"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.configuration.custom_config.variable_groups.condition`
 
 Read-Only:
 
@@ -14096,8 +16477,8 @@ Read-Only:
 - `value` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups--variables"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--variables"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.configuration.custom_config.variable_groups.variables`
 
 Read-Only:
 
@@ -14107,14 +16488,14 @@ Read-Only:
 - `label` (String)
 - `max_length` (String)
 - `name` (String)
-- `options` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups--variables--options))
+- `options` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--variables--options))
 - `process_input` (String)
 - `required` (Boolean)
 - `type` (String)
 - `value` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups--variables--options"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.configuration.custom_config.variable_groups.variables.options`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--variables--options"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.configuration.custom_config.variable_groups.variables.options`
 
 Read-Only:
 
@@ -14126,16 +16507,16 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--container_detail"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.container_detail`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--container_detail"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.container_detail`
 
 Read-Only:
 
 - `container_create_option` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--desc"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.desc`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--desc"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.desc`
 
 Read-Only:
 
@@ -14149,8 +16530,8 @@ Read-Only:
 - `support` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--images"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.images`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--images"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.images`
 
 Read-Only:
 
@@ -14162,14 +16543,14 @@ Read-Only:
 - `imagename` (String)
 - `maxsize` (String)
 - `mountpath` (String)
-- `params` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--images--params))
+- `params` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--images--params))
 - `preserve` (Boolean)
 - `readonly` (Boolean)
 - `target` (String)
 - `volumelabel` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--images--params"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.images.volumelabel`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--images--params"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.images.params`
 
 Read-Only:
 
@@ -14178,43 +16559,43 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--interfaces"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.interfaces`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--interfaces"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.interfaces`
 
 Read-Only:
 
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--interfaces--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls))
 - `directattach` (Boolean)
 - `name` (String)
 - `optional` (Boolean)
 - `privateip` (Boolean)
 - `type` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--interfaces--acls"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.interfaces.type`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--interfaces--type--actions))
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--interfaces--type--matches))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--interfaces--type--actions"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.interfaces.type.name`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.interfaces.acls.actions`
 
 Read-Only:
 
 - `drop` (Boolean)
 - `limit` (Boolean)
-- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--interfaces--type--name--limit_value))
+- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions--limit_value))
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
 - `portmap` (Boolean)
-- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--interfaces--type--name--portmapto))
+- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions--portmapto))
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--interfaces--type--name--limit_value"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions--limit_value"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.interfaces.acls.actions.limit_value`
 
 Read-Only:
 
@@ -14223,8 +16604,8 @@ Read-Only:
 - `limitunit` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--interfaces--type--name--portmapto"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions--portmapto"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.interfaces.acls.actions.portmapto`
 
 Read-Only:
 
@@ -14232,8 +16613,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--interfaces--type--matches"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.interfaces.type.name`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--matches"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.interfaces.acls.matches`
 
 Read-Only:
 
@@ -14243,8 +16624,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--module"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.module`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--module"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.module`
 
 Read-Only:
 
@@ -14254,8 +16635,8 @@ Read-Only:
 - `twin_detail` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--owner"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.owner`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--owner"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.owner`
 
 Read-Only:
 
@@ -14266,15 +16647,15 @@ Read-Only:
 - `website` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--permissions"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.permissions`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--permissions"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.permissions`
 
 Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--resources"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.resources`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--resources"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.resources`
 
 Read-Only:
 
@@ -14284,7 +16665,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--parent_detail"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title`
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.parent_detail`
 
 Read-Only:
 
@@ -14343,7 +16724,7 @@ Read-Only:
 - `type` (String)
 
 <a id="nestedobjatt--cloud_policy--network_policy--net_instance_config--dns_list"></a>
-### Nested Schema for `cloud_policy.network_policy.net_instance_config.type`
+### Nested Schema for `cloud_policy.network_policy.net_instance_config.dns_list`
 
 Read-Only:
 
@@ -14352,11 +16733,11 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--network_policy--net_instance_config--ip"></a>
-### Nested Schema for `cloud_policy.network_policy.net_instance_config.type`
+### Nested Schema for `cloud_policy.network_policy.net_instance_config.ip`
 
 Read-Only:
 
-- `dhcp_range` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--network_policy--net_instance_config--type--dhcp_range))
+- `dhcp_range` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--network_policy--net_instance_config--ip--dhcp_range))
 - `dns` (List of String)
 - `domain` (String)
 - `gateway` (String)
@@ -14364,8 +16745,8 @@ Read-Only:
 - `ntp` (String)
 - `subnet` (String)
 
-<a id="nestedobjatt--cloud_policy--network_policy--net_instance_config--type--dhcp_range"></a>
-### Nested Schema for `cloud_policy.network_policy.net_instance_config.type.dhcp_range`
+<a id="nestedobjatt--cloud_policy--network_policy--net_instance_config--ip--dhcp_range"></a>
+### Nested Schema for `cloud_policy.network_policy.net_instance_config.ip.dhcp_range`
 
 Read-Only:
 
@@ -14375,7 +16756,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--network_policy--net_instance_config--lisp"></a>
-### Nested Schema for `cloud_policy.network_policy.net_instance_config.type`
+### Nested Schema for `cloud_policy.network_policy.net_instance_config.lisp`
 
 Read-Only:
 
@@ -14384,10 +16765,10 @@ Read-Only:
 - `allocationprefixlen` (Number)
 - `exportprivate` (Boolean)
 - `lispiid` (Number)
-- `sp` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--network_policy--net_instance_config--type--sp))
+- `sp` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--network_policy--net_instance_config--lisp--sp))
 
-<a id="nestedobjatt--cloud_policy--network_policy--net_instance_config--type--sp"></a>
-### Nested Schema for `cloud_policy.network_policy.net_instance_config.type.sp`
+<a id="nestedobjatt--cloud_policy--network_policy--net_instance_config--lisp--sp"></a>
+### Nested Schema for `cloud_policy.network_policy.net_instance_config.lisp.sp`
 
 Read-Only:
 
@@ -14398,16 +16779,16 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--network_policy--net_instance_config--opaque"></a>
-### Nested Schema for `cloud_policy.network_policy.net_instance_config.type`
+### Nested Schema for `cloud_policy.network_policy.net_instance_config.opaque`
 
 Read-Only:
 
-- `lisp` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--network_policy--net_instance_config--type--lisp))
+- `lisp` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--network_policy--net_instance_config--opaque--lisp))
 - `oconfig` (String)
 - `type` (String)
 
-<a id="nestedobjatt--cloud_policy--network_policy--net_instance_config--type--lisp"></a>
-### Nested Schema for `cloud_policy.network_policy.net_instance_config.type.lisp`
+<a id="nestedobjatt--cloud_policy--network_policy--net_instance_config--opaque--lisp"></a>
+### Nested Schema for `cloud_policy.network_policy.net_instance_config.opaque.lisp`
 
 Read-Only:
 
@@ -14416,10 +16797,10 @@ Read-Only:
 - `allocationprefixlen` (Number)
 - `exportprivate` (Boolean)
 - `lispiid` (Number)
-- `sp` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--network_policy--net_instance_config--type--lisp--sp))
+- `sp` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--network_policy--net_instance_config--opaque--lisp--sp))
 
-<a id="nestedobjatt--cloud_policy--network_policy--net_instance_config--type--lisp--sp"></a>
-### Nested Schema for `cloud_policy.network_policy.net_instance_config.type.lisp.sp`
+<a id="nestedobjatt--cloud_policy--network_policy--net_instance_config--opaque--lisp--sp"></a>
+### Nested Schema for `cloud_policy.network_policy.net_instance_config.opaque.lisp.sp`
 
 Read-Only:
 
@@ -14431,7 +16812,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--network_policy--net_instance_config--revision"></a>
-### Nested Schema for `cloud_policy.network_policy.net_instance_config.type`
+### Nested Schema for `cloud_policy.network_policy.net_instance_config.revision`
 
 Read-Only:
 
@@ -14444,7 +16825,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--network_policy--net_instance_config--static_routes"></a>
-### Nested Schema for `cloud_policy.network_policy.net_instance_config.type`
+### Nested Schema for `cloud_policy.network_policy.net_instance_config.static_routes`
 
 Read-Only:
 
@@ -14478,6 +16859,7 @@ Read-Only:
 - `attr` (Map of String)
 - `azure_policy` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy))
 - `cluster_policy` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--cluster_policy))
+- `configuration_lock_policy` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--configuration_lock_policy))
 - `description` (String)
 - `edgeview_policy` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--edgeview_policy))
 - `id` (String)
@@ -14525,18 +16907,18 @@ Read-Only:
 - `title` (String)
 
 <a id="nestedobjatt--module_policy--app_policy--apps--interfaces"></a>
-### Nested Schema for `module_policy.app_policy.apps.title`
+### Nested Schema for `module_policy.app_policy.apps.interfaces`
 
 Read-Only:
 
 - `access_vlan_id` (Number)
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--interfaces--acls))
 - `default_net_instance` (Boolean)
 - `directattach` (Boolean)
-- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--eidregister))
+- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--interfaces--eidregister))
 - `intfname` (String)
 - `intforder` (Number)
-- `io` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--io))
+- `io` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--interfaces--io))
 - `ipaddr` (String)
 - `macaddr` (String)
 - `netinstid` (String)
@@ -14545,18 +16927,18 @@ Read-Only:
 - `netname` (String)
 - `privateip` (Boolean)
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--acls"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.acls`
+<a id="nestedobjatt--module_policy--app_policy--apps--interfaces--acls"></a>
+### Nested Schema for `module_policy.app_policy.apps.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--acls--actions))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--interfaces--acls--actions))
 - `id` (Number)
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--acls--matches))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--acls--actions"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.acls.name`
+<a id="nestedobjatt--module_policy--app_policy--apps--interfaces--acls--actions"></a>
+### Nested Schema for `module_policy.app_policy.apps.interfaces.acls.actions`
 
 Read-Only:
 
@@ -14565,11 +16947,11 @@ Read-Only:
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
-- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--acls--name--mapparams))
+- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--interfaces--acls--actions--mapparams))
 - `portmap` (Boolean)
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--acls--name--mapparams"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.acls.name.portmap`
+<a id="nestedobjatt--module_policy--app_policy--apps--interfaces--acls--actions--mapparams"></a>
+### Nested Schema for `module_policy.app_policy.apps.interfaces.acls.actions.mapparams`
 
 Read-Only:
 
@@ -14577,8 +16959,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--acls--matches"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.acls.name`
+<a id="nestedobjatt--module_policy--app_policy--apps--interfaces--acls--matches"></a>
+### Nested Schema for `module_policy.app_policy.apps.interfaces.acls.matches`
 
 Read-Only:
 
@@ -14587,8 +16969,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--eidregister"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.eidregister`
+<a id="nestedobjatt--module_policy--app_policy--apps--interfaces--eidregister"></a>
+### Nested Schema for `module_policy.app_policy.apps.interfaces.eidregister`
 
 Read-Only:
 
@@ -14599,12 +16981,12 @@ Read-Only:
 - `e_id` (String)
 - `e_id_hash_len` (Number)
 - `lisp_instance` (Number)
-- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--eidregister--lisp_map_servers))
+- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--interfaces--eidregister--lisp_map_servers))
 - `lisp_signature` (String)
 - `uuid` (String)
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--eidregister--lisp_map_servers"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.eidregister.uuid`
+<a id="nestedobjatt--module_policy--app_policy--apps--interfaces--eidregister--lisp_map_servers"></a>
+### Nested Schema for `module_policy.app_policy.apps.interfaces.eidregister.lisp_map_servers`
 
 Read-Only:
 
@@ -14613,8 +16995,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--io"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.io`
+<a id="nestedobjatt--module_policy--app_policy--apps--interfaces--io"></a>
+### Nested Schema for `module_policy.app_policy.apps.interfaces.io`
 
 Read-Only:
 
@@ -14625,39 +17007,39 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--app_policy--apps--manifest_json"></a>
-### Nested Schema for `module_policy.app_policy.apps.title`
+### Nested Schema for `module_policy.app_policy.apps.manifest_json`
 
 Read-Only:
 
 - `ac_kind` (String)
 - `ac_version` (String)
 - `app_type` (String)
-- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--configuration))
-- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--container_detail))
+- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--configuration))
+- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--container_detail))
 - `cpu_pinning_enabled` (Boolean)
 - `deployment_type` (String)
-- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--desc))
+- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--desc))
 - `description` (String)
 - `display_name` (String)
 - `enablevnc` (Boolean)
-- `images` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--images))
-- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--interfaces))
-- `module` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--module))
+- `images` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--images))
+- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--interfaces))
+- `module` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--module))
 - `name` (String)
-- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--owner))
-- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--permissions))
-- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--resources))
+- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--owner))
+- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--permissions))
+- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--resources))
 - `vmmode` (String)
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--configuration"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.configuration`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--configuration"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.configuration`
 
 Read-Only:
 
-- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--configuration--custom_config))
+- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--configuration--custom_config))
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--configuration--custom_config"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.configuration.custom_config`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--configuration--custom_config"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.configuration.custom_config`
 
 Read-Only:
 
@@ -14667,20 +17049,20 @@ Read-Only:
 - `name` (String)
 - `override` (Boolean)
 - `template` (String)
-- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--configuration--custom_config--variable_groups))
+- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups))
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--configuration--custom_config--variable_groups"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.configuration.custom_config.variable_groups`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.configuration.custom_config.variable_groups`
 
 Read-Only:
 
-- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--configuration--custom_config--variable_groups--condition))
+- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--condition))
 - `name` (String)
 - `required` (Boolean)
-- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--configuration--custom_config--variable_groups--variables))
+- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables))
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--configuration--custom_config--variable_groups--condition"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--condition"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.configuration.custom_config.variable_groups.condition`
 
 Read-Only:
 
@@ -14689,8 +17071,8 @@ Read-Only:
 - `value` (String)
 
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--configuration--custom_config--variable_groups--variables"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.configuration.custom_config.variable_groups.variables`
 
 Read-Only:
 
@@ -14700,14 +17082,14 @@ Read-Only:
 - `label` (String)
 - `max_length` (String)
 - `name` (String)
-- `options` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--configuration--custom_config--variable_groups--variables--options))
+- `options` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables--options))
 - `process_input` (String)
 - `required` (Boolean)
 - `type` (String)
 - `value` (String)
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--configuration--custom_config--variable_groups--variables--options"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.configuration.custom_config.variable_groups.variables.options`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables--options"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.configuration.custom_config.variable_groups.variables.options`
 
 Read-Only:
 
@@ -14719,16 +17101,16 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--container_detail"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.container_detail`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--container_detail"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.container_detail`
 
 Read-Only:
 
 - `container_create_option` (String)
 
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--desc"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.desc`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--desc"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.desc`
 
 Read-Only:
 
@@ -14742,8 +17124,8 @@ Read-Only:
 - `support` (String)
 
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--images"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.images`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--images"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.images`
 
 Read-Only:
 
@@ -14755,14 +17137,14 @@ Read-Only:
 - `imagename` (String)
 - `maxsize` (String)
 - `mountpath` (String)
-- `params` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--images--params))
+- `params` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--images--params))
 - `preserve` (Boolean)
 - `readonly` (Boolean)
 - `target` (String)
 - `volumelabel` (String)
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--images--params"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.images.volumelabel`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--images--params"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.images.params`
 
 Read-Only:
 
@@ -14771,43 +17153,43 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--interfaces"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.interfaces`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--interfaces"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.interfaces`
 
 Read-Only:
 
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--interfaces--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--interfaces--acls))
 - `directattach` (Boolean)
 - `name` (String)
 - `optional` (Boolean)
 - `privateip` (Boolean)
 - `type` (String)
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--interfaces--acls"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.interfaces.type`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--interfaces--acls"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--interfaces--type--actions))
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--interfaces--type--matches))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--interfaces--acls--actions))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--interfaces--type--actions"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.interfaces.type.name`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--interfaces--acls--actions"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.interfaces.acls.actions`
 
 Read-Only:
 
 - `drop` (Boolean)
 - `limit` (Boolean)
-- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--interfaces--type--name--limit_value))
+- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--interfaces--acls--actions--limit_value))
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
 - `portmap` (Boolean)
-- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--interfaces--type--name--portmapto))
+- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--interfaces--acls--actions--portmapto))
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--interfaces--type--name--limit_value"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--interfaces--acls--actions--limit_value"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.interfaces.acls.actions.limit_value`
 
 Read-Only:
 
@@ -14816,8 +17198,8 @@ Read-Only:
 - `limitunit` (String)
 
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--interfaces--type--name--portmapto"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--interfaces--acls--actions--portmapto"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.interfaces.acls.actions.portmapto`
 
 Read-Only:
 
@@ -14825,8 +17207,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--interfaces--type--matches"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.interfaces.type.name`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--interfaces--acls--matches"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.interfaces.acls.matches`
 
 Read-Only:
 
@@ -14836,8 +17218,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--module"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.module`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--module"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.module`
 
 Read-Only:
 
@@ -14847,8 +17229,8 @@ Read-Only:
 - `twin_detail` (String)
 
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--owner"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.owner`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--owner"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.owner`
 
 Read-Only:
 
@@ -14859,15 +17241,15 @@ Read-Only:
 - `website` (String)
 
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--permissions"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.permissions`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--permissions"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.permissions`
 
 Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--resources"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.resources`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--resources"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.resources`
 
 Read-Only:
 
@@ -14877,7 +17259,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--app_policy--apps--parent_detail"></a>
-### Nested Schema for `module_policy.app_policy.apps.title`
+### Nested Schema for `module_policy.app_policy.apps.parent_detail`
 
 Read-Only:
 
@@ -14922,38 +17304,38 @@ Read-Only:
 - `resource_group` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group))
 
 <a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service"></a>
-### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.resource_group`
+### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.dps_service`
 
 Read-Only:
 
-- `enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--enrollment))
-- `service_detail` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--service_detail))
+- `enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--enrollment))
+- `service_detail` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--service_detail))
 
-<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--enrollment"></a>
-### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.resource_group.enrollment`
+<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--enrollment"></a>
+### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.dps_service.enrollment`
 
 Read-Only:
 
 - `allocation_policy` (String)
 - `attached_iot_hubs_name` (List of String)
-- `certificate_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--certificate_enrollment))
+- `certificate_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--certificate_enrollment))
 - `enable_iot_edge_device` (Boolean)
 - `mechanism` (String)
-- `symmetric_key_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--symmetric_key_enrollment))
+- `symmetric_key_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment))
 - `tags` (Map of String)
-- `tpm_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment))
+- `tpm_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--tpm_enrollment))
 
-<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--certificate_enrollment"></a>
-### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.resource_group.enrollment.tpm_enrollment`
+<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--certificate_enrollment"></a>
+### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.certificate_enrollment`
 
 Read-Only:
 
-- `group_certificate_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment--group_certificate_enrollment))
+- `group_certificate_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--certificate_enrollment--group_certificate_enrollment))
 - `individual_certificate_enrollment` (String)
 - `type` (String)
 
-<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment--group_certificate_enrollment"></a>
-### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.resource_group.enrollment.tpm_enrollment.type`
+<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--certificate_enrollment--group_certificate_enrollment"></a>
+### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.certificate_enrollment.group_certificate_enrollment`
 
 Read-Only:
 
@@ -14961,25 +17343,25 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--symmetric_key_enrollment"></a>
-### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.resource_group.enrollment.tpm_enrollment`
+<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment"></a>
+### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.symmetric_key_enrollment`
 
 Read-Only:
 
-- `group_symmetric_key_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment--group_symmetric_key_enrollment))
-- `individual_symmetric_key_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment--individual_symmetric_key_enrollment))
+- `group_symmetric_key_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment--group_symmetric_key_enrollment))
+- `individual_symmetric_key_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment--individual_symmetric_key_enrollment))
 - `type` (String)
 
-<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment--group_symmetric_key_enrollment"></a>
-### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.resource_group.enrollment.tpm_enrollment.type`
+<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment--group_symmetric_key_enrollment"></a>
+### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.symmetric_key_enrollment.group_symmetric_key_enrollment`
 
 Read-Only:
 
 - `group_name` (String)
 
 
-<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment--individual_symmetric_key_enrollment"></a>
-### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.resource_group.enrollment.tpm_enrollment.type`
+<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment--individual_symmetric_key_enrollment"></a>
+### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.symmetric_key_enrollment.individual_symmetric_key_enrollment`
 
 Read-Only:
 
@@ -14987,8 +17369,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment"></a>
-### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.resource_group.enrollment.tpm_enrollment`
+<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--tpm_enrollment"></a>
+### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.tpm_enrollment`
 
 Read-Only:
 
@@ -14996,8 +17378,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--service_detail"></a>
-### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.resource_group.service_detail`
+<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--service_detail"></a>
+### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.dps_service.service_detail`
 
 Read-Only:
 
@@ -15005,11 +17387,11 @@ Read-Only:
 - `name` (String)
 - `region` (String)
 - `resource_group_name` (String)
-- `s_k_u` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--service_detail--s_k_u))
+- `s_k_u` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--service_detail--s_k_u))
 - `subscription_id` (String)
 
-<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--service_detail--s_k_u"></a>
-### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.resource_group.service_detail.subscription_id`
+<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--service_detail--s_k_u"></a>
+### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.dps_service.service_detail.s_k_u`
 
 Read-Only:
 
@@ -15021,14 +17403,14 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--iot_hub_service"></a>
-### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.resource_group`
+### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.iot_hub_service`
 
 Read-Only:
 
-- `service_detail` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--service_detail))
+- `service_detail` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--iot_hub_service--service_detail))
 
-<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--service_detail"></a>
-### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.resource_group.service_detail`
+<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--iot_hub_service--service_detail"></a>
+### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.iot_hub_service.service_detail`
 
 Read-Only:
 
@@ -15036,11 +17418,11 @@ Read-Only:
 - `name` (String)
 - `region` (String)
 - `resource_group_name` (String)
-- `s_k_u` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--service_detail--s_k_u))
+- `s_k_u` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--iot_hub_service--service_detail--s_k_u))
 - `subscription_id` (String)
 
-<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--service_detail--s_k_u"></a>
-### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.resource_group.service_detail.subscription_id`
+<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--iot_hub_service--service_detail--s_k_u"></a>
+### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.iot_hub_service.service_detail.s_k_u`
 
 Read-Only:
 
@@ -15090,7 +17472,7 @@ Read-Only:
 - `valid_till` (String)
 
 <a id="nestedobjatt--module_policy--azure_policy--certificate--ecdsa_encryption"></a>
-### Nested Schema for `module_policy.azure_policy.certificate.valid_till`
+### Nested Schema for `module_policy.azure_policy.certificate.ecdsa_encryption`
 
 Read-Only:
 
@@ -15098,7 +17480,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--azure_policy--certificate--issuer"></a>
-### Nested Schema for `module_policy.azure_policy.certificate.valid_till`
+### Nested Schema for `module_policy.azure_policy.certificate.issuer`
 
 Read-Only:
 
@@ -15113,7 +17495,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--azure_policy--certificate--rsa_ecryption"></a>
-### Nested Schema for `module_policy.azure_policy.certificate.valid_till`
+### Nested Schema for `module_policy.azure_policy.certificate.rsa_ecryption`
 
 Read-Only:
 
@@ -15121,7 +17503,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--azure_policy--certificate--san_values"></a>
-### Nested Schema for `module_policy.azure_policy.certificate.valid_till`
+### Nested Schema for `module_policy.azure_policy.certificate.san_values`
 
 Read-Only:
 
@@ -15134,7 +17516,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--azure_policy--certificate--subject"></a>
-### Nested Schema for `module_policy.azure_policy.certificate.valid_till`
+### Nested Schema for `module_policy.azure_policy.certificate.subject`
 
 Read-Only:
 
@@ -15169,6 +17551,15 @@ Read-Only:
 
 
 
+<a id="nestedobjatt--module_policy--configuration_lock_policy"></a>
+### Nested Schema for `module_policy.configuration_lock_policy`
+
+Read-Only:
+
+- `config_lock` (String)
+- `id` (String)
+
+
 <a id="nestedobjatt--module_policy--edgeview_policy"></a>
 ### Nested Schema for `module_policy.edgeview_policy`
 
@@ -15193,7 +17584,7 @@ Read-Only:
 - `token` (String)
 
 <a id="nestedobjatt--module_policy--edgeview_policy--edgeviewcfg--app_policy"></a>
-### Nested Schema for `module_policy.edgeview_policy.edgeviewcfg.token`
+### Nested Schema for `module_policy.edgeview_policy.edgeviewcfg.app_policy`
 
 Read-Only:
 
@@ -15201,7 +17592,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--edgeview_policy--edgeviewcfg--dev_policy"></a>
-### Nested Schema for `module_policy.edgeview_policy.edgeviewcfg.token`
+### Nested Schema for `module_policy.edgeview_policy.edgeviewcfg.dev_policy`
 
 Read-Only:
 
@@ -15209,7 +17600,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--edgeview_policy--edgeviewcfg--ext_policy"></a>
-### Nested Schema for `module_policy.edgeview_policy.edgeviewcfg.token`
+### Nested Schema for `module_policy.edgeview_policy.edgeviewcfg.ext_policy`
 
 Read-Only:
 
@@ -15217,7 +17608,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--edgeview_policy--edgeviewcfg--jwt_info"></a>
-### Nested Schema for `module_policy.edgeview_policy.edgeviewcfg.token`
+### Nested Schema for `module_policy.edgeview_policy.edgeviewcfg.jwt_info`
 
 Read-Only:
 
@@ -15283,18 +17674,18 @@ Read-Only:
 - `title` (String)
 
 <a id="nestedobjatt--module_policy--module_policy--apps--interfaces"></a>
-### Nested Schema for `module_policy.module_policy.apps.title`
+### Nested Schema for `module_policy.module_policy.apps.interfaces`
 
 Read-Only:
 
 - `access_vlan_id` (Number)
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--interfaces--acls))
 - `default_net_instance` (Boolean)
 - `directattach` (Boolean)
-- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--eidregister))
+- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--interfaces--eidregister))
 - `intfname` (String)
 - `intforder` (Number)
-- `io` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--io))
+- `io` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--interfaces--io))
 - `ipaddr` (String)
 - `macaddr` (String)
 - `netinstid` (String)
@@ -15303,18 +17694,18 @@ Read-Only:
 - `netname` (String)
 - `privateip` (Boolean)
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--acls"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.acls`
+<a id="nestedobjatt--module_policy--module_policy--apps--interfaces--acls"></a>
+### Nested Schema for `module_policy.module_policy.apps.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--acls--actions))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--interfaces--acls--actions))
 - `id` (Number)
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--acls--matches))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--acls--actions"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.acls.name`
+<a id="nestedobjatt--module_policy--module_policy--apps--interfaces--acls--actions"></a>
+### Nested Schema for `module_policy.module_policy.apps.interfaces.acls.actions`
 
 Read-Only:
 
@@ -15323,11 +17714,11 @@ Read-Only:
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
-- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--acls--name--mapparams))
+- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--interfaces--acls--actions--mapparams))
 - `portmap` (Boolean)
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--acls--name--mapparams"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.acls.name.portmap`
+<a id="nestedobjatt--module_policy--module_policy--apps--interfaces--acls--actions--mapparams"></a>
+### Nested Schema for `module_policy.module_policy.apps.interfaces.acls.actions.mapparams`
 
 Read-Only:
 
@@ -15335,8 +17726,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--acls--matches"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.acls.name`
+<a id="nestedobjatt--module_policy--module_policy--apps--interfaces--acls--matches"></a>
+### Nested Schema for `module_policy.module_policy.apps.interfaces.acls.matches`
 
 Read-Only:
 
@@ -15345,8 +17736,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--eidregister"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.eidregister`
+<a id="nestedobjatt--module_policy--module_policy--apps--interfaces--eidregister"></a>
+### Nested Schema for `module_policy.module_policy.apps.interfaces.eidregister`
 
 Read-Only:
 
@@ -15357,12 +17748,12 @@ Read-Only:
 - `e_id` (String)
 - `e_id_hash_len` (Number)
 - `lisp_instance` (Number)
-- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--eidregister--lisp_map_servers))
+- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--interfaces--eidregister--lisp_map_servers))
 - `lisp_signature` (String)
 - `uuid` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--eidregister--lisp_map_servers"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.eidregister.uuid`
+<a id="nestedobjatt--module_policy--module_policy--apps--interfaces--eidregister--lisp_map_servers"></a>
+### Nested Schema for `module_policy.module_policy.apps.interfaces.eidregister.lisp_map_servers`
 
 Read-Only:
 
@@ -15371,8 +17762,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--io"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.io`
+<a id="nestedobjatt--module_policy--module_policy--apps--interfaces--io"></a>
+### Nested Schema for `module_policy.module_policy.apps.interfaces.io`
 
 Read-Only:
 
@@ -15383,39 +17774,39 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--module_policy--apps--manifest_json"></a>
-### Nested Schema for `module_policy.module_policy.apps.title`
+### Nested Schema for `module_policy.module_policy.apps.manifest_json`
 
 Read-Only:
 
 - `ac_kind` (String)
 - `ac_version` (String)
 - `app_type` (String)
-- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--configuration))
-- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--container_detail))
+- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--configuration))
+- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--container_detail))
 - `cpu_pinning_enabled` (Boolean)
 - `deployment_type` (String)
-- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--desc))
+- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--desc))
 - `description` (String)
 - `display_name` (String)
 - `enablevnc` (Boolean)
-- `images` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--images))
-- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--interfaces))
-- `module` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--module))
+- `images` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--images))
+- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--interfaces))
+- `module` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--module))
 - `name` (String)
-- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--owner))
-- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--permissions))
-- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--resources))
+- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--owner))
+- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--permissions))
+- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--resources))
 - `vmmode` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--configuration"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.configuration`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--configuration"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.configuration`
 
 Read-Only:
 
-- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--configuration--custom_config))
+- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--configuration--custom_config))
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--configuration--custom_config"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.configuration.custom_config`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--configuration--custom_config"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.configuration.custom_config`
 
 Read-Only:
 
@@ -15425,20 +17816,20 @@ Read-Only:
 - `name` (String)
 - `override` (Boolean)
 - `template` (String)
-- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--configuration--custom_config--variable_groups))
+- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups))
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--configuration--custom_config--variable_groups"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.configuration.custom_config.variable_groups`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.configuration.custom_config.variable_groups`
 
 Read-Only:
 
-- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--configuration--custom_config--variable_groups--condition))
+- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--condition))
 - `name` (String)
 - `required` (Boolean)
-- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--configuration--custom_config--variable_groups--variables))
+- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables))
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--configuration--custom_config--variable_groups--condition"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--condition"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.configuration.custom_config.variable_groups.condition`
 
 Read-Only:
 
@@ -15447,8 +17838,8 @@ Read-Only:
 - `value` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--configuration--custom_config--variable_groups--variables"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.configuration.custom_config.variable_groups.variables`
 
 Read-Only:
 
@@ -15458,14 +17849,14 @@ Read-Only:
 - `label` (String)
 - `max_length` (String)
 - `name` (String)
-- `options` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--configuration--custom_config--variable_groups--variables--options))
+- `options` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables--options))
 - `process_input` (String)
 - `required` (Boolean)
 - `type` (String)
 - `value` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--configuration--custom_config--variable_groups--variables--options"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.configuration.custom_config.variable_groups.variables.options`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables--options"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.configuration.custom_config.variable_groups.variables.options`
 
 Read-Only:
 
@@ -15477,16 +17868,16 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--container_detail"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.container_detail`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--container_detail"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.container_detail`
 
 Read-Only:
 
 - `container_create_option` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--desc"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.desc`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--desc"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.desc`
 
 Read-Only:
 
@@ -15500,8 +17891,8 @@ Read-Only:
 - `support` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--images"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.images`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--images"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.images`
 
 Read-Only:
 
@@ -15513,14 +17904,14 @@ Read-Only:
 - `imagename` (String)
 - `maxsize` (String)
 - `mountpath` (String)
-- `params` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--images--params))
+- `params` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--images--params))
 - `preserve` (Boolean)
 - `readonly` (Boolean)
 - `target` (String)
 - `volumelabel` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--images--params"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.images.volumelabel`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--images--params"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.images.params`
 
 Read-Only:
 
@@ -15529,43 +17920,43 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--interfaces"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.interfaces`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--interfaces"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.interfaces`
 
 Read-Only:
 
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--interfaces--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--interfaces--acls))
 - `directattach` (Boolean)
 - `name` (String)
 - `optional` (Boolean)
 - `privateip` (Boolean)
 - `type` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--interfaces--acls"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.interfaces.type`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--interfaces--acls"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--interfaces--type--actions))
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--interfaces--type--matches))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--interfaces--acls--actions))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--interfaces--type--actions"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.interfaces.type.name`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--interfaces--acls--actions"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.interfaces.acls.actions`
 
 Read-Only:
 
 - `drop` (Boolean)
 - `limit` (Boolean)
-- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--interfaces--type--name--limit_value))
+- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--interfaces--acls--actions--limit_value))
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
 - `portmap` (Boolean)
-- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--interfaces--type--name--portmapto))
+- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--interfaces--acls--actions--portmapto))
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--interfaces--type--name--limit_value"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--interfaces--acls--actions--limit_value"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.interfaces.acls.actions.limit_value`
 
 Read-Only:
 
@@ -15574,8 +17965,8 @@ Read-Only:
 - `limitunit` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--interfaces--type--name--portmapto"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--interfaces--acls--actions--portmapto"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.interfaces.acls.actions.portmapto`
 
 Read-Only:
 
@@ -15583,8 +17974,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--interfaces--type--matches"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.interfaces.type.name`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--interfaces--acls--matches"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.interfaces.acls.matches`
 
 Read-Only:
 
@@ -15594,8 +17985,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--module"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.module`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--module"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.module`
 
 Read-Only:
 
@@ -15605,8 +17996,8 @@ Read-Only:
 - `twin_detail` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--owner"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.owner`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--owner"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.owner`
 
 Read-Only:
 
@@ -15617,15 +18008,15 @@ Read-Only:
 - `website` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--permissions"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.permissions`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--permissions"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.permissions`
 
 Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--resources"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.resources`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--resources"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.resources`
 
 Read-Only:
 
@@ -15635,7 +18026,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--module_policy--apps--parent_detail"></a>
-### Nested Schema for `module_policy.module_policy.apps.title`
+### Nested Schema for `module_policy.module_policy.apps.parent_detail`
 
 Read-Only:
 
@@ -15673,18 +18064,18 @@ Read-Only:
 - `title` (String)
 
 <a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title`
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.interfaces`
 
 Read-Only:
 
 - `access_vlan_id` (Number)
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces--acls))
 - `default_net_instance` (Boolean)
 - `directattach` (Boolean)
-- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--eidregister))
+- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces--eidregister))
 - `intfname` (String)
 - `intforder` (Number)
-- `io` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--io))
+- `io` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces--io))
 - `ipaddr` (String)
 - `macaddr` (String)
 - `netinstid` (String)
@@ -15693,18 +18084,18 @@ Read-Only:
 - `netname` (String)
 - `privateip` (Boolean)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--acls"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.acls`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces--acls"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--acls--actions))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces--acls--actions))
 - `id` (Number)
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--acls--matches))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--acls--actions"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.acls.name`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces--acls--actions"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.interfaces.acls.actions`
 
 Read-Only:
 
@@ -15713,11 +18104,11 @@ Read-Only:
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
-- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--acls--name--mapparams))
+- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces--acls--actions--mapparams))
 - `portmap` (Boolean)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--acls--name--mapparams"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.acls.name.portmap`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces--acls--actions--mapparams"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.interfaces.acls.actions.mapparams`
 
 Read-Only:
 
@@ -15725,8 +18116,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--acls--matches"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.acls.name`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces--acls--matches"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.interfaces.acls.matches`
 
 Read-Only:
 
@@ -15735,8 +18126,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--eidregister"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.eidregister`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces--eidregister"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.interfaces.eidregister`
 
 Read-Only:
 
@@ -15747,12 +18138,12 @@ Read-Only:
 - `e_id` (String)
 - `e_id_hash_len` (Number)
 - `lisp_instance` (Number)
-- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--eidregister--lisp_map_servers))
+- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces--eidregister--lisp_map_servers))
 - `lisp_signature` (String)
 - `uuid` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--eidregister--lisp_map_servers"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.eidregister.uuid`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces--eidregister--lisp_map_servers"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.interfaces.eidregister.lisp_map_servers`
 
 Read-Only:
 
@@ -15761,8 +18152,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--io"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.io`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces--io"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.interfaces.io`
 
 Read-Only:
 
@@ -15773,39 +18164,39 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title`
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json`
 
 Read-Only:
 
 - `ac_kind` (String)
 - `ac_version` (String)
 - `app_type` (String)
-- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--configuration))
-- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--container_detail))
+- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--configuration))
+- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--container_detail))
 - `cpu_pinning_enabled` (Boolean)
 - `deployment_type` (String)
-- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--desc))
+- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--desc))
 - `description` (String)
 - `display_name` (String)
 - `enablevnc` (Boolean)
-- `images` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--images))
-- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--interfaces))
-- `module` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--module))
+- `images` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--images))
+- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--interfaces))
+- `module` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--module))
 - `name` (String)
-- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--owner))
-- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--permissions))
-- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--resources))
+- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--owner))
+- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--permissions))
+- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--resources))
 - `vmmode` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--configuration"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.configuration`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--configuration"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.configuration`
 
 Read-Only:
 
-- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--configuration--custom_config))
+- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config))
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--configuration--custom_config"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.configuration.custom_config`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.configuration.custom_config`
 
 Read-Only:
 
@@ -15815,20 +18206,20 @@ Read-Only:
 - `name` (String)
 - `override` (Boolean)
 - `template` (String)
-- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups))
+- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups))
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.configuration.custom_config.variable_groups`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.configuration.custom_config.variable_groups`
 
 Read-Only:
 
-- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups--condition))
+- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--condition))
 - `name` (String)
 - `required` (Boolean)
-- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups--variables))
+- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--variables))
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups--condition"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--condition"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.configuration.custom_config.variable_groups.condition`
 
 Read-Only:
 
@@ -15837,8 +18228,8 @@ Read-Only:
 - `value` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups--variables"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--variables"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.configuration.custom_config.variable_groups.variables`
 
 Read-Only:
 
@@ -15848,14 +18239,14 @@ Read-Only:
 - `label` (String)
 - `max_length` (String)
 - `name` (String)
-- `options` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups--variables--options))
+- `options` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--variables--options))
 - `process_input` (String)
 - `required` (Boolean)
 - `type` (String)
 - `value` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups--variables--options"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.configuration.custom_config.variable_groups.variables.options`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--variables--options"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.configuration.custom_config.variable_groups.variables.options`
 
 Read-Only:
 
@@ -15867,16 +18258,16 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--container_detail"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.container_detail`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--container_detail"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.container_detail`
 
 Read-Only:
 
 - `container_create_option` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--desc"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.desc`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--desc"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.desc`
 
 Read-Only:
 
@@ -15890,8 +18281,8 @@ Read-Only:
 - `support` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--images"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.images`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--images"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.images`
 
 Read-Only:
 
@@ -15903,14 +18294,14 @@ Read-Only:
 - `imagename` (String)
 - `maxsize` (String)
 - `mountpath` (String)
-- `params` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--images--params))
+- `params` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--images--params))
 - `preserve` (Boolean)
 - `readonly` (Boolean)
 - `target` (String)
 - `volumelabel` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--images--params"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.images.volumelabel`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--images--params"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.images.params`
 
 Read-Only:
 
@@ -15919,43 +18310,43 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--interfaces"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.interfaces`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--interfaces"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.interfaces`
 
 Read-Only:
 
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--interfaces--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls))
 - `directattach` (Boolean)
 - `name` (String)
 - `optional` (Boolean)
 - `privateip` (Boolean)
 - `type` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--interfaces--acls"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.interfaces.type`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--interfaces--type--actions))
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--interfaces--type--matches))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--interfaces--type--actions"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.interfaces.type.name`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.interfaces.acls.actions`
 
 Read-Only:
 
 - `drop` (Boolean)
 - `limit` (Boolean)
-- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--interfaces--type--name--limit_value))
+- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions--limit_value))
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
 - `portmap` (Boolean)
-- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--interfaces--type--name--portmapto))
+- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions--portmapto))
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--interfaces--type--name--limit_value"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions--limit_value"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.interfaces.acls.actions.limit_value`
 
 Read-Only:
 
@@ -15964,8 +18355,8 @@ Read-Only:
 - `limitunit` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--interfaces--type--name--portmapto"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions--portmapto"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.interfaces.acls.actions.portmapto`
 
 Read-Only:
 
@@ -15973,8 +18364,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--interfaces--type--matches"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.interfaces.type.name`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--matches"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.interfaces.acls.matches`
 
 Read-Only:
 
@@ -15984,8 +18375,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--module"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.module`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--module"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.module`
 
 Read-Only:
 
@@ -15995,8 +18386,8 @@ Read-Only:
 - `twin_detail` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--owner"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.owner`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--owner"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.owner`
 
 Read-Only:
 
@@ -16007,15 +18398,15 @@ Read-Only:
 - `website` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--permissions"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.permissions`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--permissions"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.permissions`
 
 Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--resources"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.resources`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--resources"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.resources`
 
 Read-Only:
 
@@ -16025,7 +18416,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--parent_detail"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title`
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.parent_detail`
 
 Read-Only:
 
@@ -16063,18 +18454,18 @@ Read-Only:
 - `title` (String)
 
 <a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title`
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.interfaces`
 
 Read-Only:
 
 - `access_vlan_id` (Number)
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces--acls))
 - `default_net_instance` (Boolean)
 - `directattach` (Boolean)
-- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--eidregister))
+- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces--eidregister))
 - `intfname` (String)
 - `intforder` (Number)
-- `io` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--io))
+- `io` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces--io))
 - `ipaddr` (String)
 - `macaddr` (String)
 - `netinstid` (String)
@@ -16083,18 +18474,18 @@ Read-Only:
 - `netname` (String)
 - `privateip` (Boolean)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--acls"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.acls`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces--acls"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--acls--actions))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces--acls--actions))
 - `id` (Number)
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--acls--matches))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--acls--actions"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.acls.name`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces--acls--actions"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.interfaces.acls.actions`
 
 Read-Only:
 
@@ -16103,11 +18494,11 @@ Read-Only:
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
-- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--acls--name--mapparams))
+- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces--acls--actions--mapparams))
 - `portmap` (Boolean)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--acls--name--mapparams"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.acls.name.portmap`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces--acls--actions--mapparams"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.interfaces.acls.actions.mapparams`
 
 Read-Only:
 
@@ -16115,8 +18506,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--acls--matches"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.acls.name`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces--acls--matches"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.interfaces.acls.matches`
 
 Read-Only:
 
@@ -16125,8 +18516,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--eidregister"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.eidregister`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces--eidregister"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.interfaces.eidregister`
 
 Read-Only:
 
@@ -16137,12 +18528,12 @@ Read-Only:
 - `e_id` (String)
 - `e_id_hash_len` (Number)
 - `lisp_instance` (Number)
-- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--eidregister--lisp_map_servers))
+- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces--eidregister--lisp_map_servers))
 - `lisp_signature` (String)
 - `uuid` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--eidregister--lisp_map_servers"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.eidregister.uuid`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces--eidregister--lisp_map_servers"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.interfaces.eidregister.lisp_map_servers`
 
 Read-Only:
 
@@ -16151,8 +18542,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--io"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.io`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces--io"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.interfaces.io`
 
 Read-Only:
 
@@ -16163,39 +18554,39 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title`
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json`
 
 Read-Only:
 
 - `ac_kind` (String)
 - `ac_version` (String)
 - `app_type` (String)
-- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--configuration))
-- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--container_detail))
+- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--configuration))
+- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--container_detail))
 - `cpu_pinning_enabled` (Boolean)
 - `deployment_type` (String)
-- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--desc))
+- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--desc))
 - `description` (String)
 - `display_name` (String)
 - `enablevnc` (Boolean)
-- `images` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--images))
-- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--interfaces))
-- `module` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--module))
+- `images` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--images))
+- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--interfaces))
+- `module` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--module))
 - `name` (String)
-- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--owner))
-- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--permissions))
-- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--resources))
+- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--owner))
+- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--permissions))
+- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--resources))
 - `vmmode` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--configuration"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.configuration`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--configuration"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.configuration`
 
 Read-Only:
 
-- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--configuration--custom_config))
+- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config))
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--configuration--custom_config"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.configuration.custom_config`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.configuration.custom_config`
 
 Read-Only:
 
@@ -16205,20 +18596,20 @@ Read-Only:
 - `name` (String)
 - `override` (Boolean)
 - `template` (String)
-- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups))
+- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups))
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.configuration.custom_config.variable_groups`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.configuration.custom_config.variable_groups`
 
 Read-Only:
 
-- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups--condition))
+- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--condition))
 - `name` (String)
 - `required` (Boolean)
-- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups--variables))
+- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--variables))
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups--condition"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--condition"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.configuration.custom_config.variable_groups.condition`
 
 Read-Only:
 
@@ -16227,8 +18618,8 @@ Read-Only:
 - `value` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups--variables"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--variables"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.configuration.custom_config.variable_groups.variables`
 
 Read-Only:
 
@@ -16238,14 +18629,14 @@ Read-Only:
 - `label` (String)
 - `max_length` (String)
 - `name` (String)
-- `options` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups--variables--options))
+- `options` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--variables--options))
 - `process_input` (String)
 - `required` (Boolean)
 - `type` (String)
 - `value` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups--variables--options"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.configuration.custom_config.variable_groups.variables.options`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--variables--options"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.configuration.custom_config.variable_groups.variables.options`
 
 Read-Only:
 
@@ -16257,16 +18648,16 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--container_detail"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.container_detail`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--container_detail"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.container_detail`
 
 Read-Only:
 
 - `container_create_option` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--desc"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.desc`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--desc"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.desc`
 
 Read-Only:
 
@@ -16280,8 +18671,8 @@ Read-Only:
 - `support` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--images"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.images`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--images"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.images`
 
 Read-Only:
 
@@ -16293,14 +18684,14 @@ Read-Only:
 - `imagename` (String)
 - `maxsize` (String)
 - `mountpath` (String)
-- `params` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--images--params))
+- `params` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--images--params))
 - `preserve` (Boolean)
 - `readonly` (Boolean)
 - `target` (String)
 - `volumelabel` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--images--params"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.images.volumelabel`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--images--params"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.images.params`
 
 Read-Only:
 
@@ -16309,43 +18700,43 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--interfaces"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.interfaces`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--interfaces"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.interfaces`
 
 Read-Only:
 
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--interfaces--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls))
 - `directattach` (Boolean)
 - `name` (String)
 - `optional` (Boolean)
 - `privateip` (Boolean)
 - `type` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--interfaces--acls"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.interfaces.type`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--interfaces--type--actions))
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--interfaces--type--matches))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--interfaces--type--actions"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.interfaces.type.name`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.interfaces.acls.actions`
 
 Read-Only:
 
 - `drop` (Boolean)
 - `limit` (Boolean)
-- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--interfaces--type--name--limit_value))
+- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions--limit_value))
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
 - `portmap` (Boolean)
-- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--interfaces--type--name--portmapto))
+- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions--portmapto))
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--interfaces--type--name--limit_value"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions--limit_value"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.interfaces.acls.actions.limit_value`
 
 Read-Only:
 
@@ -16354,8 +18745,8 @@ Read-Only:
 - `limitunit` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--interfaces--type--name--portmapto"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions--portmapto"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.interfaces.acls.actions.portmapto`
 
 Read-Only:
 
@@ -16363,8 +18754,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--interfaces--type--matches"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.interfaces.type.name`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--matches"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.interfaces.acls.matches`
 
 Read-Only:
 
@@ -16374,8 +18765,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--module"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.module`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--module"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.module`
 
 Read-Only:
 
@@ -16385,8 +18776,8 @@ Read-Only:
 - `twin_detail` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--owner"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.owner`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--owner"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.owner`
 
 Read-Only:
 
@@ -16397,15 +18788,15 @@ Read-Only:
 - `website` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--permissions"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.permissions`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--permissions"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.permissions`
 
 Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--resources"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.resources`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--resources"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.resources`
 
 Read-Only:
 
@@ -16415,7 +18806,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--parent_detail"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title`
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.parent_detail`
 
 Read-Only:
 
@@ -16474,7 +18865,7 @@ Read-Only:
 - `type` (String)
 
 <a id="nestedobjatt--module_policy--network_policy--net_instance_config--dns_list"></a>
-### Nested Schema for `module_policy.network_policy.net_instance_config.type`
+### Nested Schema for `module_policy.network_policy.net_instance_config.dns_list`
 
 Read-Only:
 
@@ -16483,11 +18874,11 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--network_policy--net_instance_config--ip"></a>
-### Nested Schema for `module_policy.network_policy.net_instance_config.type`
+### Nested Schema for `module_policy.network_policy.net_instance_config.ip`
 
 Read-Only:
 
-- `dhcp_range` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--network_policy--net_instance_config--type--dhcp_range))
+- `dhcp_range` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--network_policy--net_instance_config--ip--dhcp_range))
 - `dns` (List of String)
 - `domain` (String)
 - `gateway` (String)
@@ -16495,8 +18886,8 @@ Read-Only:
 - `ntp` (String)
 - `subnet` (String)
 
-<a id="nestedobjatt--module_policy--network_policy--net_instance_config--type--dhcp_range"></a>
-### Nested Schema for `module_policy.network_policy.net_instance_config.type.dhcp_range`
+<a id="nestedobjatt--module_policy--network_policy--net_instance_config--ip--dhcp_range"></a>
+### Nested Schema for `module_policy.network_policy.net_instance_config.ip.dhcp_range`
 
 Read-Only:
 
@@ -16506,7 +18897,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--network_policy--net_instance_config--lisp"></a>
-### Nested Schema for `module_policy.network_policy.net_instance_config.type`
+### Nested Schema for `module_policy.network_policy.net_instance_config.lisp`
 
 Read-Only:
 
@@ -16515,10 +18906,10 @@ Read-Only:
 - `allocationprefixlen` (Number)
 - `exportprivate` (Boolean)
 - `lispiid` (Number)
-- `sp` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--network_policy--net_instance_config--type--sp))
+- `sp` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--network_policy--net_instance_config--lisp--sp))
 
-<a id="nestedobjatt--module_policy--network_policy--net_instance_config--type--sp"></a>
-### Nested Schema for `module_policy.network_policy.net_instance_config.type.sp`
+<a id="nestedobjatt--module_policy--network_policy--net_instance_config--lisp--sp"></a>
+### Nested Schema for `module_policy.network_policy.net_instance_config.lisp.sp`
 
 Read-Only:
 
@@ -16529,16 +18920,16 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--network_policy--net_instance_config--opaque"></a>
-### Nested Schema for `module_policy.network_policy.net_instance_config.type`
+### Nested Schema for `module_policy.network_policy.net_instance_config.opaque`
 
 Read-Only:
 
-- `lisp` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--network_policy--net_instance_config--type--lisp))
+- `lisp` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--network_policy--net_instance_config--opaque--lisp))
 - `oconfig` (String)
 - `type` (String)
 
-<a id="nestedobjatt--module_policy--network_policy--net_instance_config--type--lisp"></a>
-### Nested Schema for `module_policy.network_policy.net_instance_config.type.lisp`
+<a id="nestedobjatt--module_policy--network_policy--net_instance_config--opaque--lisp"></a>
+### Nested Schema for `module_policy.network_policy.net_instance_config.opaque.lisp`
 
 Read-Only:
 
@@ -16547,10 +18938,10 @@ Read-Only:
 - `allocationprefixlen` (Number)
 - `exportprivate` (Boolean)
 - `lispiid` (Number)
-- `sp` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--network_policy--net_instance_config--type--lisp--sp))
+- `sp` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--network_policy--net_instance_config--opaque--lisp--sp))
 
-<a id="nestedobjatt--module_policy--network_policy--net_instance_config--type--lisp--sp"></a>
-### Nested Schema for `module_policy.network_policy.net_instance_config.type.lisp.sp`
+<a id="nestedobjatt--module_policy--network_policy--net_instance_config--opaque--lisp--sp"></a>
+### Nested Schema for `module_policy.network_policy.net_instance_config.opaque.lisp.sp`
 
 Read-Only:
 
@@ -16562,7 +18953,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--network_policy--net_instance_config--revision"></a>
-### Nested Schema for `module_policy.network_policy.net_instance_config.type`
+### Nested Schema for `module_policy.network_policy.net_instance_config.revision`
 
 Read-Only:
 
@@ -16575,7 +18966,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--network_policy--net_instance_config--static_routes"></a>
-### Nested Schema for `module_policy.network_policy.net_instance_config.type`
+### Nested Schema for `module_policy.network_policy.net_instance_config.static_routes`
 
 Read-Only:
 

--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -57,7 +57,7 @@ Optional:
 
 Read-Only:
 
-- `id` (String) The ID of this resource.
+- `id` (String)
 
 
 <a id="nestedatt--revision"></a>

--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -22,24 +22,24 @@ description: |-
 
 ### Optional
 
-- `cpus` (Number) user defined cpus for bundle
 - `description` (String) Detailed description of the edge application
 - `is_imported` (Boolean) Flag to represent where app bundle is already imported
 - `manifest` (Block List, Max: 1) user defined manifest in JSON format (see [below for nested schema](#nestedblock--manifest))
 - `manifest_file` (String) path to manifest.json
-- `memory` (Number) user defined memory for bundle
 - `networks` (Number) user defined network options
 - `origin_type` (String) origin of object
 - `parent_detail` (Block List) origin and parent related details (see [below for nested schema](#nestedblock--parent_detail))
 - `project_access_list` (List of String) project access list of the app bundle
-- `storage` (Number) user defined storage for bundle
 - `user_defined_version` (String) User defined version for the given edge-app
 
 ### Read-Only
 
+- `cpus` (Number) user defined cpus for bundle
 - `drives` (Number) user defined drives
 - `id` (String) System defined universally unique Id of the edge application
+- `memory` (Number) user defined memory for bundle
 - `revision` (List of Object) system defined info (see [below for nested schema](#nestedatt--revision))
+- `storage` (Number) user defined storage for bundle
 
 <a id="nestedblock--manifest"></a>
 ### Nested Schema for `manifest`

--- a/docs/resources/model.md
+++ b/docs/resources/model.md
@@ -39,7 +39,7 @@ description: |-
 ### Read-Only
 
 - `id` (String) System defined universally unique Id of the model.
-- `revision` (List of Object) Object Revision  of the model (see [below for nested schema](#nestedatt--revision))
+- `revision` (Block List) Object Revision  of the model (see [below for nested schema](#nestedblock--revision))
 
 <a id="nestedblock--io_member_list"></a>
 ### Nested Schema for `io_member_list`
@@ -112,14 +112,14 @@ Read-Only:
 - `version_of_parent_object` (Number) version of object present in parent
 
 
-<a id="nestedatt--revision"></a>
+<a id="nestedblock--revision"></a>
 ### Nested Schema for `revision`
 
 Read-Only:
 
-- `created_at` (String)
-- `created_by` (String)
-- `curr` (String)
-- `prev` (String)
-- `updated_at` (String)
-- `updated_by` (String)
+- `created_at` (String) The time, in milliseconds since the epoch, when the record was created.
+- `created_by` (String) User data: Created By
+- `curr` (String) Current Database version of the record
+- `prev` (String) Previous
+- `updated_at` (String) The time, in milliseconds since the epoch, when the record was last updated.
+- `updated_by` (String) User data: Updated By

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -18,6 +18,7 @@ description: |-
 ### Required
 
 - `name` (String) User defined name of the resource group, unique across the enterprise. Once resource group is created, name can’t be changed.
+- `tag_level_settings` (Block List, Min: 1) tag level setting within a enterprise (see [below for nested schema](#nestedblock--tag_level_settings))
 - `title` (String) User defined title of the resource group. Title can be changed at any time.
 - `type` (String) Resource group type
 
@@ -31,7 +32,6 @@ description: |-
 - `edgeview_policy` (Block List) Edgeview policy on devices of this project (see [below for nested schema](#nestedblock--edgeview_policy))
 - `local_operator_console_policy` (Block List) Local operator console policy on devices of this project (see [below for nested schema](#nestedblock--local_operator_console_policy))
 - `network_policy` (Block List) Network policy to enforce on all devices of this project (see [below for nested schema](#nestedblock--network_policy))
-- `tag_level_settings` (Block List) tag level setting within a enterprise (see [below for nested schema](#nestedblock--tag_level_settings))
 - `tags` (Map of String) Tags are name/value pairs that enable you to categorize resources. Tag names are case insensitive with max_length 512 and min_length 3. Tag values are case sensitive with max_length 256 and min_length 3.
 
 ### Read-Only
@@ -42,6 +42,15 @@ description: |-
 - `module_policy` (List of Object) Resource group wide policy for Azure module configuration to be applied to all edge applications (see [below for nested schema](#nestedatt--module_policy))
 - `numdevices` (Number) Number of edge nodes in this resource group
 - `revision` (List of Object) system defined info (see [below for nested schema](#nestedatt--revision))
+
+<a id="nestedblock--tag_level_settings"></a>
+### Nested Schema for `tag_level_settings`
+
+Required:
+
+- `flow_log_transmission` (String) Flow log transmission setting for the network instances, it has two possible values NETWORK_INSTANCE_FLOW_LOG_TRANSMISSION_DISABLED or NETWORK_INSTANCE_FLOW_LOG_TRANSMISSION_ENABLED
+- `interface_ordering` (String) interface ordering for app instances, it has two possible values INTERFACE_ORDERING_DISABLED or INTERFACE_ORDERING_ENABLED
+
 
 <a id="nestedblock--app_policy"></a>
 ### Nested Schema for `app_policy`
@@ -7429,12 +7438,12 @@ Read-Only:
 
 Optional:
 
+- `id` (String)
 - `name` (String)
 - `title` (String)
 
 Read-Only:
 
-- `id` (String) The ID of this resource.
 - `revision` (Block List) (see [below for nested schema](#nestedblock--deployment--cluster_policy--revision))
 
 <a id="nestedblock--deployment--cluster_policy--revision"></a>
@@ -7503,12 +7512,12 @@ Read-Only:
 
 Optional:
 
+- `id` (String)
 - `name` (String)
 - `title` (String)
 
 Read-Only:
 
-- `id` (String) The ID of this resource.
 - `revision` (Block List) (see [below for nested schema](#nestedblock--deployment--integration_policy--revision))
 
 <a id="nestedblock--deployment--integration_policy--revision"></a>
@@ -14699,14 +14708,6 @@ Read-Only:
 
 
 
-<a id="nestedblock--tag_level_settings"></a>
-### Nested Schema for `tag_level_settings`
-
-Optional:
-
-- `flow_log_transmission` (String) Flow log transmission setting for the network instances
-
-
 <a id="nestedatt--cloud_policy"></a>
 ### Nested Schema for `cloud_policy`
 
@@ -14765,18 +14766,18 @@ Read-Only:
 - `title` (String)
 
 <a id="nestedobjatt--cloud_policy--app_policy--apps--interfaces"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title`
+### Nested Schema for `cloud_policy.app_policy.apps.interfaces`
 
 Read-Only:
 
 - `access_vlan_id` (Number)
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--interfaces--acls))
 - `default_net_instance` (Boolean)
 - `directattach` (Boolean)
-- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--eidregister))
+- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--interfaces--eidregister))
 - `intfname` (String)
 - `intforder` (Number)
-- `io` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--io))
+- `io` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--interfaces--io))
 - `ipaddr` (String)
 - `macaddr` (String)
 - `netinstid` (String)
@@ -14785,18 +14786,18 @@ Read-Only:
 - `netname` (String)
 - `privateip` (Boolean)
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--acls"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.acls`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--interfaces--acls"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--acls--actions))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--interfaces--acls--actions))
 - `id` (Number)
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--acls--matches))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--acls--actions"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.acls.name`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--interfaces--acls--actions"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.interfaces.acls.actions`
 
 Read-Only:
 
@@ -14805,11 +14806,11 @@ Read-Only:
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
-- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--acls--name--mapparams))
+- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--interfaces--acls--actions--mapparams))
 - `portmap` (Boolean)
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--acls--name--mapparams"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.acls.name.portmap`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--interfaces--acls--actions--mapparams"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.interfaces.acls.actions.mapparams`
 
 Read-Only:
 
@@ -14817,8 +14818,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--acls--matches"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.acls.name`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--interfaces--acls--matches"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.interfaces.acls.matches`
 
 Read-Only:
 
@@ -14827,8 +14828,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--eidregister"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.eidregister`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--interfaces--eidregister"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.interfaces.eidregister`
 
 Read-Only:
 
@@ -14839,12 +14840,12 @@ Read-Only:
 - `e_id` (String)
 - `e_id_hash_len` (Number)
 - `lisp_instance` (Number)
-- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--eidregister--lisp_map_servers))
+- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--interfaces--eidregister--lisp_map_servers))
 - `lisp_signature` (String)
 - `uuid` (String)
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--eidregister--lisp_map_servers"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.eidregister.uuid`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--interfaces--eidregister--lisp_map_servers"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.interfaces.eidregister.lisp_map_servers`
 
 Read-Only:
 
@@ -14853,8 +14854,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--io"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.io`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--interfaces--io"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.interfaces.io`
 
 Read-Only:
 
@@ -14865,39 +14866,39 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title`
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json`
 
 Read-Only:
 
 - `ac_kind` (String)
 - `ac_version` (String)
 - `app_type` (String)
-- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--configuration))
-- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--container_detail))
+- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--configuration))
+- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--container_detail))
 - `cpu_pinning_enabled` (Boolean)
 - `deployment_type` (String)
-- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--desc))
+- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--desc))
 - `description` (String)
 - `display_name` (String)
 - `enablevnc` (Boolean)
-- `images` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--images))
-- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--interfaces))
-- `module` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--module))
+- `images` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--images))
+- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--interfaces))
+- `module` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--module))
 - `name` (String)
-- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--owner))
-- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--permissions))
-- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--resources))
+- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--owner))
+- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--permissions))
+- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--resources))
 - `vmmode` (String)
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--configuration"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.configuration`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--configuration"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.configuration`
 
 Read-Only:
 
-- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--configuration--custom_config))
+- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--configuration--custom_config))
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--configuration--custom_config"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.configuration.custom_config`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--configuration--custom_config"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.configuration.custom_config`
 
 Read-Only:
 
@@ -14907,20 +14908,20 @@ Read-Only:
 - `name` (String)
 - `override` (Boolean)
 - `template` (String)
-- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--configuration--custom_config--variable_groups))
+- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups))
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--configuration--custom_config--variable_groups"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.configuration.custom_config.variable_groups`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.configuration.custom_config.variable_groups`
 
 Read-Only:
 
-- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--configuration--custom_config--variable_groups--condition))
+- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--condition))
 - `name` (String)
 - `required` (Boolean)
-- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--configuration--custom_config--variable_groups--variables))
+- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables))
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--configuration--custom_config--variable_groups--condition"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--condition"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.configuration.custom_config.variable_groups.condition`
 
 Read-Only:
 
@@ -14929,8 +14930,8 @@ Read-Only:
 - `value` (String)
 
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--configuration--custom_config--variable_groups--variables"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.configuration.custom_config.variable_groups.variables`
 
 Read-Only:
 
@@ -14940,14 +14941,14 @@ Read-Only:
 - `label` (String)
 - `max_length` (String)
 - `name` (String)
-- `options` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--configuration--custom_config--variable_groups--variables--options))
+- `options` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables--options))
 - `process_input` (String)
 - `required` (Boolean)
 - `type` (String)
 - `value` (String)
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--configuration--custom_config--variable_groups--variables--options"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.configuration.custom_config.variable_groups.variables.options`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables--options"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.configuration.custom_config.variable_groups.variables.options`
 
 Read-Only:
 
@@ -14959,16 +14960,16 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--container_detail"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.container_detail`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--container_detail"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.container_detail`
 
 Read-Only:
 
 - `container_create_option` (String)
 
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--desc"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.desc`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--desc"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.desc`
 
 Read-Only:
 
@@ -14982,8 +14983,8 @@ Read-Only:
 - `support` (String)
 
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--images"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.images`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--images"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.images`
 
 Read-Only:
 
@@ -14995,14 +14996,14 @@ Read-Only:
 - `imagename` (String)
 - `maxsize` (String)
 - `mountpath` (String)
-- `params` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--images--params))
+- `params` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--images--params))
 - `preserve` (Boolean)
 - `readonly` (Boolean)
 - `target` (String)
 - `volumelabel` (String)
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--images--params"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.images.volumelabel`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--images--params"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.images.params`
 
 Read-Only:
 
@@ -15011,43 +15012,43 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--interfaces"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.interfaces`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--interfaces"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.interfaces`
 
 Read-Only:
 
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--interfaces--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--interfaces--acls))
 - `directattach` (Boolean)
 - `name` (String)
 - `optional` (Boolean)
 - `privateip` (Boolean)
 - `type` (String)
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--interfaces--acls"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.interfaces.type`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--interfaces--acls"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--interfaces--type--actions))
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--interfaces--type--matches))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--interfaces--acls--actions))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--interfaces--type--actions"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.interfaces.type.name`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--interfaces--acls--actions"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.interfaces.acls.actions`
 
 Read-Only:
 
 - `drop` (Boolean)
 - `limit` (Boolean)
-- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--interfaces--type--name--limit_value))
+- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--interfaces--acls--actions--limit_value))
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
 - `portmap` (Boolean)
-- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--title--interfaces--type--name--portmapto))
+- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--app_policy--apps--manifest_json--interfaces--acls--actions--portmapto))
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--interfaces--type--name--limit_value"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--interfaces--acls--actions--limit_value"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.interfaces.acls.actions.limit_value`
 
 Read-Only:
 
@@ -15056,8 +15057,8 @@ Read-Only:
 - `limitunit` (String)
 
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--interfaces--type--name--portmapto"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--interfaces--acls--actions--portmapto"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.interfaces.acls.actions.portmapto`
 
 Read-Only:
 
@@ -15065,8 +15066,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--interfaces--type--matches"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.interfaces.type.name`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--interfaces--acls--matches"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.interfaces.acls.matches`
 
 Read-Only:
 
@@ -15076,8 +15077,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--module"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.module`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--module"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.module`
 
 Read-Only:
 
@@ -15087,8 +15088,8 @@ Read-Only:
 - `twin_detail` (String)
 
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--owner"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.owner`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--owner"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.owner`
 
 Read-Only:
 
@@ -15099,15 +15100,15 @@ Read-Only:
 - `website` (String)
 
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--permissions"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.permissions`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--permissions"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.permissions`
 
 Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--app_policy--apps--title--resources"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title.resources`
+<a id="nestedobjatt--cloud_policy--app_policy--apps--manifest_json--resources"></a>
+### Nested Schema for `cloud_policy.app_policy.apps.manifest_json.resources`
 
 Read-Only:
 
@@ -15117,7 +15118,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--app_policy--apps--parent_detail"></a>
-### Nested Schema for `cloud_policy.app_policy.apps.title`
+### Nested Schema for `cloud_policy.app_policy.apps.parent_detail`
 
 Read-Only:
 
@@ -15162,38 +15163,38 @@ Read-Only:
 - `resource_group` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group))
 
 <a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service"></a>
-### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.resource_group`
+### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.dps_service`
 
 Read-Only:
 
-- `enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--enrollment))
-- `service_detail` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--service_detail))
+- `enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--enrollment))
+- `service_detail` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--service_detail))
 
-<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--enrollment"></a>
-### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.resource_group.enrollment`
+<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--enrollment"></a>
+### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.dps_service.enrollment`
 
 Read-Only:
 
 - `allocation_policy` (String)
 - `attached_iot_hubs_name` (List of String)
-- `certificate_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--certificate_enrollment))
+- `certificate_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--certificate_enrollment))
 - `enable_iot_edge_device` (Boolean)
 - `mechanism` (String)
-- `symmetric_key_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--symmetric_key_enrollment))
+- `symmetric_key_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment))
 - `tags` (Map of String)
-- `tpm_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment))
+- `tpm_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--tpm_enrollment))
 
-<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--certificate_enrollment"></a>
-### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.resource_group.enrollment.tpm_enrollment`
+<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--certificate_enrollment"></a>
+### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.certificate_enrollment`
 
 Read-Only:
 
-- `group_certificate_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment--group_certificate_enrollment))
+- `group_certificate_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--certificate_enrollment--group_certificate_enrollment))
 - `individual_certificate_enrollment` (String)
 - `type` (String)
 
-<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment--group_certificate_enrollment"></a>
-### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.resource_group.enrollment.tpm_enrollment.type`
+<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--certificate_enrollment--group_certificate_enrollment"></a>
+### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.certificate_enrollment.group_certificate_enrollment`
 
 Read-Only:
 
@@ -15201,25 +15202,25 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--symmetric_key_enrollment"></a>
-### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.resource_group.enrollment.tpm_enrollment`
+<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment"></a>
+### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.symmetric_key_enrollment`
 
 Read-Only:
 
-- `group_symmetric_key_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment--group_symmetric_key_enrollment))
-- `individual_symmetric_key_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment--individual_symmetric_key_enrollment))
+- `group_symmetric_key_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment--group_symmetric_key_enrollment))
+- `individual_symmetric_key_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment--individual_symmetric_key_enrollment))
 - `type` (String)
 
-<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment--group_symmetric_key_enrollment"></a>
-### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.resource_group.enrollment.tpm_enrollment.type`
+<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment--group_symmetric_key_enrollment"></a>
+### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.symmetric_key_enrollment.group_symmetric_key_enrollment`
 
 Read-Only:
 
 - `group_name` (String)
 
 
-<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment--individual_symmetric_key_enrollment"></a>
-### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.resource_group.enrollment.tpm_enrollment.type`
+<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment--individual_symmetric_key_enrollment"></a>
+### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.symmetric_key_enrollment.individual_symmetric_key_enrollment`
 
 Read-Only:
 
@@ -15227,8 +15228,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment"></a>
-### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.resource_group.enrollment.tpm_enrollment`
+<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--tpm_enrollment"></a>
+### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.tpm_enrollment`
 
 Read-Only:
 
@@ -15236,8 +15237,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--service_detail"></a>
-### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.resource_group.service_detail`
+<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--service_detail"></a>
+### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.dps_service.service_detail`
 
 Read-Only:
 
@@ -15245,11 +15246,11 @@ Read-Only:
 - `name` (String)
 - `region` (String)
 - `resource_group_name` (String)
-- `s_k_u` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--service_detail--s_k_u))
+- `s_k_u` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--service_detail--s_k_u))
 - `subscription_id` (String)
 
-<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--service_detail--s_k_u"></a>
-### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.resource_group.service_detail.subscription_id`
+<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--dps_service--service_detail--s_k_u"></a>
+### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.dps_service.service_detail.s_k_u`
 
 Read-Only:
 
@@ -15261,14 +15262,14 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--iot_hub_service"></a>
-### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.resource_group`
+### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.iot_hub_service`
 
 Read-Only:
 
-- `service_detail` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--service_detail))
+- `service_detail` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--iot_hub_service--service_detail))
 
-<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--service_detail"></a>
-### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.resource_group.service_detail`
+<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--iot_hub_service--service_detail"></a>
+### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.iot_hub_service.service_detail`
 
 Read-Only:
 
@@ -15276,11 +15277,11 @@ Read-Only:
 - `name` (String)
 - `region` (String)
 - `resource_group_name` (String)
-- `s_k_u` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--service_detail--s_k_u))
+- `s_k_u` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--iot_hub_service--service_detail--s_k_u))
 - `subscription_id` (String)
 
-<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--resource_group--service_detail--s_k_u"></a>
-### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.resource_group.service_detail.subscription_id`
+<a id="nestedobjatt--cloud_policy--azure_policy--azure_resource_and_services--iot_hub_service--service_detail--s_k_u"></a>
+### Nested Schema for `cloud_policy.azure_policy.azure_resource_and_services.iot_hub_service.service_detail.s_k_u`
 
 Read-Only:
 
@@ -15330,7 +15331,7 @@ Read-Only:
 - `valid_till` (String)
 
 <a id="nestedobjatt--cloud_policy--azure_policy--certificate--ecdsa_encryption"></a>
-### Nested Schema for `cloud_policy.azure_policy.certificate.valid_till`
+### Nested Schema for `cloud_policy.azure_policy.certificate.ecdsa_encryption`
 
 Read-Only:
 
@@ -15338,7 +15339,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--azure_policy--certificate--issuer"></a>
-### Nested Schema for `cloud_policy.azure_policy.certificate.valid_till`
+### Nested Schema for `cloud_policy.azure_policy.certificate.issuer`
 
 Read-Only:
 
@@ -15353,7 +15354,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--azure_policy--certificate--rsa_ecryption"></a>
-### Nested Schema for `cloud_policy.azure_policy.certificate.valid_till`
+### Nested Schema for `cloud_policy.azure_policy.certificate.rsa_ecryption`
 
 Read-Only:
 
@@ -15361,7 +15362,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--azure_policy--certificate--san_values"></a>
-### Nested Schema for `cloud_policy.azure_policy.certificate.valid_till`
+### Nested Schema for `cloud_policy.azure_policy.certificate.san_values`
 
 Read-Only:
 
@@ -15374,7 +15375,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--azure_policy--certificate--subject"></a>
-### Nested Schema for `cloud_policy.azure_policy.certificate.valid_till`
+### Nested Schema for `cloud_policy.azure_policy.certificate.subject`
 
 Read-Only:
 
@@ -15442,7 +15443,7 @@ Read-Only:
 - `token` (String)
 
 <a id="nestedobjatt--cloud_policy--edgeview_policy--edgeviewcfg--app_policy"></a>
-### Nested Schema for `cloud_policy.edgeview_policy.edgeviewcfg.token`
+### Nested Schema for `cloud_policy.edgeview_policy.edgeviewcfg.app_policy`
 
 Read-Only:
 
@@ -15450,7 +15451,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--edgeview_policy--edgeviewcfg--dev_policy"></a>
-### Nested Schema for `cloud_policy.edgeview_policy.edgeviewcfg.token`
+### Nested Schema for `cloud_policy.edgeview_policy.edgeviewcfg.dev_policy`
 
 Read-Only:
 
@@ -15458,7 +15459,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--edgeview_policy--edgeviewcfg--ext_policy"></a>
-### Nested Schema for `cloud_policy.edgeview_policy.edgeviewcfg.token`
+### Nested Schema for `cloud_policy.edgeview_policy.edgeviewcfg.ext_policy`
 
 Read-Only:
 
@@ -15466,7 +15467,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--edgeview_policy--edgeviewcfg--jwt_info"></a>
-### Nested Schema for `cloud_policy.edgeview_policy.edgeviewcfg.token`
+### Nested Schema for `cloud_policy.edgeview_policy.edgeviewcfg.jwt_info`
 
 Read-Only:
 
@@ -15532,18 +15533,18 @@ Read-Only:
 - `title` (String)
 
 <a id="nestedobjatt--cloud_policy--module_policy--apps--interfaces"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title`
+### Nested Schema for `cloud_policy.module_policy.apps.interfaces`
 
 Read-Only:
 
 - `access_vlan_id` (Number)
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--interfaces--acls))
 - `default_net_instance` (Boolean)
 - `directattach` (Boolean)
-- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--eidregister))
+- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--interfaces--eidregister))
 - `intfname` (String)
 - `intforder` (Number)
-- `io` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--io))
+- `io` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--interfaces--io))
 - `ipaddr` (String)
 - `macaddr` (String)
 - `netinstid` (String)
@@ -15552,18 +15553,18 @@ Read-Only:
 - `netname` (String)
 - `privateip` (Boolean)
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--acls"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.acls`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--interfaces--acls"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--acls--actions))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--interfaces--acls--actions))
 - `id` (Number)
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--acls--matches))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--acls--actions"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.acls.name`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--interfaces--acls--actions"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.interfaces.acls.actions`
 
 Read-Only:
 
@@ -15572,11 +15573,11 @@ Read-Only:
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
-- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--acls--name--mapparams))
+- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--interfaces--acls--actions--mapparams))
 - `portmap` (Boolean)
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--acls--name--mapparams"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.acls.name.portmap`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--interfaces--acls--actions--mapparams"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.interfaces.acls.actions.mapparams`
 
 Read-Only:
 
@@ -15584,8 +15585,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--acls--matches"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.acls.name`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--interfaces--acls--matches"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.interfaces.acls.matches`
 
 Read-Only:
 
@@ -15594,8 +15595,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--eidregister"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.eidregister`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--interfaces--eidregister"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.interfaces.eidregister`
 
 Read-Only:
 
@@ -15606,12 +15607,12 @@ Read-Only:
 - `e_id` (String)
 - `e_id_hash_len` (Number)
 - `lisp_instance` (Number)
-- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--eidregister--lisp_map_servers))
+- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--interfaces--eidregister--lisp_map_servers))
 - `lisp_signature` (String)
 - `uuid` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--eidregister--lisp_map_servers"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.eidregister.uuid`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--interfaces--eidregister--lisp_map_servers"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.interfaces.eidregister.lisp_map_servers`
 
 Read-Only:
 
@@ -15620,8 +15621,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--io"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.io`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--interfaces--io"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.interfaces.io`
 
 Read-Only:
 
@@ -15632,39 +15633,39 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title`
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json`
 
 Read-Only:
 
 - `ac_kind` (String)
 - `ac_version` (String)
 - `app_type` (String)
-- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--configuration))
-- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--container_detail))
+- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--configuration))
+- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--container_detail))
 - `cpu_pinning_enabled` (Boolean)
 - `deployment_type` (String)
-- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--desc))
+- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--desc))
 - `description` (String)
 - `display_name` (String)
 - `enablevnc` (Boolean)
-- `images` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--images))
-- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--interfaces))
-- `module` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--module))
+- `images` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--images))
+- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--interfaces))
+- `module` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--module))
 - `name` (String)
-- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--owner))
-- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--permissions))
-- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--resources))
+- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--owner))
+- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--permissions))
+- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--resources))
 - `vmmode` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--configuration"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.configuration`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--configuration"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.configuration`
 
 Read-Only:
 
-- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--configuration--custom_config))
+- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--configuration--custom_config))
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--configuration--custom_config"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.configuration.custom_config`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--configuration--custom_config"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.configuration.custom_config`
 
 Read-Only:
 
@@ -15674,20 +15675,20 @@ Read-Only:
 - `name` (String)
 - `override` (Boolean)
 - `template` (String)
-- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--configuration--custom_config--variable_groups))
+- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups))
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--configuration--custom_config--variable_groups"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.configuration.custom_config.variable_groups`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.configuration.custom_config.variable_groups`
 
 Read-Only:
 
-- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--configuration--custom_config--variable_groups--condition))
+- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--condition))
 - `name` (String)
 - `required` (Boolean)
-- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--configuration--custom_config--variable_groups--variables))
+- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables))
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--configuration--custom_config--variable_groups--condition"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--condition"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.configuration.custom_config.variable_groups.condition`
 
 Read-Only:
 
@@ -15696,8 +15697,8 @@ Read-Only:
 - `value` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--configuration--custom_config--variable_groups--variables"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.configuration.custom_config.variable_groups.variables`
 
 Read-Only:
 
@@ -15707,14 +15708,14 @@ Read-Only:
 - `label` (String)
 - `max_length` (String)
 - `name` (String)
-- `options` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--configuration--custom_config--variable_groups--variables--options))
+- `options` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables--options))
 - `process_input` (String)
 - `required` (Boolean)
 - `type` (String)
 - `value` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--configuration--custom_config--variable_groups--variables--options"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.configuration.custom_config.variable_groups.variables.options`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables--options"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.configuration.custom_config.variable_groups.variables.options`
 
 Read-Only:
 
@@ -15726,16 +15727,16 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--container_detail"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.container_detail`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--container_detail"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.container_detail`
 
 Read-Only:
 
 - `container_create_option` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--desc"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.desc`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--desc"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.desc`
 
 Read-Only:
 
@@ -15749,8 +15750,8 @@ Read-Only:
 - `support` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--images"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.images`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--images"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.images`
 
 Read-Only:
 
@@ -15762,14 +15763,14 @@ Read-Only:
 - `imagename` (String)
 - `maxsize` (String)
 - `mountpath` (String)
-- `params` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--images--params))
+- `params` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--images--params))
 - `preserve` (Boolean)
 - `readonly` (Boolean)
 - `target` (String)
 - `volumelabel` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--images--params"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.images.volumelabel`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--images--params"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.images.params`
 
 Read-Only:
 
@@ -15778,43 +15779,43 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--interfaces"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.interfaces`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--interfaces"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.interfaces`
 
 Read-Only:
 
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--interfaces--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--interfaces--acls))
 - `directattach` (Boolean)
 - `name` (String)
 - `optional` (Boolean)
 - `privateip` (Boolean)
 - `type` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--interfaces--acls"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.interfaces.type`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--interfaces--acls"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--interfaces--type--actions))
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--interfaces--type--matches))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--interfaces--acls--actions))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--interfaces--type--actions"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.interfaces.type.name`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--interfaces--acls--actions"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.interfaces.acls.actions`
 
 Read-Only:
 
 - `drop` (Boolean)
 - `limit` (Boolean)
-- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--interfaces--type--name--limit_value))
+- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--interfaces--acls--actions--limit_value))
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
 - `portmap` (Boolean)
-- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--title--interfaces--type--name--portmapto))
+- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--apps--manifest_json--interfaces--acls--actions--portmapto))
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--interfaces--type--name--limit_value"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--interfaces--acls--actions--limit_value"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.interfaces.acls.actions.limit_value`
 
 Read-Only:
 
@@ -15823,8 +15824,8 @@ Read-Only:
 - `limitunit` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--interfaces--type--name--portmapto"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--interfaces--acls--actions--portmapto"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.interfaces.acls.actions.portmapto`
 
 Read-Only:
 
@@ -15832,8 +15833,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--interfaces--type--matches"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.interfaces.type.name`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--interfaces--acls--matches"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.interfaces.acls.matches`
 
 Read-Only:
 
@@ -15843,8 +15844,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--module"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.module`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--module"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.module`
 
 Read-Only:
 
@@ -15854,8 +15855,8 @@ Read-Only:
 - `twin_detail` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--owner"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.owner`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--owner"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.owner`
 
 Read-Only:
 
@@ -15866,15 +15867,15 @@ Read-Only:
 - `website` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--permissions"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.permissions`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--permissions"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.permissions`
 
 Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--apps--title--resources"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title.resources`
+<a id="nestedobjatt--cloud_policy--module_policy--apps--manifest_json--resources"></a>
+### Nested Schema for `cloud_policy.module_policy.apps.manifest_json.resources`
 
 Read-Only:
 
@@ -15884,7 +15885,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--module_policy--apps--parent_detail"></a>
-### Nested Schema for `cloud_policy.module_policy.apps.title`
+### Nested Schema for `cloud_policy.module_policy.apps.parent_detail`
 
 Read-Only:
 
@@ -15922,18 +15923,18 @@ Read-Only:
 - `title` (String)
 
 <a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title`
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.interfaces`
 
 Read-Only:
 
 - `access_vlan_id` (Number)
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces--acls))
 - `default_net_instance` (Boolean)
 - `directattach` (Boolean)
-- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--eidregister))
+- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces--eidregister))
 - `intfname` (String)
 - `intforder` (Number)
-- `io` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--io))
+- `io` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces--io))
 - `ipaddr` (String)
 - `macaddr` (String)
 - `netinstid` (String)
@@ -15942,18 +15943,18 @@ Read-Only:
 - `netname` (String)
 - `privateip` (Boolean)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--acls"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.acls`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces--acls"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--acls--actions))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces--acls--actions))
 - `id` (Number)
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--acls--matches))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--acls--actions"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.acls.name`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces--acls--actions"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.interfaces.acls.actions`
 
 Read-Only:
 
@@ -15962,11 +15963,11 @@ Read-Only:
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
-- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--acls--name--mapparams))
+- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces--acls--actions--mapparams))
 - `portmap` (Boolean)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--acls--name--mapparams"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.acls.name.portmap`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces--acls--actions--mapparams"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.interfaces.acls.actions.mapparams`
 
 Read-Only:
 
@@ -15974,8 +15975,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--acls--matches"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.acls.name`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces--acls--matches"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.interfaces.acls.matches`
 
 Read-Only:
 
@@ -15984,8 +15985,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--eidregister"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.eidregister`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces--eidregister"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.interfaces.eidregister`
 
 Read-Only:
 
@@ -15996,12 +15997,12 @@ Read-Only:
 - `e_id` (String)
 - `e_id_hash_len` (Number)
 - `lisp_instance` (Number)
-- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--eidregister--lisp_map_servers))
+- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces--eidregister--lisp_map_servers))
 - `lisp_signature` (String)
 - `uuid` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--eidregister--lisp_map_servers"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.eidregister.uuid`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces--eidregister--lisp_map_servers"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.interfaces.eidregister.lisp_map_servers`
 
 Read-Only:
 
@@ -16010,8 +16011,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--io"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.io`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--interfaces--io"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.interfaces.io`
 
 Read-Only:
 
@@ -16022,39 +16023,39 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title`
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json`
 
 Read-Only:
 
 - `ac_kind` (String)
 - `ac_version` (String)
 - `app_type` (String)
-- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--configuration))
-- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--container_detail))
+- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--configuration))
+- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--container_detail))
 - `cpu_pinning_enabled` (Boolean)
 - `deployment_type` (String)
-- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--desc))
+- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--desc))
 - `description` (String)
 - `display_name` (String)
 - `enablevnc` (Boolean)
-- `images` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--images))
-- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--interfaces))
-- `module` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--module))
+- `images` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--images))
+- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--interfaces))
+- `module` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--module))
 - `name` (String)
-- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--owner))
-- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--permissions))
-- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--resources))
+- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--owner))
+- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--permissions))
+- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--resources))
 - `vmmode` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--configuration"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.configuration`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--configuration"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.configuration`
 
 Read-Only:
 
-- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--configuration--custom_config))
+- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config))
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--configuration--custom_config"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.configuration.custom_config`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.configuration.custom_config`
 
 Read-Only:
 
@@ -16064,20 +16065,20 @@ Read-Only:
 - `name` (String)
 - `override` (Boolean)
 - `template` (String)
-- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups))
+- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups))
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.configuration.custom_config.variable_groups`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.configuration.custom_config.variable_groups`
 
 Read-Only:
 
-- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups--condition))
+- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--condition))
 - `name` (String)
 - `required` (Boolean)
-- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups--variables))
+- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--variables))
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups--condition"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--condition"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.configuration.custom_config.variable_groups.condition`
 
 Read-Only:
 
@@ -16086,8 +16087,8 @@ Read-Only:
 - `value` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups--variables"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--variables"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.configuration.custom_config.variable_groups.variables`
 
 Read-Only:
 
@@ -16097,14 +16098,14 @@ Read-Only:
 - `label` (String)
 - `max_length` (String)
 - `name` (String)
-- `options` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups--variables--options))
+- `options` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--variables--options))
 - `process_input` (String)
 - `required` (Boolean)
 - `type` (String)
 - `value` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups--variables--options"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.configuration.custom_config.variable_groups.variables.options`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--variables--options"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.configuration.custom_config.variable_groups.variables.options`
 
 Read-Only:
 
@@ -16116,16 +16117,16 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--container_detail"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.container_detail`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--container_detail"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.container_detail`
 
 Read-Only:
 
 - `container_create_option` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--desc"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.desc`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--desc"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.desc`
 
 Read-Only:
 
@@ -16139,8 +16140,8 @@ Read-Only:
 - `support` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--images"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.images`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--images"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.images`
 
 Read-Only:
 
@@ -16152,14 +16153,14 @@ Read-Only:
 - `imagename` (String)
 - `maxsize` (String)
 - `mountpath` (String)
-- `params` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--images--params))
+- `params` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--images--params))
 - `preserve` (Boolean)
 - `readonly` (Boolean)
 - `target` (String)
 - `volumelabel` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--images--params"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.images.volumelabel`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--images--params"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.images.params`
 
 Read-Only:
 
@@ -16168,43 +16169,43 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--interfaces"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.interfaces`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--interfaces"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.interfaces`
 
 Read-Only:
 
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--interfaces--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls))
 - `directattach` (Boolean)
 - `name` (String)
 - `optional` (Boolean)
 - `privateip` (Boolean)
 - `type` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--interfaces--acls"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.interfaces.type`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--interfaces--type--actions))
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--interfaces--type--matches))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--interfaces--type--actions"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.interfaces.type.name`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.interfaces.acls.actions`
 
 Read-Only:
 
 - `drop` (Boolean)
 - `limit` (Boolean)
-- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--interfaces--type--name--limit_value))
+- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions--limit_value))
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
 - `portmap` (Boolean)
-- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--interfaces--type--name--portmapto))
+- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions--portmapto))
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--interfaces--type--name--limit_value"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions--limit_value"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.interfaces.acls.actions.limit_value`
 
 Read-Only:
 
@@ -16213,8 +16214,8 @@ Read-Only:
 - `limitunit` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--interfaces--type--name--portmapto"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions--portmapto"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.interfaces.acls.actions.portmapto`
 
 Read-Only:
 
@@ -16222,8 +16223,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--interfaces--type--matches"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.interfaces.type.name`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--matches"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.interfaces.acls.matches`
 
 Read-Only:
 
@@ -16233,8 +16234,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--module"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.module`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--module"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.module`
 
 Read-Only:
 
@@ -16244,8 +16245,8 @@ Read-Only:
 - `twin_detail` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--owner"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.owner`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--owner"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.owner`
 
 Read-Only:
 
@@ -16256,15 +16257,15 @@ Read-Only:
 - `website` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--permissions"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.permissions`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--permissions"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.permissions`
 
 Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--title--resources"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title.resources`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--manifest_json--resources"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.manifest_json.resources`
 
 Read-Only:
 
@@ -16274,7 +16275,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--module_policy--azure_edge_agent--parent_detail"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.title`
+### Nested Schema for `cloud_policy.module_policy.azure_edge_agent.parent_detail`
 
 Read-Only:
 
@@ -16312,18 +16313,18 @@ Read-Only:
 - `title` (String)
 
 <a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title`
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.interfaces`
 
 Read-Only:
 
 - `access_vlan_id` (Number)
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces--acls))
 - `default_net_instance` (Boolean)
 - `directattach` (Boolean)
-- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--eidregister))
+- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces--eidregister))
 - `intfname` (String)
 - `intforder` (Number)
-- `io` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--io))
+- `io` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces--io))
 - `ipaddr` (String)
 - `macaddr` (String)
 - `netinstid` (String)
@@ -16332,18 +16333,18 @@ Read-Only:
 - `netname` (String)
 - `privateip` (Boolean)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--acls"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.acls`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces--acls"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--acls--actions))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces--acls--actions))
 - `id` (Number)
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--acls--matches))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--acls--actions"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.acls.name`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces--acls--actions"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.interfaces.acls.actions`
 
 Read-Only:
 
@@ -16352,11 +16353,11 @@ Read-Only:
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
-- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--acls--name--mapparams))
+- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces--acls--actions--mapparams))
 - `portmap` (Boolean)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--acls--name--mapparams"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.acls.name.portmap`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces--acls--actions--mapparams"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.interfaces.acls.actions.mapparams`
 
 Read-Only:
 
@@ -16364,8 +16365,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--acls--matches"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.acls.name`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces--acls--matches"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.interfaces.acls.matches`
 
 Read-Only:
 
@@ -16374,8 +16375,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--eidregister"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.eidregister`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces--eidregister"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.interfaces.eidregister`
 
 Read-Only:
 
@@ -16386,12 +16387,12 @@ Read-Only:
 - `e_id` (String)
 - `e_id_hash_len` (Number)
 - `lisp_instance` (Number)
-- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--eidregister--lisp_map_servers))
+- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces--eidregister--lisp_map_servers))
 - `lisp_signature` (String)
 - `uuid` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--eidregister--lisp_map_servers"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.eidregister.uuid`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces--eidregister--lisp_map_servers"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.interfaces.eidregister.lisp_map_servers`
 
 Read-Only:
 
@@ -16400,8 +16401,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--io"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.io`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--interfaces--io"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.interfaces.io`
 
 Read-Only:
 
@@ -16412,39 +16413,39 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title`
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json`
 
 Read-Only:
 
 - `ac_kind` (String)
 - `ac_version` (String)
 - `app_type` (String)
-- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--configuration))
-- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--container_detail))
+- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--configuration))
+- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--container_detail))
 - `cpu_pinning_enabled` (Boolean)
 - `deployment_type` (String)
-- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--desc))
+- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--desc))
 - `description` (String)
 - `display_name` (String)
 - `enablevnc` (Boolean)
-- `images` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--images))
-- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--interfaces))
-- `module` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--module))
+- `images` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--images))
+- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--interfaces))
+- `module` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--module))
 - `name` (String)
-- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--owner))
-- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--permissions))
-- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--resources))
+- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--owner))
+- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--permissions))
+- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--resources))
 - `vmmode` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--configuration"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.configuration`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--configuration"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.configuration`
 
 Read-Only:
 
-- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--configuration--custom_config))
+- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config))
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--configuration--custom_config"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.configuration.custom_config`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.configuration.custom_config`
 
 Read-Only:
 
@@ -16454,20 +16455,20 @@ Read-Only:
 - `name` (String)
 - `override` (Boolean)
 - `template` (String)
-- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups))
+- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups))
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.configuration.custom_config.variable_groups`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.configuration.custom_config.variable_groups`
 
 Read-Only:
 
-- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups--condition))
+- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--condition))
 - `name` (String)
 - `required` (Boolean)
-- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups--variables))
+- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--variables))
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups--condition"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--condition"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.configuration.custom_config.variable_groups.condition`
 
 Read-Only:
 
@@ -16476,8 +16477,8 @@ Read-Only:
 - `value` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups--variables"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--variables"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.configuration.custom_config.variable_groups.variables`
 
 Read-Only:
 
@@ -16487,14 +16488,14 @@ Read-Only:
 - `label` (String)
 - `max_length` (String)
 - `name` (String)
-- `options` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups--variables--options))
+- `options` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--variables--options))
 - `process_input` (String)
 - `required` (Boolean)
 - `type` (String)
 - `value` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups--variables--options"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.configuration.custom_config.variable_groups.variables.options`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--variables--options"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.configuration.custom_config.variable_groups.variables.options`
 
 Read-Only:
 
@@ -16506,16 +16507,16 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--container_detail"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.container_detail`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--container_detail"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.container_detail`
 
 Read-Only:
 
 - `container_create_option` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--desc"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.desc`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--desc"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.desc`
 
 Read-Only:
 
@@ -16529,8 +16530,8 @@ Read-Only:
 - `support` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--images"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.images`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--images"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.images`
 
 Read-Only:
 
@@ -16542,14 +16543,14 @@ Read-Only:
 - `imagename` (String)
 - `maxsize` (String)
 - `mountpath` (String)
-- `params` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--images--params))
+- `params` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--images--params))
 - `preserve` (Boolean)
 - `readonly` (Boolean)
 - `target` (String)
 - `volumelabel` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--images--params"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.images.volumelabel`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--images--params"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.images.params`
 
 Read-Only:
 
@@ -16558,43 +16559,43 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--interfaces"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.interfaces`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--interfaces"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.interfaces`
 
 Read-Only:
 
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--interfaces--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls))
 - `directattach` (Boolean)
 - `name` (String)
 - `optional` (Boolean)
 - `privateip` (Boolean)
 - `type` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--interfaces--acls"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.interfaces.type`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--interfaces--type--actions))
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--interfaces--type--matches))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--interfaces--type--actions"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.interfaces.type.name`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.interfaces.acls.actions`
 
 Read-Only:
 
 - `drop` (Boolean)
 - `limit` (Boolean)
-- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--interfaces--type--name--limit_value))
+- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions--limit_value))
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
 - `portmap` (Boolean)
-- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--interfaces--type--name--portmapto))
+- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions--portmapto))
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--interfaces--type--name--limit_value"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions--limit_value"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.interfaces.acls.actions.limit_value`
 
 Read-Only:
 
@@ -16603,8 +16604,8 @@ Read-Only:
 - `limitunit` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--interfaces--type--name--portmapto"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions--portmapto"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.interfaces.acls.actions.portmapto`
 
 Read-Only:
 
@@ -16612,8 +16613,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--interfaces--type--matches"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.interfaces.type.name`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--matches"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.interfaces.acls.matches`
 
 Read-Only:
 
@@ -16623,8 +16624,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--module"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.module`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--module"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.module`
 
 Read-Only:
 
@@ -16634,8 +16635,8 @@ Read-Only:
 - `twin_detail` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--owner"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.owner`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--owner"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.owner`
 
 Read-Only:
 
@@ -16646,15 +16647,15 @@ Read-Only:
 - `website` (String)
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--permissions"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.permissions`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--permissions"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.permissions`
 
 Read-Only:
 
 
 
-<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--title--resources"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title.resources`
+<a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--manifest_json--resources"></a>
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.manifest_json.resources`
 
 Read-Only:
 
@@ -16664,7 +16665,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--module_policy--azure_edge_hub--parent_detail"></a>
-### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.title`
+### Nested Schema for `cloud_policy.module_policy.azure_edge_hub.parent_detail`
 
 Read-Only:
 
@@ -16723,7 +16724,7 @@ Read-Only:
 - `type` (String)
 
 <a id="nestedobjatt--cloud_policy--network_policy--net_instance_config--dns_list"></a>
-### Nested Schema for `cloud_policy.network_policy.net_instance_config.type`
+### Nested Schema for `cloud_policy.network_policy.net_instance_config.dns_list`
 
 Read-Only:
 
@@ -16732,11 +16733,11 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--network_policy--net_instance_config--ip"></a>
-### Nested Schema for `cloud_policy.network_policy.net_instance_config.type`
+### Nested Schema for `cloud_policy.network_policy.net_instance_config.ip`
 
 Read-Only:
 
-- `dhcp_range` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--network_policy--net_instance_config--type--dhcp_range))
+- `dhcp_range` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--network_policy--net_instance_config--ip--dhcp_range))
 - `dns` (List of String)
 - `domain` (String)
 - `gateway` (String)
@@ -16744,8 +16745,8 @@ Read-Only:
 - `ntp` (String)
 - `subnet` (String)
 
-<a id="nestedobjatt--cloud_policy--network_policy--net_instance_config--type--dhcp_range"></a>
-### Nested Schema for `cloud_policy.network_policy.net_instance_config.type.dhcp_range`
+<a id="nestedobjatt--cloud_policy--network_policy--net_instance_config--ip--dhcp_range"></a>
+### Nested Schema for `cloud_policy.network_policy.net_instance_config.ip.dhcp_range`
 
 Read-Only:
 
@@ -16755,7 +16756,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--network_policy--net_instance_config--lisp"></a>
-### Nested Schema for `cloud_policy.network_policy.net_instance_config.type`
+### Nested Schema for `cloud_policy.network_policy.net_instance_config.lisp`
 
 Read-Only:
 
@@ -16764,10 +16765,10 @@ Read-Only:
 - `allocationprefixlen` (Number)
 - `exportprivate` (Boolean)
 - `lispiid` (Number)
-- `sp` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--network_policy--net_instance_config--type--sp))
+- `sp` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--network_policy--net_instance_config--lisp--sp))
 
-<a id="nestedobjatt--cloud_policy--network_policy--net_instance_config--type--sp"></a>
-### Nested Schema for `cloud_policy.network_policy.net_instance_config.type.sp`
+<a id="nestedobjatt--cloud_policy--network_policy--net_instance_config--lisp--sp"></a>
+### Nested Schema for `cloud_policy.network_policy.net_instance_config.lisp.sp`
 
 Read-Only:
 
@@ -16778,16 +16779,16 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--network_policy--net_instance_config--opaque"></a>
-### Nested Schema for `cloud_policy.network_policy.net_instance_config.type`
+### Nested Schema for `cloud_policy.network_policy.net_instance_config.opaque`
 
 Read-Only:
 
-- `lisp` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--network_policy--net_instance_config--type--lisp))
+- `lisp` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--network_policy--net_instance_config--opaque--lisp))
 - `oconfig` (String)
 - `type` (String)
 
-<a id="nestedobjatt--cloud_policy--network_policy--net_instance_config--type--lisp"></a>
-### Nested Schema for `cloud_policy.network_policy.net_instance_config.type.lisp`
+<a id="nestedobjatt--cloud_policy--network_policy--net_instance_config--opaque--lisp"></a>
+### Nested Schema for `cloud_policy.network_policy.net_instance_config.opaque.lisp`
 
 Read-Only:
 
@@ -16796,10 +16797,10 @@ Read-Only:
 - `allocationprefixlen` (Number)
 - `exportprivate` (Boolean)
 - `lispiid` (Number)
-- `sp` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--network_policy--net_instance_config--type--lisp--sp))
+- `sp` (List of Object) (see [below for nested schema](#nestedobjatt--cloud_policy--network_policy--net_instance_config--opaque--lisp--sp))
 
-<a id="nestedobjatt--cloud_policy--network_policy--net_instance_config--type--lisp--sp"></a>
-### Nested Schema for `cloud_policy.network_policy.net_instance_config.type.lisp.sp`
+<a id="nestedobjatt--cloud_policy--network_policy--net_instance_config--opaque--lisp--sp"></a>
+### Nested Schema for `cloud_policy.network_policy.net_instance_config.opaque.lisp.sp`
 
 Read-Only:
 
@@ -16811,7 +16812,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--network_policy--net_instance_config--revision"></a>
-### Nested Schema for `cloud_policy.network_policy.net_instance_config.type`
+### Nested Schema for `cloud_policy.network_policy.net_instance_config.revision`
 
 Read-Only:
 
@@ -16824,7 +16825,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--cloud_policy--network_policy--net_instance_config--static_routes"></a>
-### Nested Schema for `cloud_policy.network_policy.net_instance_config.type`
+### Nested Schema for `cloud_policy.network_policy.net_instance_config.static_routes`
 
 Read-Only:
 
@@ -16906,18 +16907,18 @@ Read-Only:
 - `title` (String)
 
 <a id="nestedobjatt--module_policy--app_policy--apps--interfaces"></a>
-### Nested Schema for `module_policy.app_policy.apps.title`
+### Nested Schema for `module_policy.app_policy.apps.interfaces`
 
 Read-Only:
 
 - `access_vlan_id` (Number)
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--interfaces--acls))
 - `default_net_instance` (Boolean)
 - `directattach` (Boolean)
-- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--eidregister))
+- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--interfaces--eidregister))
 - `intfname` (String)
 - `intforder` (Number)
-- `io` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--io))
+- `io` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--interfaces--io))
 - `ipaddr` (String)
 - `macaddr` (String)
 - `netinstid` (String)
@@ -16926,18 +16927,18 @@ Read-Only:
 - `netname` (String)
 - `privateip` (Boolean)
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--acls"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.acls`
+<a id="nestedobjatt--module_policy--app_policy--apps--interfaces--acls"></a>
+### Nested Schema for `module_policy.app_policy.apps.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--acls--actions))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--interfaces--acls--actions))
 - `id` (Number)
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--acls--matches))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--acls--actions"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.acls.name`
+<a id="nestedobjatt--module_policy--app_policy--apps--interfaces--acls--actions"></a>
+### Nested Schema for `module_policy.app_policy.apps.interfaces.acls.actions`
 
 Read-Only:
 
@@ -16946,11 +16947,11 @@ Read-Only:
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
-- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--acls--name--mapparams))
+- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--interfaces--acls--actions--mapparams))
 - `portmap` (Boolean)
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--acls--name--mapparams"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.acls.name.portmap`
+<a id="nestedobjatt--module_policy--app_policy--apps--interfaces--acls--actions--mapparams"></a>
+### Nested Schema for `module_policy.app_policy.apps.interfaces.acls.actions.mapparams`
 
 Read-Only:
 
@@ -16958,8 +16959,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--acls--matches"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.acls.name`
+<a id="nestedobjatt--module_policy--app_policy--apps--interfaces--acls--matches"></a>
+### Nested Schema for `module_policy.app_policy.apps.interfaces.acls.matches`
 
 Read-Only:
 
@@ -16968,8 +16969,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--eidregister"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.eidregister`
+<a id="nestedobjatt--module_policy--app_policy--apps--interfaces--eidregister"></a>
+### Nested Schema for `module_policy.app_policy.apps.interfaces.eidregister`
 
 Read-Only:
 
@@ -16980,12 +16981,12 @@ Read-Only:
 - `e_id` (String)
 - `e_id_hash_len` (Number)
 - `lisp_instance` (Number)
-- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--eidregister--lisp_map_servers))
+- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--interfaces--eidregister--lisp_map_servers))
 - `lisp_signature` (String)
 - `uuid` (String)
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--eidregister--lisp_map_servers"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.eidregister.uuid`
+<a id="nestedobjatt--module_policy--app_policy--apps--interfaces--eidregister--lisp_map_servers"></a>
+### Nested Schema for `module_policy.app_policy.apps.interfaces.eidregister.lisp_map_servers`
 
 Read-Only:
 
@@ -16994,8 +16995,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--io"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.io`
+<a id="nestedobjatt--module_policy--app_policy--apps--interfaces--io"></a>
+### Nested Schema for `module_policy.app_policy.apps.interfaces.io`
 
 Read-Only:
 
@@ -17006,39 +17007,39 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--app_policy--apps--manifest_json"></a>
-### Nested Schema for `module_policy.app_policy.apps.title`
+### Nested Schema for `module_policy.app_policy.apps.manifest_json`
 
 Read-Only:
 
 - `ac_kind` (String)
 - `ac_version` (String)
 - `app_type` (String)
-- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--configuration))
-- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--container_detail))
+- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--configuration))
+- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--container_detail))
 - `cpu_pinning_enabled` (Boolean)
 - `deployment_type` (String)
-- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--desc))
+- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--desc))
 - `description` (String)
 - `display_name` (String)
 - `enablevnc` (Boolean)
-- `images` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--images))
-- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--interfaces))
-- `module` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--module))
+- `images` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--images))
+- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--interfaces))
+- `module` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--module))
 - `name` (String)
-- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--owner))
-- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--permissions))
-- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--resources))
+- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--owner))
+- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--permissions))
+- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--resources))
 - `vmmode` (String)
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--configuration"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.configuration`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--configuration"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.configuration`
 
 Read-Only:
 
-- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--configuration--custom_config))
+- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--configuration--custom_config))
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--configuration--custom_config"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.configuration.custom_config`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--configuration--custom_config"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.configuration.custom_config`
 
 Read-Only:
 
@@ -17048,20 +17049,20 @@ Read-Only:
 - `name` (String)
 - `override` (Boolean)
 - `template` (String)
-- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--configuration--custom_config--variable_groups))
+- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups))
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--configuration--custom_config--variable_groups"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.configuration.custom_config.variable_groups`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.configuration.custom_config.variable_groups`
 
 Read-Only:
 
-- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--configuration--custom_config--variable_groups--condition))
+- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--condition))
 - `name` (String)
 - `required` (Boolean)
-- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--configuration--custom_config--variable_groups--variables))
+- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables))
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--configuration--custom_config--variable_groups--condition"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--condition"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.configuration.custom_config.variable_groups.condition`
 
 Read-Only:
 
@@ -17070,8 +17071,8 @@ Read-Only:
 - `value` (String)
 
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--configuration--custom_config--variable_groups--variables"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.configuration.custom_config.variable_groups.variables`
 
 Read-Only:
 
@@ -17081,14 +17082,14 @@ Read-Only:
 - `label` (String)
 - `max_length` (String)
 - `name` (String)
-- `options` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--configuration--custom_config--variable_groups--variables--options))
+- `options` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables--options))
 - `process_input` (String)
 - `required` (Boolean)
 - `type` (String)
 - `value` (String)
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--configuration--custom_config--variable_groups--variables--options"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.configuration.custom_config.variable_groups.variables.options`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables--options"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.configuration.custom_config.variable_groups.variables.options`
 
 Read-Only:
 
@@ -17100,16 +17101,16 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--container_detail"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.container_detail`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--container_detail"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.container_detail`
 
 Read-Only:
 
 - `container_create_option` (String)
 
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--desc"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.desc`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--desc"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.desc`
 
 Read-Only:
 
@@ -17123,8 +17124,8 @@ Read-Only:
 - `support` (String)
 
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--images"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.images`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--images"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.images`
 
 Read-Only:
 
@@ -17136,14 +17137,14 @@ Read-Only:
 - `imagename` (String)
 - `maxsize` (String)
 - `mountpath` (String)
-- `params` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--images--params))
+- `params` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--images--params))
 - `preserve` (Boolean)
 - `readonly` (Boolean)
 - `target` (String)
 - `volumelabel` (String)
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--images--params"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.images.volumelabel`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--images--params"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.images.params`
 
 Read-Only:
 
@@ -17152,43 +17153,43 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--interfaces"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.interfaces`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--interfaces"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.interfaces`
 
 Read-Only:
 
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--interfaces--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--interfaces--acls))
 - `directattach` (Boolean)
 - `name` (String)
 - `optional` (Boolean)
 - `privateip` (Boolean)
 - `type` (String)
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--interfaces--acls"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.interfaces.type`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--interfaces--acls"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--interfaces--type--actions))
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--interfaces--type--matches))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--interfaces--acls--actions))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--interfaces--type--actions"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.interfaces.type.name`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--interfaces--acls--actions"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.interfaces.acls.actions`
 
 Read-Only:
 
 - `drop` (Boolean)
 - `limit` (Boolean)
-- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--interfaces--type--name--limit_value))
+- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--interfaces--acls--actions--limit_value))
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
 - `portmap` (Boolean)
-- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--title--interfaces--type--name--portmapto))
+- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--app_policy--apps--manifest_json--interfaces--acls--actions--portmapto))
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--interfaces--type--name--limit_value"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--interfaces--acls--actions--limit_value"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.interfaces.acls.actions.limit_value`
 
 Read-Only:
 
@@ -17197,8 +17198,8 @@ Read-Only:
 - `limitunit` (String)
 
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--interfaces--type--name--portmapto"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--interfaces--acls--actions--portmapto"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.interfaces.acls.actions.portmapto`
 
 Read-Only:
 
@@ -17206,8 +17207,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--interfaces--type--matches"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.interfaces.type.name`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--interfaces--acls--matches"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.interfaces.acls.matches`
 
 Read-Only:
 
@@ -17217,8 +17218,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--module"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.module`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--module"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.module`
 
 Read-Only:
 
@@ -17228,8 +17229,8 @@ Read-Only:
 - `twin_detail` (String)
 
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--owner"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.owner`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--owner"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.owner`
 
 Read-Only:
 
@@ -17240,15 +17241,15 @@ Read-Only:
 - `website` (String)
 
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--permissions"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.permissions`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--permissions"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.permissions`
 
 Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--app_policy--apps--title--resources"></a>
-### Nested Schema for `module_policy.app_policy.apps.title.resources`
+<a id="nestedobjatt--module_policy--app_policy--apps--manifest_json--resources"></a>
+### Nested Schema for `module_policy.app_policy.apps.manifest_json.resources`
 
 Read-Only:
 
@@ -17258,7 +17259,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--app_policy--apps--parent_detail"></a>
-### Nested Schema for `module_policy.app_policy.apps.title`
+### Nested Schema for `module_policy.app_policy.apps.parent_detail`
 
 Read-Only:
 
@@ -17303,38 +17304,38 @@ Read-Only:
 - `resource_group` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group))
 
 <a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service"></a>
-### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.resource_group`
+### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.dps_service`
 
 Read-Only:
 
-- `enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--enrollment))
-- `service_detail` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--service_detail))
+- `enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--enrollment))
+- `service_detail` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--service_detail))
 
-<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--enrollment"></a>
-### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.resource_group.enrollment`
+<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--enrollment"></a>
+### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.dps_service.enrollment`
 
 Read-Only:
 
 - `allocation_policy` (String)
 - `attached_iot_hubs_name` (List of String)
-- `certificate_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--certificate_enrollment))
+- `certificate_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--certificate_enrollment))
 - `enable_iot_edge_device` (Boolean)
 - `mechanism` (String)
-- `symmetric_key_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--symmetric_key_enrollment))
+- `symmetric_key_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment))
 - `tags` (Map of String)
-- `tpm_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment))
+- `tpm_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--tpm_enrollment))
 
-<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--certificate_enrollment"></a>
-### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.resource_group.enrollment.tpm_enrollment`
+<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--certificate_enrollment"></a>
+### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.certificate_enrollment`
 
 Read-Only:
 
-- `group_certificate_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment--group_certificate_enrollment))
+- `group_certificate_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--certificate_enrollment--group_certificate_enrollment))
 - `individual_certificate_enrollment` (String)
 - `type` (String)
 
-<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment--group_certificate_enrollment"></a>
-### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.resource_group.enrollment.tpm_enrollment.type`
+<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--certificate_enrollment--group_certificate_enrollment"></a>
+### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.certificate_enrollment.group_certificate_enrollment`
 
 Read-Only:
 
@@ -17342,25 +17343,25 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--symmetric_key_enrollment"></a>
-### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.resource_group.enrollment.tpm_enrollment`
+<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment"></a>
+### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.symmetric_key_enrollment`
 
 Read-Only:
 
-- `group_symmetric_key_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment--group_symmetric_key_enrollment))
-- `individual_symmetric_key_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment--individual_symmetric_key_enrollment))
+- `group_symmetric_key_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment--group_symmetric_key_enrollment))
+- `individual_symmetric_key_enrollment` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment--individual_symmetric_key_enrollment))
 - `type` (String)
 
-<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment--group_symmetric_key_enrollment"></a>
-### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.resource_group.enrollment.tpm_enrollment.type`
+<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment--group_symmetric_key_enrollment"></a>
+### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.symmetric_key_enrollment.group_symmetric_key_enrollment`
 
 Read-Only:
 
 - `group_name` (String)
 
 
-<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment--individual_symmetric_key_enrollment"></a>
-### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.resource_group.enrollment.tpm_enrollment.type`
+<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--symmetric_key_enrollment--individual_symmetric_key_enrollment"></a>
+### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.symmetric_key_enrollment.individual_symmetric_key_enrollment`
 
 Read-Only:
 
@@ -17368,8 +17369,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--enrollment--tpm_enrollment"></a>
-### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.resource_group.enrollment.tpm_enrollment`
+<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--enrollment--tpm_enrollment"></a>
+### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.dps_service.enrollment.tpm_enrollment`
 
 Read-Only:
 
@@ -17377,8 +17378,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--service_detail"></a>
-### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.resource_group.service_detail`
+<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--service_detail"></a>
+### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.dps_service.service_detail`
 
 Read-Only:
 
@@ -17386,11 +17387,11 @@ Read-Only:
 - `name` (String)
 - `region` (String)
 - `resource_group_name` (String)
-- `s_k_u` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--service_detail--s_k_u))
+- `s_k_u` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--service_detail--s_k_u))
 - `subscription_id` (String)
 
-<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--service_detail--s_k_u"></a>
-### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.resource_group.service_detail.subscription_id`
+<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--dps_service--service_detail--s_k_u"></a>
+### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.dps_service.service_detail.s_k_u`
 
 Read-Only:
 
@@ -17402,14 +17403,14 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--iot_hub_service"></a>
-### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.resource_group`
+### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.iot_hub_service`
 
 Read-Only:
 
-- `service_detail` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--service_detail))
+- `service_detail` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--iot_hub_service--service_detail))
 
-<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--service_detail"></a>
-### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.resource_group.service_detail`
+<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--iot_hub_service--service_detail"></a>
+### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.iot_hub_service.service_detail`
 
 Read-Only:
 
@@ -17417,11 +17418,11 @@ Read-Only:
 - `name` (String)
 - `region` (String)
 - `resource_group_name` (String)
-- `s_k_u` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--service_detail--s_k_u))
+- `s_k_u` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--azure_policy--azure_resource_and_services--iot_hub_service--service_detail--s_k_u))
 - `subscription_id` (String)
 
-<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--resource_group--service_detail--s_k_u"></a>
-### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.resource_group.service_detail.subscription_id`
+<a id="nestedobjatt--module_policy--azure_policy--azure_resource_and_services--iot_hub_service--service_detail--s_k_u"></a>
+### Nested Schema for `module_policy.azure_policy.azure_resource_and_services.iot_hub_service.service_detail.s_k_u`
 
 Read-Only:
 
@@ -17471,7 +17472,7 @@ Read-Only:
 - `valid_till` (String)
 
 <a id="nestedobjatt--module_policy--azure_policy--certificate--ecdsa_encryption"></a>
-### Nested Schema for `module_policy.azure_policy.certificate.valid_till`
+### Nested Schema for `module_policy.azure_policy.certificate.ecdsa_encryption`
 
 Read-Only:
 
@@ -17479,7 +17480,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--azure_policy--certificate--issuer"></a>
-### Nested Schema for `module_policy.azure_policy.certificate.valid_till`
+### Nested Schema for `module_policy.azure_policy.certificate.issuer`
 
 Read-Only:
 
@@ -17494,7 +17495,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--azure_policy--certificate--rsa_ecryption"></a>
-### Nested Schema for `module_policy.azure_policy.certificate.valid_till`
+### Nested Schema for `module_policy.azure_policy.certificate.rsa_ecryption`
 
 Read-Only:
 
@@ -17502,7 +17503,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--azure_policy--certificate--san_values"></a>
-### Nested Schema for `module_policy.azure_policy.certificate.valid_till`
+### Nested Schema for `module_policy.azure_policy.certificate.san_values`
 
 Read-Only:
 
@@ -17515,7 +17516,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--azure_policy--certificate--subject"></a>
-### Nested Schema for `module_policy.azure_policy.certificate.valid_till`
+### Nested Schema for `module_policy.azure_policy.certificate.subject`
 
 Read-Only:
 
@@ -17583,7 +17584,7 @@ Read-Only:
 - `token` (String)
 
 <a id="nestedobjatt--module_policy--edgeview_policy--edgeviewcfg--app_policy"></a>
-### Nested Schema for `module_policy.edgeview_policy.edgeviewcfg.token`
+### Nested Schema for `module_policy.edgeview_policy.edgeviewcfg.app_policy`
 
 Read-Only:
 
@@ -17591,7 +17592,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--edgeview_policy--edgeviewcfg--dev_policy"></a>
-### Nested Schema for `module_policy.edgeview_policy.edgeviewcfg.token`
+### Nested Schema for `module_policy.edgeview_policy.edgeviewcfg.dev_policy`
 
 Read-Only:
 
@@ -17599,7 +17600,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--edgeview_policy--edgeviewcfg--ext_policy"></a>
-### Nested Schema for `module_policy.edgeview_policy.edgeviewcfg.token`
+### Nested Schema for `module_policy.edgeview_policy.edgeviewcfg.ext_policy`
 
 Read-Only:
 
@@ -17607,7 +17608,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--edgeview_policy--edgeviewcfg--jwt_info"></a>
-### Nested Schema for `module_policy.edgeview_policy.edgeviewcfg.token`
+### Nested Schema for `module_policy.edgeview_policy.edgeviewcfg.jwt_info`
 
 Read-Only:
 
@@ -17673,18 +17674,18 @@ Read-Only:
 - `title` (String)
 
 <a id="nestedobjatt--module_policy--module_policy--apps--interfaces"></a>
-### Nested Schema for `module_policy.module_policy.apps.title`
+### Nested Schema for `module_policy.module_policy.apps.interfaces`
 
 Read-Only:
 
 - `access_vlan_id` (Number)
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--interfaces--acls))
 - `default_net_instance` (Boolean)
 - `directattach` (Boolean)
-- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--eidregister))
+- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--interfaces--eidregister))
 - `intfname` (String)
 - `intforder` (Number)
-- `io` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--io))
+- `io` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--interfaces--io))
 - `ipaddr` (String)
 - `macaddr` (String)
 - `netinstid` (String)
@@ -17693,18 +17694,18 @@ Read-Only:
 - `netname` (String)
 - `privateip` (Boolean)
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--acls"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.acls`
+<a id="nestedobjatt--module_policy--module_policy--apps--interfaces--acls"></a>
+### Nested Schema for `module_policy.module_policy.apps.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--acls--actions))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--interfaces--acls--actions))
 - `id` (Number)
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--acls--matches))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--acls--actions"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.acls.name`
+<a id="nestedobjatt--module_policy--module_policy--apps--interfaces--acls--actions"></a>
+### Nested Schema for `module_policy.module_policy.apps.interfaces.acls.actions`
 
 Read-Only:
 
@@ -17713,11 +17714,11 @@ Read-Only:
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
-- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--acls--name--mapparams))
+- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--interfaces--acls--actions--mapparams))
 - `portmap` (Boolean)
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--acls--name--mapparams"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.acls.name.portmap`
+<a id="nestedobjatt--module_policy--module_policy--apps--interfaces--acls--actions--mapparams"></a>
+### Nested Schema for `module_policy.module_policy.apps.interfaces.acls.actions.mapparams`
 
 Read-Only:
 
@@ -17725,8 +17726,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--acls--matches"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.acls.name`
+<a id="nestedobjatt--module_policy--module_policy--apps--interfaces--acls--matches"></a>
+### Nested Schema for `module_policy.module_policy.apps.interfaces.acls.matches`
 
 Read-Only:
 
@@ -17735,8 +17736,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--eidregister"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.eidregister`
+<a id="nestedobjatt--module_policy--module_policy--apps--interfaces--eidregister"></a>
+### Nested Schema for `module_policy.module_policy.apps.interfaces.eidregister`
 
 Read-Only:
 
@@ -17747,12 +17748,12 @@ Read-Only:
 - `e_id` (String)
 - `e_id_hash_len` (Number)
 - `lisp_instance` (Number)
-- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--eidregister--lisp_map_servers))
+- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--interfaces--eidregister--lisp_map_servers))
 - `lisp_signature` (String)
 - `uuid` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--eidregister--lisp_map_servers"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.eidregister.uuid`
+<a id="nestedobjatt--module_policy--module_policy--apps--interfaces--eidregister--lisp_map_servers"></a>
+### Nested Schema for `module_policy.module_policy.apps.interfaces.eidregister.lisp_map_servers`
 
 Read-Only:
 
@@ -17761,8 +17762,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--io"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.io`
+<a id="nestedobjatt--module_policy--module_policy--apps--interfaces--io"></a>
+### Nested Schema for `module_policy.module_policy.apps.interfaces.io`
 
 Read-Only:
 
@@ -17773,39 +17774,39 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--module_policy--apps--manifest_json"></a>
-### Nested Schema for `module_policy.module_policy.apps.title`
+### Nested Schema for `module_policy.module_policy.apps.manifest_json`
 
 Read-Only:
 
 - `ac_kind` (String)
 - `ac_version` (String)
 - `app_type` (String)
-- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--configuration))
-- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--container_detail))
+- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--configuration))
+- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--container_detail))
 - `cpu_pinning_enabled` (Boolean)
 - `deployment_type` (String)
-- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--desc))
+- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--desc))
 - `description` (String)
 - `display_name` (String)
 - `enablevnc` (Boolean)
-- `images` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--images))
-- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--interfaces))
-- `module` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--module))
+- `images` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--images))
+- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--interfaces))
+- `module` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--module))
 - `name` (String)
-- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--owner))
-- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--permissions))
-- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--resources))
+- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--owner))
+- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--permissions))
+- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--resources))
 - `vmmode` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--configuration"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.configuration`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--configuration"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.configuration`
 
 Read-Only:
 
-- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--configuration--custom_config))
+- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--configuration--custom_config))
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--configuration--custom_config"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.configuration.custom_config`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--configuration--custom_config"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.configuration.custom_config`
 
 Read-Only:
 
@@ -17815,20 +17816,20 @@ Read-Only:
 - `name` (String)
 - `override` (Boolean)
 - `template` (String)
-- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--configuration--custom_config--variable_groups))
+- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups))
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--configuration--custom_config--variable_groups"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.configuration.custom_config.variable_groups`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.configuration.custom_config.variable_groups`
 
 Read-Only:
 
-- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--configuration--custom_config--variable_groups--condition))
+- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--condition))
 - `name` (String)
 - `required` (Boolean)
-- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--configuration--custom_config--variable_groups--variables))
+- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables))
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--configuration--custom_config--variable_groups--condition"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--condition"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.configuration.custom_config.variable_groups.condition`
 
 Read-Only:
 
@@ -17837,8 +17838,8 @@ Read-Only:
 - `value` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--configuration--custom_config--variable_groups--variables"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.configuration.custom_config.variable_groups.variables`
 
 Read-Only:
 
@@ -17848,14 +17849,14 @@ Read-Only:
 - `label` (String)
 - `max_length` (String)
 - `name` (String)
-- `options` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--configuration--custom_config--variable_groups--variables--options))
+- `options` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables--options))
 - `process_input` (String)
 - `required` (Boolean)
 - `type` (String)
 - `value` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--configuration--custom_config--variable_groups--variables--options"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.configuration.custom_config.variable_groups.variables.options`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--configuration--custom_config--variable_groups--variables--options"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.configuration.custom_config.variable_groups.variables.options`
 
 Read-Only:
 
@@ -17867,16 +17868,16 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--container_detail"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.container_detail`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--container_detail"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.container_detail`
 
 Read-Only:
 
 - `container_create_option` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--desc"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.desc`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--desc"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.desc`
 
 Read-Only:
 
@@ -17890,8 +17891,8 @@ Read-Only:
 - `support` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--images"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.images`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--images"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.images`
 
 Read-Only:
 
@@ -17903,14 +17904,14 @@ Read-Only:
 - `imagename` (String)
 - `maxsize` (String)
 - `mountpath` (String)
-- `params` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--images--params))
+- `params` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--images--params))
 - `preserve` (Boolean)
 - `readonly` (Boolean)
 - `target` (String)
 - `volumelabel` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--images--params"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.images.volumelabel`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--images--params"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.images.params`
 
 Read-Only:
 
@@ -17919,43 +17920,43 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--interfaces"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.interfaces`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--interfaces"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.interfaces`
 
 Read-Only:
 
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--interfaces--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--interfaces--acls))
 - `directattach` (Boolean)
 - `name` (String)
 - `optional` (Boolean)
 - `privateip` (Boolean)
 - `type` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--interfaces--acls"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.interfaces.type`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--interfaces--acls"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--interfaces--type--actions))
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--interfaces--type--matches))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--interfaces--acls--actions))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--interfaces--type--actions"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.interfaces.type.name`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--interfaces--acls--actions"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.interfaces.acls.actions`
 
 Read-Only:
 
 - `drop` (Boolean)
 - `limit` (Boolean)
-- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--interfaces--type--name--limit_value))
+- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--interfaces--acls--actions--limit_value))
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
 - `portmap` (Boolean)
-- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--title--interfaces--type--name--portmapto))
+- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--apps--manifest_json--interfaces--acls--actions--portmapto))
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--interfaces--type--name--limit_value"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--interfaces--acls--actions--limit_value"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.interfaces.acls.actions.limit_value`
 
 Read-Only:
 
@@ -17964,8 +17965,8 @@ Read-Only:
 - `limitunit` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--interfaces--type--name--portmapto"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--interfaces--acls--actions--portmapto"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.interfaces.acls.actions.portmapto`
 
 Read-Only:
 
@@ -17973,8 +17974,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--interfaces--type--matches"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.interfaces.type.name`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--interfaces--acls--matches"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.interfaces.acls.matches`
 
 Read-Only:
 
@@ -17984,8 +17985,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--module"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.module`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--module"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.module`
 
 Read-Only:
 
@@ -17995,8 +17996,8 @@ Read-Only:
 - `twin_detail` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--owner"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.owner`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--owner"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.owner`
 
 Read-Only:
 
@@ -18007,15 +18008,15 @@ Read-Only:
 - `website` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--permissions"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.permissions`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--permissions"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.permissions`
 
 Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--apps--title--resources"></a>
-### Nested Schema for `module_policy.module_policy.apps.title.resources`
+<a id="nestedobjatt--module_policy--module_policy--apps--manifest_json--resources"></a>
+### Nested Schema for `module_policy.module_policy.apps.manifest_json.resources`
 
 Read-Only:
 
@@ -18025,7 +18026,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--module_policy--apps--parent_detail"></a>
-### Nested Schema for `module_policy.module_policy.apps.title`
+### Nested Schema for `module_policy.module_policy.apps.parent_detail`
 
 Read-Only:
 
@@ -18063,18 +18064,18 @@ Read-Only:
 - `title` (String)
 
 <a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title`
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.interfaces`
 
 Read-Only:
 
 - `access_vlan_id` (Number)
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces--acls))
 - `default_net_instance` (Boolean)
 - `directattach` (Boolean)
-- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--eidregister))
+- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces--eidregister))
 - `intfname` (String)
 - `intforder` (Number)
-- `io` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--io))
+- `io` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces--io))
 - `ipaddr` (String)
 - `macaddr` (String)
 - `netinstid` (String)
@@ -18083,18 +18084,18 @@ Read-Only:
 - `netname` (String)
 - `privateip` (Boolean)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--acls"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.acls`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces--acls"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--acls--actions))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces--acls--actions))
 - `id` (Number)
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--acls--matches))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--acls--actions"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.acls.name`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces--acls--actions"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.interfaces.acls.actions`
 
 Read-Only:
 
@@ -18103,11 +18104,11 @@ Read-Only:
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
-- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--acls--name--mapparams))
+- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces--acls--actions--mapparams))
 - `portmap` (Boolean)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--acls--name--mapparams"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.acls.name.portmap`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces--acls--actions--mapparams"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.interfaces.acls.actions.mapparams`
 
 Read-Only:
 
@@ -18115,8 +18116,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--acls--matches"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.acls.name`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces--acls--matches"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.interfaces.acls.matches`
 
 Read-Only:
 
@@ -18125,8 +18126,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--eidregister"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.eidregister`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces--eidregister"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.interfaces.eidregister`
 
 Read-Only:
 
@@ -18137,12 +18138,12 @@ Read-Only:
 - `e_id` (String)
 - `e_id_hash_len` (Number)
 - `lisp_instance` (Number)
-- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--eidregister--lisp_map_servers))
+- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces--eidregister--lisp_map_servers))
 - `lisp_signature` (String)
 - `uuid` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--eidregister--lisp_map_servers"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.eidregister.uuid`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces--eidregister--lisp_map_servers"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.interfaces.eidregister.lisp_map_servers`
 
 Read-Only:
 
@@ -18151,8 +18152,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--io"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.io`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--interfaces--io"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.interfaces.io`
 
 Read-Only:
 
@@ -18163,39 +18164,39 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title`
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json`
 
 Read-Only:
 
 - `ac_kind` (String)
 - `ac_version` (String)
 - `app_type` (String)
-- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--configuration))
-- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--container_detail))
+- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--configuration))
+- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--container_detail))
 - `cpu_pinning_enabled` (Boolean)
 - `deployment_type` (String)
-- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--desc))
+- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--desc))
 - `description` (String)
 - `display_name` (String)
 - `enablevnc` (Boolean)
-- `images` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--images))
-- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--interfaces))
-- `module` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--module))
+- `images` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--images))
+- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--interfaces))
+- `module` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--module))
 - `name` (String)
-- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--owner))
-- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--permissions))
-- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--resources))
+- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--owner))
+- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--permissions))
+- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--resources))
 - `vmmode` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--configuration"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.configuration`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--configuration"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.configuration`
 
 Read-Only:
 
-- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--configuration--custom_config))
+- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config))
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--configuration--custom_config"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.configuration.custom_config`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.configuration.custom_config`
 
 Read-Only:
 
@@ -18205,20 +18206,20 @@ Read-Only:
 - `name` (String)
 - `override` (Boolean)
 - `template` (String)
-- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups))
+- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups))
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.configuration.custom_config.variable_groups`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.configuration.custom_config.variable_groups`
 
 Read-Only:
 
-- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups--condition))
+- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--condition))
 - `name` (String)
 - `required` (Boolean)
-- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups--variables))
+- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--variables))
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups--condition"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--condition"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.configuration.custom_config.variable_groups.condition`
 
 Read-Only:
 
@@ -18227,8 +18228,8 @@ Read-Only:
 - `value` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups--variables"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--variables"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.configuration.custom_config.variable_groups.variables`
 
 Read-Only:
 
@@ -18238,14 +18239,14 @@ Read-Only:
 - `label` (String)
 - `max_length` (String)
 - `name` (String)
-- `options` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups--variables--options))
+- `options` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--variables--options))
 - `process_input` (String)
 - `required` (Boolean)
 - `type` (String)
 - `value` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--configuration--custom_config--variable_groups--variables--options"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.configuration.custom_config.variable_groups.variables.options`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--configuration--custom_config--variable_groups--variables--options"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.configuration.custom_config.variable_groups.variables.options`
 
 Read-Only:
 
@@ -18257,16 +18258,16 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--container_detail"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.container_detail`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--container_detail"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.container_detail`
 
 Read-Only:
 
 - `container_create_option` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--desc"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.desc`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--desc"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.desc`
 
 Read-Only:
 
@@ -18280,8 +18281,8 @@ Read-Only:
 - `support` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--images"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.images`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--images"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.images`
 
 Read-Only:
 
@@ -18293,14 +18294,14 @@ Read-Only:
 - `imagename` (String)
 - `maxsize` (String)
 - `mountpath` (String)
-- `params` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--images--params))
+- `params` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--images--params))
 - `preserve` (Boolean)
 - `readonly` (Boolean)
 - `target` (String)
 - `volumelabel` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--images--params"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.images.volumelabel`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--images--params"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.images.params`
 
 Read-Only:
 
@@ -18309,43 +18310,43 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--interfaces"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.interfaces`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--interfaces"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.interfaces`
 
 Read-Only:
 
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--interfaces--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls))
 - `directattach` (Boolean)
 - `name` (String)
 - `optional` (Boolean)
 - `privateip` (Boolean)
 - `type` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--interfaces--acls"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.interfaces.type`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--interfaces--type--actions))
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--interfaces--type--matches))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--interfaces--type--actions"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.interfaces.type.name`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.interfaces.acls.actions`
 
 Read-Only:
 
 - `drop` (Boolean)
 - `limit` (Boolean)
-- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--interfaces--type--name--limit_value))
+- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions--limit_value))
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
 - `portmap` (Boolean)
-- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--title--interfaces--type--name--portmapto))
+- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions--portmapto))
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--interfaces--type--name--limit_value"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions--limit_value"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.interfaces.acls.actions.limit_value`
 
 Read-Only:
 
@@ -18354,8 +18355,8 @@ Read-Only:
 - `limitunit` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--interfaces--type--name--portmapto"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--actions--portmapto"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.interfaces.acls.actions.portmapto`
 
 Read-Only:
 
@@ -18363,8 +18364,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--interfaces--type--matches"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.interfaces.type.name`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--interfaces--acls--matches"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.interfaces.acls.matches`
 
 Read-Only:
 
@@ -18374,8 +18375,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--module"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.module`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--module"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.module`
 
 Read-Only:
 
@@ -18385,8 +18386,8 @@ Read-Only:
 - `twin_detail` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--owner"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.owner`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--owner"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.owner`
 
 Read-Only:
 
@@ -18397,15 +18398,15 @@ Read-Only:
 - `website` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--permissions"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.permissions`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--permissions"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.permissions`
 
 Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--title--resources"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title.resources`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--manifest_json--resources"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.manifest_json.resources`
 
 Read-Only:
 
@@ -18415,7 +18416,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--module_policy--azure_edge_agent--parent_detail"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_agent.title`
+### Nested Schema for `module_policy.module_policy.azure_edge_agent.parent_detail`
 
 Read-Only:
 
@@ -18453,18 +18454,18 @@ Read-Only:
 - `title` (String)
 
 <a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title`
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.interfaces`
 
 Read-Only:
 
 - `access_vlan_id` (Number)
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces--acls))
 - `default_net_instance` (Boolean)
 - `directattach` (Boolean)
-- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--eidregister))
+- `eidregister` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces--eidregister))
 - `intfname` (String)
 - `intforder` (Number)
-- `io` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--io))
+- `io` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces--io))
 - `ipaddr` (String)
 - `macaddr` (String)
 - `netinstid` (String)
@@ -18473,18 +18474,18 @@ Read-Only:
 - `netname` (String)
 - `privateip` (Boolean)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--acls"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.acls`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces--acls"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--acls--actions))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces--acls--actions))
 - `id` (Number)
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--acls--matches))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--acls--actions"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.acls.name`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces--acls--actions"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.interfaces.acls.actions`
 
 Read-Only:
 
@@ -18493,11 +18494,11 @@ Read-Only:
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
-- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--acls--name--mapparams))
+- `mapparams` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces--acls--actions--mapparams))
 - `portmap` (Boolean)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--acls--name--mapparams"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.acls.name.portmap`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces--acls--actions--mapparams"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.interfaces.acls.actions.mapparams`
 
 Read-Only:
 
@@ -18505,8 +18506,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--acls--matches"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.acls.name`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces--acls--matches"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.interfaces.acls.matches`
 
 Read-Only:
 
@@ -18515,8 +18516,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--eidregister"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.eidregister`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces--eidregister"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.interfaces.eidregister`
 
 Read-Only:
 
@@ -18527,12 +18528,12 @@ Read-Only:
 - `e_id` (String)
 - `e_id_hash_len` (Number)
 - `lisp_instance` (Number)
-- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--eidregister--lisp_map_servers))
+- `lisp_map_servers` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces--eidregister--lisp_map_servers))
 - `lisp_signature` (String)
 - `uuid` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--eidregister--lisp_map_servers"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.eidregister.uuid`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces--eidregister--lisp_map_servers"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.interfaces.eidregister.lisp_map_servers`
 
 Read-Only:
 
@@ -18541,8 +18542,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--io"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.io`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--interfaces--io"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.interfaces.io`
 
 Read-Only:
 
@@ -18553,39 +18554,39 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title`
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json`
 
 Read-Only:
 
 - `ac_kind` (String)
 - `ac_version` (String)
 - `app_type` (String)
-- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--configuration))
-- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--container_detail))
+- `configuration` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--configuration))
+- `container_detail` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--container_detail))
 - `cpu_pinning_enabled` (Boolean)
 - `deployment_type` (String)
-- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--desc))
+- `desc` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--desc))
 - `description` (String)
 - `display_name` (String)
 - `enablevnc` (Boolean)
-- `images` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--images))
-- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--interfaces))
-- `module` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--module))
+- `images` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--images))
+- `interfaces` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--interfaces))
+- `module` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--module))
 - `name` (String)
-- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--owner))
-- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--permissions))
-- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--resources))
+- `owner` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--owner))
+- `permissions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--permissions))
+- `resources` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--resources))
 - `vmmode` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--configuration"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.configuration`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--configuration"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.configuration`
 
 Read-Only:
 
-- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--configuration--custom_config))
+- `custom_config` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config))
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--configuration--custom_config"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.configuration.custom_config`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.configuration.custom_config`
 
 Read-Only:
 
@@ -18595,20 +18596,20 @@ Read-Only:
 - `name` (String)
 - `override` (Boolean)
 - `template` (String)
-- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups))
+- `variable_groups` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups))
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.configuration.custom_config.variable_groups`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.configuration.custom_config.variable_groups`
 
 Read-Only:
 
-- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups--condition))
+- `condition` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--condition))
 - `name` (String)
 - `required` (Boolean)
-- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups--variables))
+- `variables` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--variables))
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups--condition"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--condition"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.configuration.custom_config.variable_groups.condition`
 
 Read-Only:
 
@@ -18617,8 +18618,8 @@ Read-Only:
 - `value` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups--variables"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.configuration.custom_config.variable_groups.variables`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--variables"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.configuration.custom_config.variable_groups.variables`
 
 Read-Only:
 
@@ -18628,14 +18629,14 @@ Read-Only:
 - `label` (String)
 - `max_length` (String)
 - `name` (String)
-- `options` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups--variables--options))
+- `options` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--variables--options))
 - `process_input` (String)
 - `required` (Boolean)
 - `type` (String)
 - `value` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--configuration--custom_config--variable_groups--variables--options"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.configuration.custom_config.variable_groups.variables.options`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--configuration--custom_config--variable_groups--variables--options"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.configuration.custom_config.variable_groups.variables.options`
 
 Read-Only:
 
@@ -18647,16 +18648,16 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--container_detail"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.container_detail`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--container_detail"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.container_detail`
 
 Read-Only:
 
 - `container_create_option` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--desc"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.desc`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--desc"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.desc`
 
 Read-Only:
 
@@ -18670,8 +18671,8 @@ Read-Only:
 - `support` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--images"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.images`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--images"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.images`
 
 Read-Only:
 
@@ -18683,14 +18684,14 @@ Read-Only:
 - `imagename` (String)
 - `maxsize` (String)
 - `mountpath` (String)
-- `params` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--images--params))
+- `params` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--images--params))
 - `preserve` (Boolean)
 - `readonly` (Boolean)
 - `target` (String)
 - `volumelabel` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--images--params"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.images.volumelabel`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--images--params"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.images.params`
 
 Read-Only:
 
@@ -18699,43 +18700,43 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--interfaces"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.interfaces`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--interfaces"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.interfaces`
 
 Read-Only:
 
-- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--interfaces--acls))
+- `acls` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls))
 - `directattach` (Boolean)
 - `name` (String)
 - `optional` (Boolean)
 - `privateip` (Boolean)
 - `type` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--interfaces--acls"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.interfaces.type`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.interfaces.acls`
 
 Read-Only:
 
-- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--interfaces--type--actions))
-- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--interfaces--type--matches))
+- `actions` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions))
+- `matches` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--matches))
 - `name` (String)
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--interfaces--type--actions"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.interfaces.type.name`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.interfaces.acls.actions`
 
 Read-Only:
 
 - `drop` (Boolean)
 - `limit` (Boolean)
-- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--interfaces--type--name--limit_value))
+- `limit_value` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions--limit_value))
 - `limitburst` (Number)
 - `limitrate` (Number)
 - `limitunit` (String)
 - `portmap` (Boolean)
-- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--title--interfaces--type--name--portmapto))
+- `portmapto` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions--portmapto))
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--interfaces--type--name--limit_value"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions--limit_value"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.interfaces.acls.actions.limit_value`
 
 Read-Only:
 
@@ -18744,8 +18745,8 @@ Read-Only:
 - `limitunit` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--interfaces--type--name--portmapto"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.interfaces.type.name.portmapto`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--actions--portmapto"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.interfaces.acls.actions.portmapto`
 
 Read-Only:
 
@@ -18753,8 +18754,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--interfaces--type--matches"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.interfaces.type.name`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--interfaces--acls--matches"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.interfaces.acls.matches`
 
 Read-Only:
 
@@ -18764,8 +18765,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--module"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.module`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--module"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.module`
 
 Read-Only:
 
@@ -18775,8 +18776,8 @@ Read-Only:
 - `twin_detail` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--owner"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.owner`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--owner"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.owner`
 
 Read-Only:
 
@@ -18787,15 +18788,15 @@ Read-Only:
 - `website` (String)
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--permissions"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.permissions`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--permissions"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.permissions`
 
 Read-Only:
 
 
 
-<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--title--resources"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title.resources`
+<a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--manifest_json--resources"></a>
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.manifest_json.resources`
 
 Read-Only:
 
@@ -18805,7 +18806,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--module_policy--azure_edge_hub--parent_detail"></a>
-### Nested Schema for `module_policy.module_policy.azure_edge_hub.title`
+### Nested Schema for `module_policy.module_policy.azure_edge_hub.parent_detail`
 
 Read-Only:
 
@@ -18864,7 +18865,7 @@ Read-Only:
 - `type` (String)
 
 <a id="nestedobjatt--module_policy--network_policy--net_instance_config--dns_list"></a>
-### Nested Schema for `module_policy.network_policy.net_instance_config.type`
+### Nested Schema for `module_policy.network_policy.net_instance_config.dns_list`
 
 Read-Only:
 
@@ -18873,11 +18874,11 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--network_policy--net_instance_config--ip"></a>
-### Nested Schema for `module_policy.network_policy.net_instance_config.type`
+### Nested Schema for `module_policy.network_policy.net_instance_config.ip`
 
 Read-Only:
 
-- `dhcp_range` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--network_policy--net_instance_config--type--dhcp_range))
+- `dhcp_range` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--network_policy--net_instance_config--ip--dhcp_range))
 - `dns` (List of String)
 - `domain` (String)
 - `gateway` (String)
@@ -18885,8 +18886,8 @@ Read-Only:
 - `ntp` (String)
 - `subnet` (String)
 
-<a id="nestedobjatt--module_policy--network_policy--net_instance_config--type--dhcp_range"></a>
-### Nested Schema for `module_policy.network_policy.net_instance_config.type.dhcp_range`
+<a id="nestedobjatt--module_policy--network_policy--net_instance_config--ip--dhcp_range"></a>
+### Nested Schema for `module_policy.network_policy.net_instance_config.ip.dhcp_range`
 
 Read-Only:
 
@@ -18896,7 +18897,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--network_policy--net_instance_config--lisp"></a>
-### Nested Schema for `module_policy.network_policy.net_instance_config.type`
+### Nested Schema for `module_policy.network_policy.net_instance_config.lisp`
 
 Read-Only:
 
@@ -18905,10 +18906,10 @@ Read-Only:
 - `allocationprefixlen` (Number)
 - `exportprivate` (Boolean)
 - `lispiid` (Number)
-- `sp` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--network_policy--net_instance_config--type--sp))
+- `sp` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--network_policy--net_instance_config--lisp--sp))
 
-<a id="nestedobjatt--module_policy--network_policy--net_instance_config--type--sp"></a>
-### Nested Schema for `module_policy.network_policy.net_instance_config.type.sp`
+<a id="nestedobjatt--module_policy--network_policy--net_instance_config--lisp--sp"></a>
+### Nested Schema for `module_policy.network_policy.net_instance_config.lisp.sp`
 
 Read-Only:
 
@@ -18919,16 +18920,16 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--network_policy--net_instance_config--opaque"></a>
-### Nested Schema for `module_policy.network_policy.net_instance_config.type`
+### Nested Schema for `module_policy.network_policy.net_instance_config.opaque`
 
 Read-Only:
 
-- `lisp` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--network_policy--net_instance_config--type--lisp))
+- `lisp` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--network_policy--net_instance_config--opaque--lisp))
 - `oconfig` (String)
 - `type` (String)
 
-<a id="nestedobjatt--module_policy--network_policy--net_instance_config--type--lisp"></a>
-### Nested Schema for `module_policy.network_policy.net_instance_config.type.lisp`
+<a id="nestedobjatt--module_policy--network_policy--net_instance_config--opaque--lisp"></a>
+### Nested Schema for `module_policy.network_policy.net_instance_config.opaque.lisp`
 
 Read-Only:
 
@@ -18937,10 +18938,10 @@ Read-Only:
 - `allocationprefixlen` (Number)
 - `exportprivate` (Boolean)
 - `lispiid` (Number)
-- `sp` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--network_policy--net_instance_config--type--lisp--sp))
+- `sp` (List of Object) (see [below for nested schema](#nestedobjatt--module_policy--network_policy--net_instance_config--opaque--lisp--sp))
 
-<a id="nestedobjatt--module_policy--network_policy--net_instance_config--type--lisp--sp"></a>
-### Nested Schema for `module_policy.network_policy.net_instance_config.type.lisp.sp`
+<a id="nestedobjatt--module_policy--network_policy--net_instance_config--opaque--lisp--sp"></a>
+### Nested Schema for `module_policy.network_policy.net_instance_config.opaque.lisp.sp`
 
 Read-Only:
 
@@ -18952,7 +18953,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--network_policy--net_instance_config--revision"></a>
-### Nested Schema for `module_policy.network_policy.net_instance_config.type`
+### Nested Schema for `module_policy.network_policy.net_instance_config.revision`
 
 Read-Only:
 
@@ -18965,7 +18966,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--module_policy--network_policy--net_instance_config--static_routes"></a>
-### Nested Schema for `module_policy.network_policy.net_instance_config.type`
+### Nested Schema for `module_policy.network_policy.net_instance_config.static_routes`
 
 Read-Only:
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -57,7 +57,7 @@ Optional:
 
 Read-Only:
 
-- `id` (String) The ID of this resource.
+- `id` (String)
 
 
 <a id="nestedatt--revision"></a>

--- a/main.tf
+++ b/main.tf
@@ -18,41 +18,48 @@ resource "zedcloud_project" "test_tf_provider" {
 
   # optional
   type = "TAG_TYPE_PROJECT"
-  attestation_policy {
-    # required
-    title = "title"
-    type  = "POLICY_TYPE_ATTESTATION"
+  tag_level_settings {
+    flow_log_transmission =  "NETWORK_INSTANCE_FLOW_LOG_TRANSMISSION_DISABLED"
+    interface_ordering = "INTERFACE_ORDERING_DISABLED"
+  }
+  # attestation_policy {
+  #   # required
+  #   title = "tf-attestation-policy"
+  #   name  = "tf-attestation-policy"
+  #   type  = "POLICY_TYPE_ATTESTATION"
 
-    attestation_policy {
-      type = "ATTEST_POLICY_TYPE_ACCEPT"
-    }
-  }
-  edgeview_policy {
-    edgeview_policy {
-      # required
-      edgeview_allow = false
-      # optional
-      access_allow_change = true
-      edgeviewcfg {
-        dev_policy {
-          allow_dev = true
-        }
-        ext_policy {
-          allow_ext = false
-        }
-        generation_id = 0
-        jwt_info {
-          allow_sec = 18000
-          disp_url  = "zedcloud.local.zededa.net/api/v1/edge-view"
-          encrypt   = false
-          num_inst = 1
-        }
-      }
-      max_expire_sec = 2592000
-      max_inst       = 3
-    }
-    type = "POLICY_TYPE_EDGEVIEW"
-  }
+  #   attestation_policy {
+  #     type = "ATTEST_POLICY_TYPE_ACCEPT"
+  #   }
+  # }
+  # edgeview_policy {
+  #   title = "tf-edgeview-policy"
+  #   name  = "tf-edgeview-policy"
+  #   edgeview_policy {
+  #     # required
+  #     edgeview_allow = false
+  #     # optional
+  #     access_allow_change = true
+  #     edgeviewcfg {
+  #       dev_policy {
+  #         allow_dev = true
+  #       }
+  #       ext_policy {
+  #         allow_ext = false
+  #       }
+  #       generation_id = 0
+  #       jwt_info {
+  #         allow_sec = 18000
+  #         disp_url  = "zedcloud.local.zededa.net/api/v1/edge-view"
+  #         encrypt   = false
+  #         num_inst  = 1
+  #       }
+  #     }
+  #     max_expire_sec = 2592000
+  #     max_inst       = 3
+  #   }
+  #   type = "POLICY_TYPE_EDGEVIEW"
+  # }
 }
 
 data "zedcloud_project" "test_tf_provider" {
@@ -64,13 +71,122 @@ data "zedcloud_project" "test_tf_provider" {
   ]
 }
 
+resource "zedcloud_brand" "test_tf_provider" {
+  name        = "qemu"
+  title       = "QEMU"
+  description = "qemu"
+  origin_type = "ORIGIN_LOCAL"
+}
+
+resource "zedcloud_model" "test_tf_provider" {
+  brand_id    = zedcloud_brand.test_tf_provider.id
+  name        = "test_tf_provider-create_edgenode"
+  title       = "test_tf_provider-create_edgenode"
+  type        = "AMD64"
+  origin_type = "ORIGIN_LOCAL"
+  state       = "SYS_MODEL_STATE_ACTIVE"
+  attr = {
+    memory  = "8G"
+    storage = "100G"
+    Cpus    = "4"
+  }
+  io_member_list {
+    ztype     = "IO_TYPE_ETH"
+    phylabel  = "firstEth"
+    usage     = "ADAPTER_USAGE_MANAGEMENT"
+    assigngrp = "eth0"
+    phyaddrs = {
+      Ifname  = "eth0"
+      PciLong = "0000:02:00.0"
+    }
+    logicallabel = "ethernet0"
+    usage_policy = {
+      FreeUplink = true
+    }
+    cost = 0
+  }
+  depends_on = [
+    zedcloud_brand.test_tf_provider
+  ]
+}
+
+resource "zedcloud_datastore" "test_datastore" {
+  depends_on = [
+    zedcloud_project.test_tf_provider
+  ]
+  # required
+  ds_fqdn             = "docker://docker.io"
+  ds_path             = ""
+  ds_type             = "DATASTORE_TYPE_CONTAINERREGISTRY"
+  name                = "dockerhub"
+  title               = "dockerhub"
+  description         = "dockerhub"
+  region              = "eu"
+  project_access_list = [zedcloud_project.test_tf_provider.id]
+}
+
+resource "zedcloud_datastore" "alpha_ds" {
+  depends_on = [
+    zedcloud_project.test_tf_provider
+  ]
+  # required
+  ds_fqdn             = "http://147.75.33.217"
+  ds_path             = "images"
+  ds_type             = "DATASTORE_TYPE_HTTP"
+  name                = "alpha_ds"
+  title               = "alpha_ds"
+  description         = "alpha_ds"
+  region              = "eu"
+  project_access_list = [zedcloud_project.test_tf_provider.id]
+}
+
+resource "zedcloud_image" "alpine_image" {
+  depends_on = [
+    zedcloud_project.test_tf_provider,
+    zedcloud_datastore.test_datastore
+  ]
+  name                = "alpine"
+  datastore_id        = zedcloud_datastore.test_datastore.id
+  image_arch          = "ARM64"
+  image_format        = "CONTAINER"
+  image_rel_url       = "alpine:latest"
+  image_size_bytes    = 0
+  image_type          = "IMAGE_TYPE_APPLICATION"
+  title               = "alpine"
+  project_access_list = [zedcloud_project.test_tf_provider.id]
+}
+
+resource "zedcloud_image" "silverpeak_cloudinit_azure_ds" {
+  datastore_id = zedcloud_datastore.alpha_ds.id
+  image_type = "IMAGE_TYPE_APPLICATION"
+  image_arch = "AMD64"
+  image_format = "ISO"
+  image_sha256 = "290b2df3264618f8760fe115fc36b6e480ee9125699d4781867090e25eb65865"
+  image_size_bytes =  1319
+  name = "norfolk-cloudinit.iso"
+  title = "norfolk-cloudinit.iso"
+  project_access_list = [zedcloud_project.test_tf_provider.id]
+  image_rel_url = "norfolk-cloudinit.iso"
+}
+
+# data "zedcloud_image" "alpine_image" {
+#   name         = "alpine_image"
+#   title        = "alpine"
+#   datastore_id = zedcloud_datastore.test_datastore.id
+#   image_arch   = "ARM64"
+#   image_format = "CONTAINER"
+#   depends_on = [
+#     zedcloud_image.alpine_image
+#   ]
+# }
+
 resource "zedcloud_edgenode" "test_tf_provider" {
   onboarding_key = "" # placeholder
   serialno       = "2293dbe8-29ce-420c-8264-962857efc46b"
   # required
   name       = "test_tf_provider"
-  model_id   = "ab66ab26-cbc2-4d66-829e-7bedb59aabba"
-  project_id = data.zedcloud_project.test_tf_provider.id
+  model_id   = zedcloud_model.test_tf_provider.id
+  project_id = zedcloud_project.test_tf_provider.id
   title      = "test_tf_provider-create_edgenode-title"
 
   admin_state = "ADMIN_STATE_ACTIVE"
@@ -85,7 +201,7 @@ resource "zedcloud_edgenode" "test_tf_provider" {
     value_type   = "value type"
   }
   deployment_tag = "depl_tag"
-  description = "description"
+  description    = "description"
   dev_location {
     city        = "berlin"
     country     = "germany"
@@ -102,353 +218,255 @@ resource "zedcloud_edgenode" "test_tf_provider" {
     "tag-key-1" = "tag-value-1"
   }
   token = "token"
+  interfaces {
+    cost       = 255
+    intf_usage = "ADAPTER_USAGE_MANAGEMENT"
+    intfname   = "defaultIPv4"
+    ipaddr     = "127.0.0.1"
+    # macaddr = "00:00:00:00:00:00"
+    tags = {
+      "system_interface_1_key" = "system_interface_1_value"
+      "system_interface_2_key" = "system_interface_2_value"
+    }
+  }
 }
 
 data "zedcloud_edgenode" "test_tf_provider" {
   name     = "test_tf_provider"
   title    = "test_tf_provider"
-  model_id = "ab66ab26-cbc2-4d66-829e-7bedb59aabba"
+  model_id = zedcloud_model.test_tf_provider.id
   depends_on = [
     zedcloud_edgenode.test_tf_provider
   ]
 }
 
-resource "zedcloud_application" "test_tf_provider" {
-  name                 = "test_tf_provider"
-  title                = "ubuntu-all-ip"
-  description          = "ubuntu-all-ip"
-  user_defined_version = "1.1"
-  origin_type          = "ORIGIN_LOCAL"
+resource "zedcloud_application" "alpine_vm_app" {
+  name                 = "alpine_vm_app"
+  title                = "alpine_vm_app"
+  user_defined_version = "24.0.4"
+  depends_on = [ zedcloud_image.alpine_image ]
+  project_access_list = [zedcloud_project.test_tf_provider.id]
   manifest {
-    # computed
-    ac_kind = "VMManifest"
-
-    # optional
-    name       = "xenial-amd64-docker-20180725"
-    ac_version = "1.2.0"
-    app_type   = "APP_TYPE_VM"
-    configuration {
-      custom_config {
-        add                  = false
-        allow_storage_resize = false
-        field_delimiter      = ","
-        name                 = "custom_config_name"
-        override             = false
-        template             = "dGVzdA=="
-        variable_groups {
-          condition {
-            # optional
-            name     = "condition"
-            operator = "CONDITION_OPERATOR_EQUALTO"
-            value    = "val"
-          }
-          name     = "var_group"
-          required = false
-        }
-      }
-    }
+    ac_kind             = "VMManifest"
+    ac_version          = "1.2.0"
+    name                = "alpine_24"
+    vmmode              = "HV_HVM"
+    enablevnc           = true
+    app_type            = "APP_TYPE_VM"
+    deployment_type     = "DEPLOYMENT_TYPE_STAND_ALONE"
     cpu_pinning_enabled = false
-    deployment_type     = "DEPLOYMENT_TYPE_K3S"
-    desc {
-      category     = "Infrastructure"
-      os           = "Zenix"
-      app_category = "APP_CATEGORY_OTHERS"
-      support      = "support"
-    }
-    description  = "description"
-    display_name = "display_name"
-    enablevnc    = false
-    interfaces {
-      name         = "indirect"
-      directattach = false
-      privateip    = false
-      acls {
-        matches {
-          type  = "protocol"
-          value = "tcp"
-        }
-        matches {
-          type  = "lport"
-          value = "8022"
-        }
-        actions {
-          portmap = true
-          portmapto {
-            app_port = 22
-          }
-        }
-      }
-      acls {
-        matches {
-          type  = "host"
-          value = ""
-        }
-      }
-    }
-    owner {
-      company = "Zededa Inc."
-      email   = "test@zededa.com"
-      group   = "testgroup"
-      user    = "testuser"
-      website = "http://www.zededa.com"
-    }
     resources {
       name  = "cpus"
-      value = "2"
+      value = 2
     }
     resources {
       name  = "memory"
-      value = "1024000"
+      value = 8000000
     }
-    vmmode = "HV_HVM"
-  }
-}
-
-data "zedcloud_application" "test_tf_provider" {
-  name  = "test_tf_provider"
-  title = "test_tf_provider"
-  depends_on = [
-    zedcloud_application.test_tf_provider
-  ]
-}
-
-resource "zedcloud_volume_instance" "test_tf_provider" {
-  device_id   = data.zedcloud_edgenode.test_tf_provider.id
-  name        = "test_tf_provider"
-  title       = "test_title"
-  description = "test_description"
-  type        = "VOLUME_INSTANCE_TYPE_BLOCKSTORAGE"
-
-  multiattach = true
-  cleartext   = true
-  accessmode  = "VOLUME_INSTANCE_ACCESS_MODE_READWRITE"
-  size_bytes  = "1024"
-  implicit    = false
-  label       = "label"
-  tags = {
-    "tag-key-1" = "tag-value-1"
-    "tag-key-2" = "tag-value-2"
-  }
-  depends_on = [
-    data.zedcloud_edgenode.test_tf_provider
-  ]
-}
-
-data "zedcloud_volume_instance" "test_tf_provider" {
-  name      = "test_tf_provider"
-  title     = "test_tf_provider"
-  type      = "VOLUME_INSTANCE_TYPE_CONTENT_TREE"
-  device_id = data.zedcloud_edgenode.test_tf_provider.id
-  depends_on = [
-    zedcloud_volume_instance.test_tf_provider
-  ]
-}
-
-resource "zedcloud_network_instance" "test_tf_provider" {
-  depends_on = [
-    zedcloud_edgenode.test_tf_provider,
-  ]
-  # required
-  device_id = data.zedcloud_edgenode.test_tf_provider.id
-  name      = "test_tf_provider"
-  title     = "title"
-  kind      = "NETWORK_INSTANCE_KIND_LOCAL"
-  port      = "eth1"
-
-  # optional
-  description    = "zedcloud_network_instance-complete-description"
-  type           = "NETWORK_INSTANCE_DHCP_TYPE_V4"
-  device_default = false
-  dhcp           = false
-  dns_list {
-    addrs = [
-      "10.1.2.2",
-      "10.1.2.1"
-    ]
-    hostname = "wwww.ns2.example.com"
-  }
-  dns_list {
-    addrs = [
-      "10.1.1.1",
-      "10.1.1.2"
-    ]
-    hostname = "wwww.ns1.example.com"
-  }
-  opaque {
-    oconfig = "Test OConfig"
-    type    = "OPAQUE_CONFIG_TYPE_UNSPECIFIED"
-  }
-  tags = {
-    "ni-tag1" = "ni-tag-value-1"
-    "ni-tag2" = "ni-tag-value-2"
-  }
-}
-
-data "zedcloud_network_instance" "test_tf_provider" {
-  name      = "test_tf_provider"
-  title     = "test_tf_provider"
-  kind      = "NETWORK_INSTANCE_KIND_LOCAL"
-  device_id = data.zedcloud_edgenode.test_tf_provider.id
-  depends_on = [
-    zedcloud_network_instance.test_tf_provider
-  ]
-}
-
-resource "zedcloud_application_instance" "test_tf_provider" {
-  depends_on = [
-    zedcloud_application.test_tf_provider,
-    zedcloud_edgenode.test_tf_provider,
-    zedcloud_network_instance.test_tf_provider
-  ]
-
-  # required
-  name        = "test_tf_provider"
-  title       = "tf test"
-  description = "tf test"
-  activate    = "true"
-  app_id      = zedcloud_application.test_tf_provider.id
-  device_id   = zedcloud_edgenode.test_tf_provider.id
-  drives {
-    # required
-    drvtype   = "UNSPECIFIED"
-    imagename = "ubuntu-tiny"
-    maxsize   = "0"
-    preserve  = false
-    readonly  = false
-    target    = "Disk"
-
-    # optional
-    cleartext   = false
-    ignorepurge = false
-  }
-  interfaces {
-    directattach = false
-    privateip    = false
-    netinstname  = zedcloud_network_instance.test_tf_provider.name
-    intfname     = "indirect"
-    acls {
-      actions {
-        drop       = false
-        limit      = false
-        limitburst = 0
-        limitrate  = 0
-        portmap    = true
-
-        mapparams {
-          port = 22
-        }
-      }
-
-      matches {
-        type  = "protocol"
-        value = "tcp"
-      }
-      matches {
-        type  = "lport"
-        value = "8022"
-      }
+    resources {
+      name  = "storage"
+      value = 102400000
     }
-    acls {
-      #   id = 2
-      matches {
-        type = "host"
+    images {
+      imagename   = zedcloud_image.alpine_image.name
+      imageid     = zedcloud_image.alpine_image.id
+      imageformat = zedcloud_image.alpine_image.image_format
+      cleartext   = false
+      drvtype     = "HDD"
+      ignorepurge = true
+      maxsize     = 102400000
+      target      = "Disk"
+    }
+    configuration {
+      custom_config {
+        add      = true
+        name     = "cloud-config"
+        override = true
+        template = ""
       }
     }
   }
-  # optional
-  remote_console        = false
-  is_secret_updated     = false
-  collect_stats_ip_addr = "true"
-  app_policy_id         = ""
-  app_type              = "APP_TYPE_VM"
-  cluster_id            = ""
-  custom_config {
-    add                  = false
-    allow_storage_resize = false
-    override             = false
-  }
-  logs {
-    access = false
-  }
-  manifest_info {
-    transition_action = "INSTANCE_TA_NONE"
-  }
-  start_delay_in_seconds = 120
-  user_data              = ""
-  vminfo {
-    # required
-    cpus = 2
-    mode = "HV_HVM"
-    vnc  = false
-    # optional
-  }
-  tags = {
-    "tag-key-1" = "tag-value-1"
-  }
 }
 
-data "zedcloud_application_instance" "test_tf_provider" {
+data "zedcloud_application" "alpine_vm_app" {
+  name  = "alpine_vm_app"
+  title = "alpine_vm_app"
   depends_on = [
-    zedcloud_application_instance.test_tf_provider
-  ]
-  name      = "test_tf_provider"
-  title     = "test_tf_provider"
-  device_id = zedcloud_edgenode.test_tf_provider.id
-  app_id    = zedcloud_application.test_tf_provider.id
-}
-
-
-resource "zedcloud_image"  "test_tf_provider" {
-  name = "test_tf_provider"
-  title = "test_tf_provider"
-  image_arch = "UNSPECIFIED"
-  image_format = "RAW"
-  datastore_id = "55c029bd-5d0a-46dd-b0ab-c6c9895b0d9a"
-  image_rel_url = "test_url"
-  image_size_bytes = 5000
-  image_type = "IMAGE_TYPE_ARTIFACT"
-  image_sha256 = "815fa14f544f2e955af18848667320fefd90d82e42497f429b53cc57cc76fb5c"
-  project_access_list = []
-}
-
-
-resource "zedcloud_patch_envelope" "test_tf_provider" {
-  name   = "test_tf_provider"
-  action = "PATCH_ENVELOPE_ACTION_ACTIVATE"
-  title  = "test_tf_provider"
-  description = "test tf provider"
-  user_defined_version = "1.0"
-
-  artifacts {
-    format = "OpaqueObjectCategoryInline"
-    base64_artifact {
-      base64_data      = "YXJ0aWZhY3QgZGF0YQ=="
-      file_name_to_use = "testfile"
-    }
-  }
-  artifacts {
-    format = "OpaqueObjectCategoryExternalBinary"
-    binary_artifact {
-      image_id = zedcloud_image.test_tf_provider.id
-      image_name = zedcloud_image.test_tf_provider.name
-      file_name_to_use = "new_filename"
-    }
-  }
-  project_name = zedcloud_project.test_tf_provider.name
-  project_id = zedcloud_project.test_tf_provider.id
-  depends_on = [
-    zedcloud_image.test_tf_provider
+    zedcloud_application.alpine_vm_app
   ]
 }
 
-resource "zedcloud_patch_reference_update" "test_tf_provider" {
-  app_inst_id_list = [zedcloud_application_instance.test_tf_provider.id]
-  patchenvelope_id = zedcloud_patch_envelope.test_tf_provider.id
-  project_id = zedcloud_project.test_tf_provider.id
-  depends_on = [
-    zedcloud_application_instance.test_tf_provider,
-    zedcloud_patch_envelope.test_tf_provider,
-    zedcloud_project.test_tf_provider
-  ]
-}
+# resource "zedcloud_project_deployment" "tf_deployment_project" {
+#   # required
+#   name  = "tf_deployment_project"
+#   title = "tf_deployment_project"
 
+#   # optional
+#   type = "TAG_TYPE_DEPLOYMENT"
+
+#   depends_on = [ 
+#     zedcloud_application.test_tf_provider,
+#     zedcloud_brand.test_tf_provider
+#   ]
+
+#   deployment {
+#     name = "depl_project"
+#     title = "deployment_project"
+#     deployment_tag = "depl:1234"
+
+#     device_policies {
+#         meta_data {
+#             name = "tf-edge-node"
+#             title = "tf-edge-node"
+#             policy_target_condition = {
+#               "depl": "123"
+#             }
+#         }
+#         policy_sub_type = "DEVICE_POLICY_TYPE_ATTESTATION"
+#         attestation_policy {
+#           type = "DEVICE_ATTEST_POLICY_TYPE_ACCEPT"
+#         }
+#     }
+
+#     network_inst_policies {
+#       meta_data {
+#         name = "tf-network-instance"
+#         title = "tf-network-instanceß"
+#         policy_target_condition = {
+#           "depl": "123"
+#         }
+#       }
+#       net_inst_config {
+#         port = "uplink"
+#         kind = "NETWORK_INSTANCE_KIND_LOCAL"
+#         type = "NETWORK_INSTANCE_DHCP_TYPE_V4"
+#       }
+#     }
+
+#     app_inst_policies {
+#       meta_data {
+#         name = "tf-app-instance"
+#         title = "tf-app-instance"
+#         policy_target_condition = {
+#           "depl": "123"
+#         }
+#       }
+#       app_inst_config {
+#         naming_scheme = "APP_NAMING_SCHEMEV2_PROJECT_APP_DEVICE"
+#         name_project_part = "depl-project"
+#         start_delay_in_seconds = 0
+#         name_app_part = "test_tf_provider"
+#         bundle_id = zedcloud_application.test_tf_provider.id
+#         origin_type = "ORIGIN_LOCAL"
+#         interfaces {
+#           intforder = 1
+#           intfname = "indirect"
+#           directattach = false
+#           netinstname = ""
+#           privateip = false
+#         }
+#         tags = {
+#           "depl": "123"
+#         }
+#         manifest_json {
+#           name = "tf-app-instance"
+#           ac_kind = "VMManifest"
+#           ac_version = "1.2.0"
+#           deployment_type = "DEPLOYMENT_TYPE_STAND_ALONE"
+#           app_type = "APP_TYPE_VM"
+#           owner {
+#             user = "testuser"
+#             group = "testgroup"
+#             company = "Zededa Inc."
+#             website = "https://www.zededa.com"
+#             email = "test@zededa.com"
+#           }
+#           description = "test app instance"
+#           cpu_pinning_enabled = false
+#           images {
+#             imagename = zedcloud_image.test_image.name
+#             imageid = zedcloud_image.test_image.id
+#             imageformat = "CONTAINER"
+#             preserve = false
+#             readonly = false
+#             ignorepurge = false
+#             cleartext = false
+#           }
+#           interfaces {}
+#           desc {
+#             category = "APP_CATEGORY_CLOUD_APPLICATION"
+#             app_category = "APP_CATEGORY_UNSPECIFIED"
+#             support = "support"
+#           }
+#           vmmode = "HV_HVM"
+#           enablevnc = false
+#           resources {
+#             name = "resourceType"
+#             value = "Custom"
+#           }
+#           resources {
+#             name = "cpus"
+#             value = "2"
+#           }
+#           resources {
+#             name = "memory"
+#             value = "1024000.00"
+#           }
+#           configuration {
+#             custom_config {
+#               name = "custom_config_name"
+#               add = false
+#               override = false
+#               allow_storage_resize = false
+#               field_delimiter = ""
+#               template = ""
+#             }
+#           }
+#         }
+#       }
+#     }
+
+#     volume_inst_policies {
+#       meta_data {
+#         name = "tf-volume-instance"
+#         title = "tf-volume-instance"
+#         policy_target_condition = {
+#           "depl": "123"
+#         }
+#       }
+#       vol_inst_config {
+#         type = "VOLUME_INSTANCE_TYPE_BLOCKSTORAGE"
+#         accessmode = "VOLUME_INSTANCE_ACCESS_MODE_READWRITE"
+#         size_bytes = 1048576
+#         cleartext= true
+#       }
+#     }
+#   }
+
+#   edgeview_policy {
+#     title = "tf-deployment-project"
+#     name = "tf-edgeview-policy"
+#     type = "POLICY_TYPE_EDGEVIEW"
+
+#     edgeview_policy {
+#       edgeviewcfg {
+#         jwt_info {
+#           disp_url = ""
+#           allow_sec = 18000
+#           num_inst = 1
+#           encrypt = false
+#         }
+#         dev_policy {
+#           allow_dev = true
+#         }
+#         app_policy {
+#           allow_app = true
+#         }
+#       }
+#       access_allow_change = true
+#       max_expire_sec = 2592000
+#       max_inst = 3
+#       edgeview_allow = true
+#     }
+#   }
+# }

--- a/v2/schemas/tag.go
+++ b/v2/schemas/tag.go
@@ -100,7 +100,7 @@ func TagModel(d *schema.ResourceData) *models.Tag {
 		LocalOperatorConsolePolicy: localOperatorConsolePolicy,
 		Name:                       &name, // string
 		NetworkPolicy:              networkPolicy,
-		Revision: 				    revision,
+		Revision:                   revision,
 		TagLevelSettings:           tagLevelSettings,
 		Tags:                       tags,
 		Title:                      &title, // string
@@ -212,7 +212,7 @@ func TagModelFromMap(m map[string]interface{}) *models.Tag {
 		LocalOperatorConsolePolicy: localOperatorConsolePolicy,
 		Name:                       &name,
 		NetworkPolicy:              networkPolicy,
-		Revision:			 	    revision,
+		Revision:                   revision,
 		TagLevelSettings:           tagLevelSettings,
 		Tags:                       tags,
 		Title:                      &title,
@@ -404,7 +404,7 @@ func Project() map[string]*schema.Schema {
 			Elem: &schema.Resource{
 				Schema: TagLevelSettingsSchema(),
 			},
-			Optional: true,
+			Required: true,
 		},
 
 		"tags": {

--- a/v2/schemas/tag_level_settings.go
+++ b/v2/schemas/tag_level_settings.go
@@ -63,15 +63,15 @@ func SetTagLevelSettingsSubResourceData(m []*models.TagLevelSettings) (d []*map[
 func TagLevelSettingsSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"flow_log_transmission": {
-			Description: `Flow log transmission setting for the network instances`,
+			Description: `Flow log transmission setting for the network instances, it has two possible values NETWORK_INSTANCE_FLOW_LOG_TRANSMISSION_DISABLED or NETWORK_INSTANCE_FLOW_LOG_TRANSMISSION_ENABLED`,
 			Type:        schema.TypeString,
-			Optional:    true,
+			Required:    true,
 		},
 
 		"interface_ordering": {
-			Description: `interface ordering for app instances`,
+			Description: `interface ordering for app instances, it has two possible values INTERFACE_ORDERING_DISABLED or INTERFACE_ORDERING_ENABLED`,
 			Type:        schema.TypeString,
-			Optional:    true,
+			Required:    true,
 		},
 	}
 }


### PR DESCRIPTION
- With the current terraform provider version, the `tag_level_settings` field is optional, and if the field's value is not provided, zedcloud backend sets it to:
```
tag_level_settings {
     flow_log_transmission = "NETWORK_INSTANCE_FLOW_LOG_TRANSMISSION_UNSPECIFIED"
}
```
It causes the issue when the `terraform plan` always shows a diff for this field. This fix sets the `tag_level_settings` field as required to explicitly put this field's value.
- Updated documentation.