### PR TITLE
fix: network-instance configured DNS servers are not sent to Zedcloud (CI-574)

### DIFF
--- a/v2/resources/testdata/network_instance/create_complete.tf
+++ b/v2/resources/testdata/network_instance/create_complete.tf
@@ -131,13 +131,17 @@ resource "zedcloud_network_instance" "complete" {
         hostname = "wwww.ns1.example.com"
     }
     ip {
-        domain = "htttp://example.com"
+        domain = "http://example.com"
         gateway = "10.0.20.1"
         subnet = "10.0.20.0/24"
         dhcp_range {
             end = "10.0.20.100"
             start = "10.0.20.50"
         }
+        dns = [
+          "9.9.9.9",
+          "8.8.8.8"
+        ]
         mask = "255.255.255.0"
         ntp = "10.1.0.2"
     }

--- a/v2/resources/testdata/network_instance/create_complete_expected.yaml
+++ b/v2/resources/testdata/network_instance/create_complete_expected.yaml
@@ -12,13 +12,15 @@ dnslist:
         - 10.1.2.2
       hostname: wwww.ns2.example.com
 ip:
-    domain: "htttp://example.com"
+    domain: "http://example.com"
     gateway: "10.0.20.1"
     subnet: "10.0.20.0/24"
     dhcprange:
         end: "10.0.20.100"
         start: "10.0.20.50"
-    dns: []
+    dns:
+      - "9.9.9.9"
+      - "8.8.8.8"
     mask: "255.255.255.0"
     ntp: "10.1.0.2"
 kind: NETWORK_INSTANCE_KIND_LOCAL

--- a/v2/schemas/dhcp_server.go
+++ b/v2/schemas/dhcp_server.go
@@ -19,7 +19,7 @@ func DHCPServerModel(d *schema.ResourceData) *models.DhcpServerConfig {
 	if dnsIsSet {
 		dnsSlice := dnsInterface.([]interface{})
 		for _, i := range dnsSlice {
-			dnsSlice = append(dnsSlice, i.(string))
+			dns = append(dns, i.(string))
 		}
 	}
 	domain, _ := d.Get("domain").(string)
@@ -47,13 +47,12 @@ func DHCPServerModelFromMap(m map[string]interface{}) *models.DhcpServerConfig {
 			dhcpRange = DhcpIPRangeModelFromMap(dhcpRangeMap[0].(map[string]interface{}))
 		}
 	}
-	//
 	var dns []string
 	dnsInterface, dnsIsSet := m["dns"]
 	if dnsIsSet {
 		dnsSlice := dnsInterface.([]interface{})
 		for _, i := range dnsSlice {
-			dnsSlice = append(dnsSlice, i.(string))
+			dns = append(dns, i.(string))
 		}
 	}
 	domain, _ := m["domain"].(string)
@@ -104,7 +103,7 @@ func DHCPServer() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"dhcp_range": {
 			Description: `Range of IP addresses to be used for DHCP`,
-			Type:        schema.TypeList, //GoType: DhcpIPRange
+			Type:        schema.TypeList, // GoType: DhcpIPRange
 			Elem: &schema.Resource{
 				Schema: DhcpIPRange(),
 			},
@@ -113,12 +112,20 @@ func DHCPServer() map[string]*schema.Schema {
 
 		"dns": {
 			Description: `IP Addresses of DNS servers`,
-			Type:        schema.TypeList, //GoType: []string
+			Type:        schema.TypeList, // GoType: []string
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
 			},
-			DiffSuppressFunc: diffSuppressDNSListOrder("dns"),
-			Optional:         true,
+			// DiffSuppressFunc: diffSuppressDNSListOrder("dns"),
+			//
+			// It's actually a problem trying to use diffSuppressDNSListOrder
+			// here as it expects a slices of *models.StaticDNSList and with
+			// slices of string it causes the original data to be erased.
+			// diffSuppressStringListOrder would probably be the right choice.
+			// However the order or the DNS servers actually matters, the only
+			// situation were ignoring the order would be necessary would be
+			// if the Zedcloud API doesn't guarantee the order of the entriees.
+			Optional: true,
 		},
 
 		"domain": {

--- a/v2/schemas/ip_spec.go
+++ b/v2/schemas/ip_spec.go
@@ -63,7 +63,6 @@ func IPSpecModelFromMap(m map[string]interface{}) *models.IPSpec {
 			dhcpRange = DhcpIPRangeModelFromMap(dhcpRangeMap[0].(map[string]interface{}))
 		}
 	}
-	//
 	var dns []string
 	dnsInterface, dnsIsSet := m["dns"]
 	if dnsIsSet {
@@ -143,7 +142,7 @@ NETWORK_DHCP_TYPE_CLIENT`,
 
 		"dhcp_range": {
 			Description: `Range of IP addresses to be used for DHCP for IPAM management when dhcp is turned on. If none provided, system will default pool.`,
-			Type:        schema.TypeList, //GoType: DhcpIPRange
+			Type:        schema.TypeList, // GoType: DhcpIPRange
 			Elem: &schema.Resource{
 				Schema: DhcpIPRange(),
 			},
@@ -152,7 +151,7 @@ NETWORK_DHCP_TYPE_CLIENT`,
 
 		"dns": {
 			Description: "List of IP Addresses of DNS servers",
-			Type:        schema.TypeList, //GoType: []string
+			Type:        schema.TypeList, // GoType: []string
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
 			},


### PR DESCRIPTION
The issue was that the configured DNS servers were not sent to the network instances' create request.

Changes:
- Fixed the `dns` field in the `dhcp_server` schema.
- Updated tests to test the `dns` field.