### PR TITLE
fix: add retry logic for http requests(ENG-1593)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,14 +46,14 @@ build:
 .PHONY: test
 test:
 	cd v2 && \
-	TF_ACC=1 TF_CLI_CONFIG_FILE="${PWD}/dev.tfrc" go test -v ./... && \
+	TF_ACC=1 TF_CLI_CONFIG_FILE="${PWD}/dev.tfrc" go test -v -timeout 20m ./... && \
 	cd -
 
 .PHONY: test-run
 test-run:
 	cd v2 && \
 	go vet ./... && \
-	TF_ACC=1 TF_CLI_CONFIG_FILE="${PWD}/dev.tfrc" go test -v ./... -run $(case) && \
+	TF_ACC=1 TF_CLI_CONFIG_FILE="${PWD}/dev.tfrc" go test -v -timeout 20m ./... -run $(case) && \
 	cd -
 
 .PHONY: udpatedeps

--- a/test/retry/Readme.md
+++ b/test/retry/Readme.md
@@ -1,0 +1,89 @@
+# How to generate a 404 error using mitmproxy and test retry logic in terraform
+
+## 1. Install mitmproxy
+
+### macOS (with Homebrew):
+```bash
+brew install mitmproxy
+```
+
+### Ubuntu/Debian:
+```bash
+sudo apt update && sudo apt install mitmproxy
+```
+
+---
+
+## 2. Add Fault Injection Using mitmproxy Scripting
+
+```python
+import re
+from mitmproxy import http
+from mitmproxy.http import Response
+
+# Match /api/v1/devices/id/{uuid}
+uuid_path_re = re.compile(r"^/api/v1/devices/id/[0-9a-fA-F-]{36}$")
+
+# Match /api/v1/devices/name/{name} (1–250 non-slash chars)
+name_path_re = re.compile(r"^/api/v1/devices/name/[^/]{1,250}$")
+
+# Count matching GET requests
+request_count = 0
+
+def response(flow: http.HTTPFlow) -> None:
+    global request_count
+
+    if flow.request.method != "GET":
+        return
+
+    path = flow.request.path
+    if uuid_path_re.match(path) or name_path_re.match(path):
+        request_count += 1
+
+        if request_count % 5 == 0:
+            print(f"✔️ [ALLOW #{request_count}] {path}")
+            return
+        else:
+            print(f"❌ [SIMULATED 404 #{request_count}] {path}")
+            flow.response = Response.make(
+                404,
+                b'{"code":404,"message":"Not Found"}',
+                {"Content-Type": "application/json"}
+            )
+```
+
+---
+
+## 3. Start mitmproxy as a Reverse Proxy Using Fault Injection Script
+
+Run the following command from your terminal:
+```bash
+mitmproxy --mode reverse:https://zedcontrol.local.zededa.net --listen-port 8666 -s simulate_404.py
+```
+
+This will:
+- Accept connections on `http://127.0.0.1:8666`
+- Forward them to `https://zedcontrol.local.zededa.net`
+- Intercept and log full request/response details
+- Inject a `404` error for four consecutive requests to:
+  - `/api/v1/devices/id/<your-device-id>`
+  - `/api/v1/devices/name/<your-device-name>`
+- Everty fifth request will be allowed through.
+
+---
+
+## 4. Test it with curl
+
+Run the following command to test:
+```bash
+curl -v http://127.0.0.1:8666/api/v1/devices/id/<your-device-id> \
+  -H "Authorization: Bearer <your-token>"
+```
+
+---
+
+## 5. Run you terraform script to test the retry logic
+```bash
+terraform plan -out=out.plan
+terraform apply out.plan
+```

--- a/test/retry/simulate_404.py
+++ b/test/retry/simulate_404.py
@@ -1,0 +1,33 @@
+import re
+from mitmproxy import http
+from mitmproxy.http import Response
+
+# Match /api/v1/devices/id/{uuid}
+uuid_path_re = re.compile(r"^/api/v1/devices/id/[0-9a-fA-F-]{36}$")
+
+# Match /api/v1/devices/name/{name} (1–250 non-slash chars)
+name_path_re = re.compile(r"^/api/v1/devices/name/[^/]{1,250}$")
+
+# Count matching GET requests
+request_count = 0
+
+def response(flow: http.HTTPFlow) -> None:
+    global request_count
+
+    if flow.request.method != "GET":
+        return
+
+    path = flow.request.path
+    if uuid_path_re.match(path) or name_path_re.match(path):
+        request_count += 1
+
+        if request_count % 5 == 0:
+            print(f"✔️ [ALLOW #{request_count}] {path}")
+            return
+        else:
+            print(f"❌ [SIMULATED 404 #{request_count}] {path}")
+            flow.response = Response.make(
+                404,
+                b'{"code":404,"message":"Not Found"}',
+                {"Content-Type": "application/json"}
+            )

--- a/v2/resources/app_profile_service_resource_test.go
+++ b/v2/resources/app_profile_service_resource_test.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -208,6 +209,12 @@ func testAppProfileDestroy(s *terraform.State) error {
 			if appProfileResp := resp.GetPayload(); appProfileResp != nil && appProfileResp.ID == rs.Primary.ID {
 				return fmt.Errorf("destroy failed, AppProfile with ID %s still exists", appProfileResp.ID)
 			}
+			return nil
+		}
+
+		// if we use an http client with retries,
+		// it overrrides AppProfileServiceGetAppProfileNotFound error
+		if strings.Contains(err.Error(), "unexpected HTTP status 404 Not Found") {
 			return nil
 		}
 

--- a/v2/resources/application_instance_test.go
+++ b/v2/resources/application_instance_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -143,6 +144,12 @@ func testApplicationInstanceDestroy(s *terraform.State) error {
 			if application := response.GetPayload(); application != nil && application.ID == rs.Primary.ID {
 				return fmt.Errorf("destroy failed, ApplicationInstance (%s) still exists", application.ID)
 			}
+			return nil
+		}
+
+		// if we use an http client with retries,
+		// it overrrides GetApplicationInstanceNotFound error
+		if strings.Contains(err.Error(), "unexpected HTTP status 404 Not Found") {
 			return nil
 		}
 

--- a/v2/resources/application_test.go
+++ b/v2/resources/application_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -153,6 +154,12 @@ func testApplicationDestroy(s *terraform.State) error {
 			if application := response.GetPayload(); application != nil && application.ID == rs.Primary.ID {
 				return fmt.Errorf("destroy failed, Application (%s) still exists", application.ID)
 			}
+			return nil
+		}
+
+		// if we use an http client with retries,
+		// it overrrides GetApplicationNotFound error
+		if strings.Contains(err.Error(), "unexpected HTTP status 404 Not Found") {
 			return nil
 		}
 

--- a/v2/resources/asset_group_service_resource_test.go
+++ b/v2/resources/asset_group_service_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -147,6 +148,12 @@ func testAssetGroupDestroy(s *terraform.State) error {
 			if assetGroupResp := response.GetPayload(); assetGroupResp != nil && assetGroupResp.ID == rs.Primary.ID {
 				return fmt.Errorf("destroy failed, Asset Group (%s) still exists", assetGroupResp.ID)
 			}
+			return nil
+		}
+
+		// if we use an http client with retries,
+		// it overrrides AssetGroupServiceGetAssetGroupNotFound error
+		if strings.Contains(err.Error(), "unexpected HTTP status 404 Not Found") {
 			return nil
 		}
 

--- a/v2/resources/datastore_test.go
+++ b/v2/resources/datastore_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -119,6 +120,12 @@ func testDatastoreDestroy(s *terraform.State) error {
 			if datastore := response.GetPayload(); datastore != nil && datastore.ID == rs.Primary.ID {
 				return fmt.Errorf("destroy failed, Datastore (%s) still exists", datastore.ID)
 			}
+			return nil
+		}
+
+		// if we use an http client with retries,
+		// it overrrides GetByIDNotFound error
+		if strings.Contains(err.Error(), "unexpected HTTP status 404 Not Found") {
 			return nil
 		}
 

--- a/v2/resources/deployment_test.go
+++ b/v2/resources/deployment_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -195,6 +196,12 @@ func testDeploymentDestroy(s *terraform.State) error {
 			if deviceConfig := response.GetPayload(); deviceConfig != nil && deviceConfig.ID == rs.Primary.ID {
 				return fmt.Errorf("destroy failed, Project (%s) still exists", deviceConfig.ID)
 			}
+			return nil
+		}
+
+		// if we use an http client with retries,
+		// it overrrides GetByIDNotFound error
+		if strings.Contains(err.Error(), "unexpected HTTP status 404 Not Found") {
 			return nil
 		}
 

--- a/v2/resources/image_test.go
+++ b/v2/resources/image_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -121,6 +122,12 @@ func testImageDestroy(s *terraform.State) error {
 			if image := response.GetPayload(); image != nil && image.ID == rs.Primary.ID {
 				return fmt.Errorf("destroy failed, Image (%s) still exists", image.ID)
 			}
+			return nil
+		}
+
+		// if we use an http client with retries,
+		// it overrrides GetImageNotFound error
+		if strings.Contains(err.Error(), "unexpected HTTP status 404 Not Found") {
 			return nil
 		}
 

--- a/v2/resources/network_instance_test.go
+++ b/v2/resources/network_instance_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -176,6 +177,12 @@ func testNetworkInstanceDestroy(s *terraform.State) error {
 			if network := response.GetPayload(); network != nil && network.ID == rs.Primary.ID {
 				return fmt.Errorf("destroy failed, Network Instance (%s) still exists", network.ID)
 			}
+			return nil
+		}
+
+		// if we use an http client with retries,
+		// it overrrides GetEdgeNetworkInstanceNotFound error
+		if strings.Contains(err.Error(), "unexpected HTTP status 404 Not Found") {
 			return nil
 		}
 

--- a/v2/resources/network_test.go
+++ b/v2/resources/network_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -218,6 +219,12 @@ func testNetworkDestroy(s *terraform.State) error {
 			if network := response.GetPayload(); network != nil && network.ID == rs.Primary.ID {
 				return fmt.Errorf("destroy failed, Network (%s) still exists", network.ID)
 			}
+			return nil
+		}
+
+		// if we use an http client with retries,
+		// it overrrides NetworkNotFound error
+		if strings.Contains(err.Error(), "unexpected HTTP status 404 Not Found") {
 			return nil
 		}
 

--- a/v2/resources/node_test.go
+++ b/v2/resources/node_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -180,6 +181,12 @@ func testNodeDestroy(s *terraform.State) error {
 			if deviceConfig := response.GetPayload(); deviceConfig != nil && deviceConfig.ID == rs.Primary.ID {
 				return fmt.Errorf("destroy failed, Node (%s) still exists", deviceConfig.ID)
 			}
+			return nil
+		}
+
+		// if we use an http client with retries,
+		// it overrrides EdgeNodeNotFound error
+		if strings.Contains(err.Error(), "unexpected HTTP status 404 Not Found") {
 			return nil
 		}
 

--- a/v2/resources/patch_envelope_test.go
+++ b/v2/resources/patch_envelope_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -150,6 +151,12 @@ func testPatchEnvelopeDestroy(s *terraform.State) error {
 			if patchEnv := response.GetPayload(); patchEnv != nil && patchEnv.ID == rs.Primary.ID {
 				return fmt.Errorf("destroy failed, PatchEnvelope (%s) still exists", patchEnv.ID)
 			}
+			return nil
+		}
+
+		// if we use an http client with retries,
+		// it overrrides PatchEnvelopeConfigurationGetPatchEnvelopeByIDNotFound error
+		if strings.Contains(err.Error(), "unexpected HTTP status 404 Not Found") {
 			return nil
 		}
 

--- a/v2/resources/patch_reference_update_test.go
+++ b/v2/resources/patch_reference_update_test.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -141,6 +142,12 @@ func testPatchEnvelopeReferenceDestroy(s *terraform.State) error {
 				return fmt.Errorf("destroy failed, PatchEnvelope (%s) still exists", patchEnv.ID)
 			}
 			return nil
+		}
+
+		// if we use an http client with retries,
+		// it overrrides PatchEnvelopeConfigurationGetPatchEnvelopeByIDNotFound error
+		if strings.Contains(err.Error(), "unexpected HTTP status 404 Not Found") {
+			continue
 		}
 
 		// if the error is equivalent to 404 not found, the PatchEnvelope is destroyed

--- a/v2/resources/profile_deployment_service_resource_test.go
+++ b/v2/resources/profile_deployment_service_resource_test.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -124,6 +125,11 @@ func testProfileDeploymentDestroy(s *terraform.State) error {
 			if profileDeploymentResp := response.GetPayload(); profileDeploymentResp != nil && profileDeploymentResp.ID == rs.Primary.ID {
 				return fmt.Errorf("destroy failed, ProfileDeployment(%s) still exists", rs.Primary.ID)
 			}
+			return nil
+		}
+
+		// if we use an http client with retries, it overrrides ProfileDeploymentServiceGetProfileDeploymentNotFound error
+		if strings.Contains(err.Error(), "unexpected HTTP status 404 Not Found") {
 			return nil
 		}
 

--- a/v2/resources/project_test.go
+++ b/v2/resources/project_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -202,6 +203,12 @@ func testProjectDestroy(s *terraform.State) error {
 			if deviceConfig := response.GetPayload(); deviceConfig != nil && deviceConfig.ID == rs.Primary.ID {
 				return fmt.Errorf("destroy failed, Project (%s) still exists", deviceConfig.ID)
 			}
+			return nil
+		}
+
+		// if we use an http client with retries,
+		// it overrrides ProjectsGetByIDNotFound error
+		if strings.Contains(err.Error(), "unexpected HTTP status 404 Not Found") {
 			return nil
 		}
 

--- a/v2/resources/user_test.go
+++ b/v2/resources/user_test.go
@@ -3,10 +3,12 @@ package resources
 import (
 	"errors"
 	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"regexp"
-	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -123,6 +125,12 @@ func testUserDestroy(s *terraform.State) error {
 			if user := response.GetPayload(); user != nil && user.ID == rs.Primary.ID {
 				return fmt.Errorf("destroy failed, User (%s) still exists", user.ID)
 			}
+			return nil
+		}
+
+		// if we use an http client with retries,
+		// it overrrides IdentityAccessManagementGetUserNotFound error
+		if strings.Contains(err.Error(), "unexpected HTTP status 404 Not Found") {
 			return nil
 		}
 

--- a/v2/resources/volume_instance_test.go
+++ b/v2/resources/volume_instance_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -130,10 +131,16 @@ func testVolumeInstanceDestroy(s *terraform.State) error {
 			return nil
 		}
 
+		// if we use an http client with retries,
+		// it overrrides GetByIDNotFound error
+		if strings.Contains(err.Error(), "unexpected HTTP status 404 Not Found") {
+			return nil
+		}
+
 		// if the error is equivalent to 404 not found, the VolumeInstance is destroyed
 		_, ok := err.(*config.GetByIDNotFound)
 		if !ok {
-			return fmt.Errorf("destroy failed, expect status code 404 for VolumeInstance (%s)", params.ID)
+			return fmt.Errorf("destroy failed: %v, %T", err, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
- Due to the asynchronous execution of POST requests in zedcloud, sometimes we have 404 errors during `terraform apply`. It happens because when we create a resource right after the POST request, we make a GET request to fetch the latest resource state. Sometimes, these GET requests return 404 errors because the resource has not been created yet. This PR introduces retries for HTTP calls to mitigate this issue.