### PR TITLE
fix: edge node interface changes ignored(CSD-105)

### DIFF
--- a/docs/data-sources/edgenode.md
+++ b/docs/data-sources/edgenode.md
@@ -17,6 +17,7 @@ description: |-
 
 ### Required
 
+- `interfaces` (Block Set, Min: 1) System Interface list (see [below for nested schema](#nestedblock--interfaces))
 - `model_id` (String) device model
 - `name` (String) user specified device name
 - `title` (String) user specified title
@@ -41,7 +42,6 @@ description: |-
 - `edgeviewconfig` (Block List) edgeview configuration for device (see [below for nested schema](#nestedblock--edgeviewconfig))
 - `generate_soft_serial` (Boolean) indicates whether a soft serial should be generated; it will work ONLY when device is created
 - `identity` (String) Device identity
-- `interfaces` (Block List) System Interface list (see [below for nested schema](#nestedblock--interfaces))
 - `location` (String) Device location: deprecated
 - `memory` (Number) Device memory in MBs
 - `onboarding_key` (String) Object key
@@ -63,6 +63,20 @@ description: |-
 - `debug_knob` (List of Object, Sensitive) debug knob details for the device (see [below for nested schema](#nestedatt--debug_knob))
 - `id` (String) system generated unique id for a device
 - `revision` (Block List) Object revision details (see [below for nested schema](#nestedblock--revision))
+
+<a id="nestedblock--interfaces"></a>
+### Nested Schema for `interfaces`
+
+Optional:
+
+- `cost` (Number) cost of using this interface. Default is 0.
+- `intf_usage` (String) Adapter Udage
+- `intfname` (String) name of interface in the manifest to which this network or adapter maps to
+- `ipaddr` (String) IP address: we will be needing this in cae of static network
+- `macaddr` (String) mac address needs to be over-written in some cases
+- `netname` (String) network name: if attaching a network use netname
+- `tags` (Map of String) Tags are name/value pairs that enable you to categorize resources. Tag names are case insensitive with max_length 512 and min_length 3. Tag values are case sensitive with max_length 256 and min_length 3.
+
 
 <a id="nestedblock--base_image"></a>
 ### Nested Schema for `base_image`
@@ -363,20 +377,6 @@ Optional:
 - `expire_sec` (String)
 - `num_inst` (Number)
 
-
-
-<a id="nestedblock--interfaces"></a>
-### Nested Schema for `interfaces`
-
-Optional:
-
-- `cost` (Number) cost of using this interface. Default is 0.
-- `intf_usage` (String) Adapter Udage
-- `intfname` (String) name of interface in the manifest to which this network or adapter maps to
-- `ipaddr` (String) IP address: we will be needing this in cae of static network
-- `macaddr` (String) mac address needs to be over-written in some cases
-- `netname` (String) network name: if attaching a network use netname
-- `tags` (Map of String) Tags are name/value pairs that enable you to categorize resources. Tag names are case insensitive with max_length 512 and min_length 3. Tag values are case sensitive with max_length 256 and min_length 3.
 
 
 <a id="nestedatt--debug_knob"></a>

--- a/docs/data-sources/enterprise.md
+++ b/docs/data-sources/enterprise.md
@@ -42,7 +42,7 @@ description: |-
 ### Read-Only
 
 - `id` (String) Unique system defined enterprise ID
-- `revision` (List of Object) system defined info (see [below for nested schema](#nestedatt--revision))
+- `revision` (Block List) system defined info (see [below for nested schema](#nestedblock--revision))
 
 <a id="nestedblock--child_enterprises"></a>
 ### Nested Schema for `child_enterprises`
@@ -95,14 +95,14 @@ Optional:
 - `enforced_by_parent` (Boolean)
 
 
-<a id="nestedatt--revision"></a>
+<a id="nestedblock--revision"></a>
 ### Nested Schema for `revision`
 
 Read-Only:
 
-- `created_at` (String)
-- `created_by` (String)
-- `curr` (String)
-- `prev` (String)
-- `updated_at` (String)
-- `updated_by` (String)
+- `created_at` (String) The time, in milliseconds since the epoch, when the record was created.
+- `created_by` (String) User data: Created By
+- `curr` (String) Current Database version of the record
+- `prev` (String) Previous
+- `updated_at` (String) The time, in milliseconds since the epoch, when the record was last updated.
+- `updated_by` (String) User data: Updated By

--- a/docs/resources/edgenode.md
+++ b/docs/resources/edgenode.md
@@ -17,6 +17,7 @@ description: |-
 
 ### Required
 
+- `interfaces` (Block Set, Min: 1) System Interface list (see [below for nested schema](#nestedblock--interfaces))
 - `model_id` (String) device model
 - `name` (String) user specified device name
 - `title` (String) user specified title
@@ -41,7 +42,6 @@ description: |-
 - `edgeviewconfig` (Block List) edgeview configuration for device (see [below for nested schema](#nestedblock--edgeviewconfig))
 - `generate_soft_serial` (Boolean) indicates whether a soft serial should be generated; it will work ONLY when device is created
 - `identity` (String) Device identity
-- `interfaces` (Block List) System Interface list (see [below for nested schema](#nestedblock--interfaces))
 - `location` (String) Device location: deprecated
 - `memory` (Number) Device memory in MBs
 - `onboarding_key` (String) Object key
@@ -63,6 +63,20 @@ description: |-
 - `debug_knob` (List of Object, Sensitive) debug knob details for the device (see [below for nested schema](#nestedatt--debug_knob))
 - `id` (String) system generated unique id for a device
 - `revision` (Block List) Object revision details (see [below for nested schema](#nestedblock--revision))
+
+<a id="nestedblock--interfaces"></a>
+### Nested Schema for `interfaces`
+
+Optional:
+
+- `cost` (Number) cost of using this interface. Default is 0.
+- `intf_usage` (String) Adapter Udage
+- `intfname` (String) name of interface in the manifest to which this network or adapter maps to
+- `ipaddr` (String) IP address: we will be needing this in cae of static network
+- `macaddr` (String) mac address needs to be over-written in some cases
+- `netname` (String) network name: if attaching a network use netname
+- `tags` (Map of String) Tags are name/value pairs that enable you to categorize resources. Tag names are case insensitive with max_length 512 and min_length 3. Tag values are case sensitive with max_length 256 and min_length 3.
+
 
 <a id="nestedblock--base_image"></a>
 ### Nested Schema for `base_image`
@@ -363,20 +377,6 @@ Optional:
 - `expire_sec` (String)
 - `num_inst` (Number)
 
-
-
-<a id="nestedblock--interfaces"></a>
-### Nested Schema for `interfaces`
-
-Optional:
-
-- `cost` (Number) cost of using this interface. Default is 0.
-- `intf_usage` (String) Adapter Udage
-- `intfname` (String) name of interface in the manifest to which this network or adapter maps to
-- `ipaddr` (String) IP address: we will be needing this in cae of static network
-- `macaddr` (String) mac address needs to be over-written in some cases
-- `netname` (String) network name: if attaching a network use netname
-- `tags` (Map of String) Tags are name/value pairs that enable you to categorize resources. Tag names are case insensitive with max_length 512 and min_length 3. Tag values are case sensitive with max_length 256 and min_length 3.
 
 
 <a id="nestedatt--debug_knob"></a>

--- a/docs/resources/enterprise.md
+++ b/docs/resources/enterprise.md
@@ -42,7 +42,7 @@ description: |-
 ### Read-Only
 
 - `id` (String) Unique system defined enterprise ID
-- `revision` (List of Object) system defined info (see [below for nested schema](#nestedatt--revision))
+- `revision` (Block List) system defined info (see [below for nested schema](#nestedblock--revision))
 
 <a id="nestedblock--child_enterprises"></a>
 ### Nested Schema for `child_enterprises`
@@ -95,14 +95,14 @@ Optional:
 - `enforced_by_parent` (Boolean)
 
 
-<a id="nestedatt--revision"></a>
+<a id="nestedblock--revision"></a>
 ### Nested Schema for `revision`
 
 Read-Only:
 
-- `created_at` (String)
-- `created_by` (String)
-- `curr` (String)
-- `prev` (String)
-- `updated_at` (String)
-- `updated_by` (String)
+- `created_at` (String) The time, in milliseconds since the epoch, when the record was created.
+- `created_by` (String) User data: Created By
+- `curr` (String) Current Database version of the record
+- `prev` (String) Previous
+- `updated_at` (String) The time, in milliseconds since the epoch, when the record was last updated.
+- `updated_by` (String) User data: Updated By

--- a/v2/resources/testdata/application_instance/create.tf
+++ b/v2/resources/testdata/application_instance/create.tf
@@ -103,6 +103,12 @@ resource "zedcloud_edgenode" "test_tf_provider" {
 
   admin_state = "ADMIN_STATE_ACTIVE"
   asset_id = "asset_id"
+  interfaces {
+    cost = 0
+    intf_usage = "ADAPTER_USAGE_MANAGEMENT"
+    intfname = "ethernet0"
+    tags = {}
+  }
   config_item {
     bool_value = true
     float_value = 1.0
@@ -145,6 +151,7 @@ data "zedcloud_edgenode" "test_tf_provider" {
   depends_on = [
     zedcloud_edgenode.test_tf_provider
   ]
+  interfaces {}
 }
 
 resource "zedcloud_application" "test_tf_provider" {

--- a/v2/resources/testdata/asset_groups/create.tf
+++ b/v2/resources/testdata/asset_groups/create.tf
@@ -72,6 +72,12 @@ resource "zedcloud_edgenode" "test_tf_provider" {
 
   admin_state = "ADMIN_STATE_ACTIVE"
   asset_id    = "asset_id"
+  interfaces {
+    cost = 0
+    intf_usage = "ADAPTER_USAGE_MANAGEMENT"
+    intfname = "ethernet0"
+    tags = {}
+  }
   config_item {
     bool_value   = true
     float_value  = 1.0
@@ -119,6 +125,7 @@ data "zedcloud_edgenode" "test_tf_provider" {
   depends_on = [
     zedcloud_edgenode.test_tf_provider
   ]
+  interfaces {}
 }
 
 resource "zedcloud_asset_group" "test_tf_provider" {

--- a/v2/resources/testdata/network_instance/create_complete.tf
+++ b/v2/resources/testdata/network_instance/create_complete.tf
@@ -97,6 +97,12 @@ resource "zedcloud_edgenode" "test_tf_provider" {
     model_id = zedcloud_model.test_tf_provider.id
     project_id = zedcloud_project.test_tf_provider.id
     title = "title"
+    interfaces {
+        cost = 0
+        intf_usage = "ADAPTER_USAGE_MANAGEMENT"
+        intfname = "ethernet0"
+        tags = {}
+    }
 }
 
 resource "zedcloud_network_instance" "complete" {

--- a/v2/resources/testdata/network_instance/create_required_only.tf
+++ b/v2/resources/testdata/network_instance/create_required_only.tf
@@ -97,6 +97,12 @@ resource "zedcloud_edgenode" "test_tf_provider" {
   model_id = zedcloud_model.test_tf_provider.id
   project_id = zedcloud_project.test_tf_provider.id
   title = "title"
+  interfaces {
+    cost = 0
+    intf_usage = "ADAPTER_USAGE_MANAGEMENT"
+    intfname = "ethernet0"
+    tags = {}
+  }
 }
 
 

--- a/v2/resources/testdata/node/create_required_only.tf
+++ b/v2/resources/testdata/node/create_required_only.tf
@@ -104,4 +104,10 @@ resource "zedcloud_edgenode" "required_only" {
 		model_id = zedcloud_model.test_tf_provider.id
 		project_id = zedcloud_project.test_tf_provider.id
 		title = "required_only-title"
+	interfaces {
+		cost = 0
+		intf_usage = "ADAPTER_USAGE_MANAGEMENT"
+		intfname = "ethernet0"
+		tags = {}
+	}
 }

--- a/v2/resources/testdata/patch_reference_update/create.tf
+++ b/v2/resources/testdata/patch_reference_update/create.tf
@@ -105,6 +105,12 @@ resource "zedcloud_edgenode" "test_tf_provider" {
 
   admin_state = "ADMIN_STATE_ACTIVE"
   asset_id = "asset_id"
+  interfaces {
+    cost = 0
+    intf_usage = "ADAPTER_USAGE_MANAGEMENT"
+    intfname = "ethernet0"
+    tags = {}
+  }
   config_item {
     bool_value = true
     float_value = 1.0

--- a/v2/resources/testdata/profile_deployments/create.tf
+++ b/v2/resources/testdata/profile_deployments/create.tf
@@ -119,6 +119,7 @@ data "zedcloud_edgenode" "test_tf_provider" {
   depends_on = [
     zedcloud_edgenode.test_tf_provider
   ]
+  interfaces {}
 }
 
 resource "zedcloud_asset_group" "test_tf_provider" {

--- a/v2/resources/testdata/volume_instance/create.tf
+++ b/v2/resources/testdata/volume_instance/create.tf
@@ -69,6 +69,12 @@ resource "zedcloud_edgenode" "test_tf_provider" {
     zedcloud_model.test_tf_provider,
     zedcloud_project.test_tf_provider
   ]
+  interfaces {
+    cost = 0
+    intf_usage = "ADAPTER_USAGE_MANAGEMENT"
+    intfname = "ethernet0"
+    tags = {}
+  }
 }
 
 resource "zedcloud_volume_instance"  "test_volume_instance" {

--- a/v2/schemas/node.go
+++ b/v2/schemas/node.go
@@ -664,10 +664,8 @@ func Node() map[string]*schema.Schema {
 			Description: `System Interface list`,
 			Type:        schema.TypeSet, //GoType: []*SysInterface
 			Elem:        systemInterfaceElem(),
-			Optional:    true,
+			Required:    true,
 			Set:         schema.HashResource(systemInterfaceElem()),
-			DiffSuppressFunc: diffSupressMapInterfaceNonConfigChangesV2("interfaces",
-				[]string{"netname", "intfname", "ipaddr", "macaddr"}),
 		},
 
 		"location": {

--- a/v2/schemas/node.go
+++ b/v2/schemas/node.go
@@ -662,13 +662,10 @@ func Node() map[string]*schema.Schema {
 
 		"interfaces": {
 			Description: `System Interface list`,
-			Type:        schema.TypeList, //GoType: []*SysInterface
-			Elem: &schema.Resource{
-				Schema: SystemInterface(),
-			},
-			// ConfigMode: schema.SchemaConfigModeAttr,
-			Optional:         true,
-			DiffSuppressFunc: diffSuppressSystemInterfaceListOrder("interfaces"),
+			Type:        schema.TypeSet, //GoType: []*SysInterface
+			Elem:        systemInterfaceElem(),
+			Optional:    true,
+			Set:         schema.HashResource(systemInterfaceElem()),
 		},
 
 		"location": {
@@ -859,5 +856,11 @@ func GetEdgeNodePropertyFields() (t []string) {
 		"title",
 		"token",
 		"utype",
+	}
+}
+
+func systemInterfaceElem() *schema.Resource {
+	return &schema.Resource{
+		Schema: SystemInterface(),
 	}
 }

--- a/v2/schemas/node.go
+++ b/v2/schemas/node.go
@@ -666,6 +666,8 @@ func Node() map[string]*schema.Schema {
 			Elem:        systemInterfaceElem(),
 			Optional:    true,
 			Set:         schema.HashResource(systemInterfaceElem()),
+			DiffSuppressFunc: diffSupressMapInterfaceNonConfigChangesV2("interfaces",
+				[]string{"netname", "intfname", "ipaddr", "macaddr"}),
 		},
 
 		"location": {


### PR DESCRIPTION
The issue is that ZedCloud changes the order of the `interfaces` list. Zedcloud transforms interfaces from a list to a map and stores it as a map in the database. So, there is no way to restore order without changing how we store data in the database.  To suppress this, we have defined DiffSuppresFunc as https://github.com/zededa/terraform-provider-zedcloud/blob/main/v2/schemas/node.go#L671. This function allows the `terraform plan` to not complain about the interfaces ordering but doesn't show changes in the existing elements of the interfaces list.

The best practice in Terraform is to use `Type: schema.TypeSet` instead of `Type: schema.TypeList` for fields where the ordering of elements is not essential or where we can’t have consistent ordering. The problem with the schema.TypeSet is that when we make changes in one of the elements of the list or add a new element, the `terraform plan` will show that it needs to update the whole interfaces list. Still, it is a proper behavior by Terraform as it treats interfaces as one object.
```
# zedcloud_edgenode.ivan_test_tf_provider will be updated in-place
  ~ resource "zedcloud_edgenode" "ivan_test_tf_provider" {
        id                        = "6c3d0fb5-983a-4138-a42f-f2224dee9aa9"
        name                      = "ivan_test_tf_provider"
        tags                      = {
            "tag-key-1" = "tag-value-1"
            "tag-key-2" = "tag-value-2"
        }
        # (21 unchanged attributes hidden)

      - interfaces {
          - cost       = 0 -> null
          - intf_usage = "ADAPTER_USAGE_UNSPECIFIED" -> null
          - intfname   = "eth0" -> null
          - tags       = {} -> null
        }
      - interfaces {
          - cost       = 255 -> null
          - intf_usage = "ADAPTER_USAGE_MANAGEMENT" -> null
          - intfname   = "defaultIPv4" -> null
          - ipaddr     = "127.0.0.1" -> null
          - macaddr    = "00:00:00:00:00:00" -> null
          - tags       = {
              - "system_interface_1_key" = "system_interface_1_value"
              - "system_interface_2_key" = "system_interface_2_value"
            } -> null
        }
      + interfaces {
          + cost       = 0
          + intf_usage = "ADAPTER_USAGE_MANAGEMENT"
          + intfname   = "COM3"
        }
      + interfaces {
          + cost       = 255
          + intf_usage = "ADAPTER_USAGE_MANAGEMENT"
          + intfname   = "defaultIPv4"
          + ipaddr     = "127.0.0.1"
          + macaddr    = "00:00:00:00:00:00"
          + tags       = {
              + "system_interface_1_key" = "system_interface_1_value"
              + "system_interface_2_key" = "system_interface_2_value"
            }
        }
      + interfaces {
          + intf_usage = "ADAPTER_USAGE_MANAGEMENT"
          + intfname   = "eth0"
        }

        # (3 unchanged blocks hidden)
    }

```