### PR TITLE
fix: Set default value for the activate field to true (eng-1775)

### DIFF
--- a/v2/schemas/application_instance.go
+++ b/v2/schemas/application_instance.go
@@ -513,6 +513,7 @@ func ApplicationInstance() map[string]*schema.Schema {
 			Description: `app instance activation flag`,
 			Type:        schema.TypeBool,
 			Optional:    true,
+			Default:     true,
 		},
 
 		"app_id": {


### PR DESCRIPTION
Changes:
- Added a default value for the activate field of the app instances schema. The default is true.

Tickets:
- https://zededa.atlassian.net/browse/ENG-1775