### PR TITLE
fix: add error handling on HTTP client errors

### DIFF
--- a/v2/resources/provider.go
+++ b/v2/resources/provider.go
@@ -165,12 +165,14 @@ func BearerToken(token string) runtime.ClientAuthInfoWriter {
 func getRetryClient() *retryablehttp.Client {
 	retryClient := retryablehttp.NewClient()
 	retryClient.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
-		if resp.StatusCode == http.StatusNotFound {
-			return true, fmt.Errorf("unexpected HTTP status %s", resp.Status)
-		}
-		// We cannot retry on other methods rather than GET. Out API is not idempotent
-		if resp.Request.Method != http.MethodGet {
-			return false, nil
+		if err == nil {
+			if resp.StatusCode == http.StatusNotFound {
+				return true, fmt.Errorf("unexpected HTTP status %s", resp.Status)
+			}
+			// We cannot retry on other methods rather than GET. Out API is not idempotent
+			if resp.Request.Method != http.MethodGet {
+				return false, nil
+			}
 		}
 		return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
 	}


### PR DESCRIPTION
When the HTTP client returns an error, it is not safe to access the response object`resp` (e.g. when the server presents a certificate that the client does not trust) and the provider process will likely crash with a segfault exception.