### PR TITLE
feat: add option to skip TLS verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ NOTE: Enabling this debug will cause each HTTP request & response to be dumped a
       with "logging level" `DEBUG`. It's useful for troubleshooting why certaing TF configs are either 
       not accepted by Zedcloud or do not produce the expected results. 
       It will EXPOSE the authentication token!
+
+export TF_INSECURE_SKIP_TLS_VERIFY=true
+
+NOTE: This option disables TLS certificate verification. Only use this when you are connecting to a 
+      Zededa Cloud instance that uses a self-signed certificate, such as a development or on-premise 
+      deployment. Setting this to `true` is insecure and should NOT be used in production environments.
 ```
 
 ## Documentation


### PR DESCRIPTION
Introduces the `TF_INSECURE_SKIP_TLS_VERIFY` environment variable to allow the provider to connect to Zededa Cloud instances with self-signed or otherwise invalid TLS certificates. This is necessary for users running on-premise or development deployments where a valid, publicly trusted certificate may not be configured.

When set to `true`, the underlying HTTP client will be configured to skip TLS verification. Documentation for this new variable has been added to the README, including a security warning for production use.