### PR TITLE
fix: add DiffSuppressFunc for the vlan_adapters field in the node schema(CI-781)

### DIFF
--- a/v2/schemas/node.go
+++ b/v2/schemas/node.go
@@ -981,7 +981,8 @@ func Node() map[string]*schema.Schema {
 				Schema: VlanAdapterSchema(),
 			},
 			// ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:         true,
+			DiffSuppressFunc: diffSuppressVlanAdapterListOrder("vlan_adapters"),
 		},
 	}
 }

--- a/v2/schemas/schema_helpers.go
+++ b/v2/schemas/schema_helpers.go
@@ -175,6 +175,53 @@ func diffSuppressSystemInterfaceListOrder(mapKey string) schema.SchemaDiffSuppre
 	}
 }
 
+func diffSuppressVlanAdapterListOrder(mapKey string) schema.SchemaDiffSuppressFunc {
+	return func(key, oldValue, newValue string, d *schema.ResourceData) bool {
+		oldData, newData := d.GetChange(mapKey)
+		if newData == nil && oldData == nil {
+			return true
+		}
+
+		if oldData == nil {
+			return false
+		}
+		if newData == nil {
+			return false
+		}
+
+		old := oldData.([]interface{})
+		new := newData.([]interface{})
+		if len(old) != len(new) {
+			return false
+		}
+
+		var oldMapList []*models.VlanAdapter
+		for _, o := range old {
+			if o == nil {
+				continue
+			}
+			if oldElem, ok := o.(map[string]interface{}); ok {
+				oldMapList = append(oldMapList, VlanAdapterModelFromMap(oldElem))
+			}
+		}
+		var newMapList []*models.VlanAdapter
+		for _, n := range new {
+			if n == nil {
+				continue
+			}
+			if newElem, ok := n.(map[string]interface{}); ok {
+				newMapList = append(newMapList, VlanAdapterModelFromMap(newElem))
+			}
+		}
+
+		adapterMismatch, reason := CompareVlanAdapterLists(oldMapList, newMapList)
+		if !adapterMismatch {
+			log.Printf("VlanAdapter list mismatch: %s\n", reason)
+		}
+		return adapterMismatch
+	}
+}
+
 func diffSuppressInterfaceListOrder(mapKey string) schema.SchemaDiffSuppressFunc {
 	return func(key, oldValue, newValue string, d *schema.ResourceData) bool {
 		oldData, newData := d.GetChange(mapKey)


### PR DESCRIPTION
- Node field `vlan_adapters` has random ordering, because of it, we see differences in the Terraform plan even if we didn't do any.
- This PR introduces DiffSuppressFunc for the `vlan_adapters` field to fix the issue.