### PR TITLE
fix: Add pinentry-mode and loopback options for GPG signing in gorele…

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,6 +41,8 @@ signs:
       # if you are using this in a GitHub action or some other automated pipeline, you
       # need to pass the batch flag to indicate its not interactive.
       - "--batch"
+      - "--pinentry-mode"
+      - "loopback"
       - "--local-user"
       - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
       - "--output"


### PR DESCRIPTION
This pull request makes a minor update to the GPG signing configuration in `.goreleaser.yml` to improve automation compatibility.

* GPG signing now explicitly sets the `--pinentry-mode` to `loopback` to ensure non-interactive operation in automated pipelines.