### PR TITLE
fix: path_list not being honored in GitRepoRepositoryDetails

### DIFF
--- a/v2/schemas/git_repo_repository_details.go
+++ b/v2/schemas/git_repo_repository_details.go
@@ -10,7 +10,7 @@ func GitRepoRepositoryDetailsModel(d *schema.ResourceData) *models.GitRepoReposi
 	branch, _ := d.Get("branch").(string)
 	commit, _ := d.Get("commit").(string)
 	var pathList []string
-	pathListInterface, pathListIsSet := d.GetOk("pathList")
+	pathListInterface, pathListIsSet := d.GetOk("path_list")
 	if pathListIsSet {
 		var items []interface{}
 		if listItems, isList := pathListInterface.([]interface{}); isList {
@@ -38,7 +38,7 @@ func GitRepoRepositoryDetailsModelFromMap(m map[string]interface{}) *models.GitR
 	branch := m["branch"].(string)
 	commit := m["commit"].(string)
 	var pathList []string
-	pathListInterface, pathListIsSet := m["pathList"]
+	pathListInterface, pathListIsSet := m["path_list"]
 	if pathListIsSet {
 		var items []interface{}
 		if listItems, isList := pathListInterface.([]interface{}); isList {


### PR DESCRIPTION
Changed from camelCase 'pathList' to snake_case 'path_list' to match the schema definition in GitRepoRepositoryDetailsModel functions