### PR TITLE
fix: base image shows diffs for imgvol field(CI-807)

### DIFF
--- a/v2/schemas/base_os_image.go
+++ b/v2/schemas/base_os_image.go
@@ -76,19 +76,19 @@ func BaseOSImage() map[string]*schema.Schema {
 		"imvol_id": {
 			Description: `immutable Volume for this base image`,
 			Type:        schema.TypeString,
-			Optional:    true,
+			Computed:    true,
 		},
 
 		"uuid": {
 			Description: `system generated unique id for an image`,
 			Type:        schema.TypeString,
-			Optional:    true,
+			Computed:    true,
 		},
 
 		"version": {
 			Description: `image version`,
 			Type:        schema.TypeString,
-			Required:    true,
+			Optional:    true,
 		},
 	}
 }


### PR DESCRIPTION
- Every time we update the base os image, zedcloud generates a new imgvol_id, so I marked this field as computed.
- Removed mandatory field `version`, as it is not used on zedcloud side.