### PR TITLE
fix: add diff suppress functions for `base_image` and `edgeviewconfig`(CI-736)

### DIFF
--- a/v2/schemas/node.go
+++ b/v2/schemas/node.go
@@ -659,7 +659,8 @@ func Node() map[string]*schema.Schema {
 				Schema: BaseOSImage(),
 			},
 			// ConfigMode: schema.SchemaConfigModeAttr,
-			Optional: true,
+			Optional:         true,
+			DiffSuppressFunc: diffSuppressBaseImage("base_image"),
 		},
 
 		"base_os_force_upgrade": {
@@ -797,7 +798,8 @@ func Node() map[string]*schema.Schema {
 			Elem: &schema.Resource{
 				Schema: EdgeView(),
 			},
-			Optional: true,
+			Optional:         true,
+			DiffSuppressFunc: diffSuppressEdgeviewConfig("edgeviewconfig"),
 		},
 
 		"generate_soft_serial": {
@@ -815,7 +817,7 @@ func Node() map[string]*schema.Schema {
 		"identity": {
 			Description: `Device identity`,
 			Type:        schema.TypeString,
-			Optional:    true,
+			Computed:    true,
 		},
 
 		"interfaces": {

--- a/v2/schemas/schema_helpers.go
+++ b/v2/schemas/schema_helpers.go
@@ -3,6 +3,7 @@ package schemas
 import (
 	"fmt"
 	"log"
+	"reflect"
 	"slices"
 	"strings"
 
@@ -499,6 +500,59 @@ func diffSuppressIfFieldValueEqual(field, value string) schema.SchemaDiffSuppres
 		}
 
 		return false
+	}
+}
+
+func isFieldDefinedInTerraformConfig(d *schema.ResourceData, field string) bool {
+	rawConfig := d.GetRawConfig()
+	if !rawConfig.IsKnown() || rawConfig.IsNull() {
+		return false
+	}
+
+	rawConfigMap := rawConfig.AsValueMap()
+	rawField, ok := rawConfigMap[field]
+	if !ok {
+		return false
+	}
+
+	return rawField.IsKnown() && !rawField.IsNull()
+}
+
+func diffSuppressBaseImage(field string) schema.SchemaDiffSuppressFunc {
+	return func(key, oldValue, newValue string, d *schema.ResourceData) bool {
+		if !isFieldDefinedInTerraformConfig(d, field) {
+			return true
+		}
+
+		oldData, newData := d.GetChange(field)
+		if oldData == nil && newData == nil {
+			return true
+		}
+
+		if oldData == nil || newData == nil {
+			return false
+		}
+
+		return reflect.DeepEqual(oldData, newData)
+	}
+}
+
+func diffSuppressEdgeviewConfig(field string) schema.SchemaDiffSuppressFunc {
+	return func(key, oldValue, newValue string, d *schema.ResourceData) bool {
+		if !isFieldDefinedInTerraformConfig(d, field) {
+			return true
+		}
+
+		oldData, newData := d.GetChange(field)
+		if oldData == nil && newData == nil {
+			return true
+		}
+
+		if oldData == nil || newData == nil {
+			return false
+		}
+
+		return reflect.DeepEqual(oldData, newData)
 	}
 }
 


### PR DESCRIPTION
- We have cases when an edge node doesn't have a defined `base_image` and `edgeviewconfig`, but zedcloud returns values for these fields inherited from other objects(project, for example). This PR adds diff suppress functions that ignore changes to `base_image` and `edgeviewconfig` if they are not defined in the Terraform configuration.