### PR TITLE
feat: update terraform to encode ca cert in create/update cep flow (ZEDCLOUD-2374)

### DIFF
--- a/v2/resources/cep_profile.go
+++ b/v2/resources/cep_profile.go
@@ -30,7 +30,7 @@ func CEPProfileResource() *schema.Resource {
 func CEPProfileDataSource() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: GetCEPProfile,
-		Schema:      zschema.CEPProfileSchema(),
+		Schema:      zschema.CEPProfileDataSourceSchema(),
 	}
 }
 

--- a/v2/resources/cep_profile_test.go
+++ b/v2/resources/cep_profile_test.go
@@ -65,7 +65,6 @@ func TestCEPProfile_CRUD(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"secret",
-					"ca_cert_pem",
 				},
 			},
 		},

--- a/v2/resources/testdata/cep_profile/create.tf
+++ b/v2/resources/testdata/cep_profile/create.tf
@@ -11,20 +11,17 @@ resource "zedcloud_cep_profile" "test_tf_provider" {
   ]
 
   csr_profile {
-    common_name          = "device-{{.DeviceID}}"
+    common_name          = "$zri.system.edge-node.name"
     organization         = "Zededa"
     organizational_unit  = "Engineering"
     country              = "US"
     renew_period_percent = 80
     key_type             = "KEY_TYPE_RSA_2048"
     hash_algorithm       = "HASH_ALGORITHM_SHA256"
+    san_uri              = ["urn:zri:$zri.system.edge-node.id"]
   }
 
   secret {
     challenge_password = "test-challenge-password"
-  }
-
-  lifecycle {
-    ignore_changes = [ca_cert_pem]
   }
 }

--- a/v2/resources/testdata/cep_profile/create.yaml
+++ b/v2/resources/testdata/cep_profile/create.yaml
@@ -4,10 +4,12 @@ description: Test SCEP certificate enrollment profile
 scepUrl: "https://scep.example.com/scep"
 useControllerProxy: false
 csrProfile:
-  commonName: "device-{{.DeviceID}}"
+  commonName: "$zri.system.edge-node.name"
   organization: Zededa
   organizationalUnit: Engineering
   country: US
   renewPeriodPercent: 80
   keyType: KEY_TYPE_RSA_2048
   hashAlgorithm: HASH_ALGORITHM_SHA256
+  sanUri:
+    - "urn:zri:$zri.system.edge-node.id"

--- a/v2/resources/testdata/cep_profile/update.tf
+++ b/v2/resources/testdata/cep_profile/update.tf
@@ -11,20 +11,17 @@ resource "zedcloud_cep_profile" "test_tf_provider" {
   ]
 
   csr_profile {
-    common_name          = "device-{{.DeviceID}}"
+    common_name          = "$zri.system.edge-node.name"
     organization         = "Zededa"
     organizational_unit  = "DevOps"
     country              = "US"
     renew_period_percent = 70
     key_type             = "KEY_TYPE_RSA_2048"
     hash_algorithm       = "HASH_ALGORITHM_SHA256"
+    san_uri              = ["urn:zri:$zri.system.edge-node.id"]
   }
 
   secret {
     challenge_password = "updated-challenge-password"
-  }
-
-  lifecycle {
-    ignore_changes = [ca_cert_pem]
   }
 }

--- a/v2/resources/testdata/cep_profile/update.yaml
+++ b/v2/resources/testdata/cep_profile/update.yaml
@@ -4,10 +4,12 @@ description: Updated SCEP certificate enrollment profile
 scepUrl: "https://scep.example.com/scep"
 useControllerProxy: false
 csrProfile:
-  commonName: "device-{{.DeviceID}}"
+  commonName: "$zri.system.edge-node.name"
   organization: Zededa
   organizationalUnit: DevOps
   country: US
   renewPeriodPercent: 70
   keyType: KEY_TYPE_RSA_2048
   hashAlgorithm: HASH_ALGORITHM_SHA256
+  sanUri:
+    - "urn:zri:$zri.system.edge-node.id"

--- a/v2/schemas/cep_profile.go
+++ b/v2/schemas/cep_profile.go
@@ -4,6 +4,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"strings"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -13,9 +14,13 @@ import (
 // validatePEMCertificate checks that the value is a valid PEM-encoded X.509 certificate.
 func validatePEMCertificate(v interface{}, k string) (warnings []string, errors []error) {
 	s := v.(string)
-	block, _ := pem.Decode([]byte(s))
+	block, rest := pem.Decode([]byte(s))
 	if block == nil {
 		errors = append(errors, fmt.Errorf("%q: not a valid PEM-encoded certificate (missing or malformed PEM block)", k))
+		return
+	}
+	if len(strings.TrimSpace(string(rest))) > 0 {
+		errors = append(errors, fmt.Errorf("%q: contains extra data after the PEM block; each list entry must contain exactly one certificate", k))
 		return
 	}
 	if _, err := x509.ParseCertificate(block.Bytes); err != nil {
@@ -36,7 +41,14 @@ func CEPProfileModel(d *schema.ResourceData) *models.CEPCommonSCEPProfile {
 	caCertPemInterface, caCertPemIsSet := d.GetOk("ca_cert_pem")
 	if caCertPemIsSet {
 		for _, v := range caCertPemInterface.([]interface{}) {
-			caCertPem = append(caCertPem, strfmt.Base64(v.(string)))
+			if s, ok := v.(string); ok && s != "" {
+				// The API requires each PEM cert to end with a trailing newline.
+				// Without it, the API silently stores 0 certs. Add one if missing.
+				if !strings.HasSuffix(s, "\n") {
+					s += "\n"
+				}
+				caCertPem = append(caCertPem, strfmt.Base64(s))
+			}
 		}
 	}
 
@@ -90,7 +102,9 @@ func CEPProfileModelFromMap(m map[string]interface{}) *models.CEPCommonSCEPProfi
 	caCertPemInterface, caCertPemIsSet := m["ca_cert_pem"]
 	if caCertPemIsSet {
 		for _, v := range caCertPemInterface.([]interface{}) {
-			caCertPem = append(caCertPem, strfmt.Base64(v.(string)))
+			if s, ok := v.(string); ok && s != "" {
+				caCertPem = append(caCertPem, strfmt.Base64(s))
+			}
 		}
 	}
 
@@ -205,9 +219,11 @@ func SetCEPProfileResourceData(d *schema.ResourceData, m *models.CEPCommonSCEPPr
 	}
 	d.Set("use_controller_proxy", m.UseControllerProxy)
 
+	// Trim whitespace from each cert before storing in state: the API may return PEM blocks with a
+	// trailing newline that the user's config omits, causing a spurious diff on identical content.
 	var caCertPemStrings []string
 	for _, b := range m.CaCertPem {
-		caCertPemStrings = append(caCertPemStrings, string(b))
+		caCertPemStrings = append(caCertPemStrings, strings.TrimSpace(string(b)))
 	}
 	d.Set("ca_cert_pem", caCertPemStrings)
 
@@ -263,8 +279,16 @@ func SetCEPCSRProfileSubResourceData(m []*models.CEPCommonCSRProfile) (d []*map[
 			properties["state"] = csrProfile.State
 			properties["locality"] = csrProfile.Locality
 			properties["renew_period_percent"] = int(csrProfile.RenewPeriodPercent)
-			properties["san_uri"] = csrProfile.SanURI
-			properties["san_email"] = csrProfile.SanEmail
+			if csrProfile.SanURI != nil {
+				properties["san_uri"] = csrProfile.SanURI
+			} else {
+				properties["san_uri"] = []string{}
+			}
+			if csrProfile.SanEmail != nil {
+				properties["san_email"] = csrProfile.SanEmail
+			} else {
+				properties["san_email"] = []string{}
+			}
 			if csrProfile.KeyType != nil {
 				properties["key_type"] = string(*csrProfile.KeyType)
 			} else {
@@ -467,4 +491,23 @@ func CEPProfileSchema() map[string]*schema.Schema {
 			},
 		},
 	}
+}
+
+// CEPProfileDataSourceSchema returns the schema for the CEP profile data source.
+// Identical to CEPProfileSchema except Required fields become Optional+Computed
+// so users only need to supply name or id for the lookup.
+func CEPProfileDataSourceSchema() map[string]*schema.Schema {
+	s := CEPProfileSchema()
+	s["scep_url"].Required = false
+	s["scep_url"].Optional = true
+	s["scep_url"].Computed = true
+	s["ca_cert_pem"].Required = false
+	s["ca_cert_pem"].Optional = true
+	s["ca_cert_pem"].Computed = true
+	s["ca_cert_pem"].MinItems = 0
+	s["csr_profile"].Required = false
+	s["csr_profile"].Optional = true
+	s["csr_profile"].Computed = true
+	s["csr_profile"].MinItems = 0
+	return s
 }

--- a/v2/schemas/cep_profile.go
+++ b/v2/schemas/cep_profile.go
@@ -1,10 +1,28 @@
 package schemas
 
 import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/zededa/terraform-provider-zedcloud/v2/models"
 )
+
+// validatePEMCertificate checks that the value is a valid PEM-encoded X.509 certificate.
+func validatePEMCertificate(v interface{}, k string) (warnings []string, errors []error) {
+	s := v.(string)
+	block, _ := pem.Decode([]byte(s))
+	if block == nil {
+		errors = append(errors, fmt.Errorf("%q: not a valid PEM-encoded certificate (missing or malformed PEM block)", k))
+		return
+	}
+	if _, err := x509.ParseCertificate(block.Bytes); err != nil {
+		errors = append(errors, fmt.Errorf("%q: invalid X.509 certificate: %s", k, err))
+	}
+	return
+}
 
 func CEPProfileModel(d *schema.ResourceData) *models.CEPCommonSCEPProfile {
 	id, _ := d.Get("id").(string)
@@ -189,7 +207,7 @@ func SetCEPProfileResourceData(d *schema.ResourceData, m *models.CEPCommonSCEPPr
 
 	var caCertPemStrings []string
 	for _, b := range m.CaCertPem {
-		caCertPemStrings = append(caCertPemStrings, b.String())
+		caCertPemStrings = append(caCertPemStrings, string(b))
 	}
 	d.Set("ca_cert_pem", caCertPemStrings)
 
@@ -219,7 +237,7 @@ func SetCEPProfileSubResourceData(m []*models.CEPCommonSCEPProfile) (d []*map[st
 			properties["use_controller_proxy"] = CEPProfileModel.UseControllerProxy
 			var caCertPemStrings []string
 			for _, b := range CEPProfileModel.CaCertPem {
-				caCertPemStrings = append(caCertPemStrings, b.String())
+				caCertPemStrings = append(caCertPemStrings, string(b))
 			}
 			properties["ca_cert_pem"] = caCertPemStrings
 			properties["csr_profile"] = SetCEPCSRProfileSubResourceData([]*models.CEPCommonCSRProfile{CEPProfileModel.CsrProfile})
@@ -293,7 +311,7 @@ func CEPProfileSchema() map[string]*schema.Schema {
 		"title": {
 			Description: `Human-readable display title`,
 			Type:        schema.TypeString,
-			Required:    true,
+			Optional:    true,
 		},
 
 		"description": {
@@ -318,9 +336,11 @@ func CEPProfileSchema() map[string]*schema.Schema {
 			Description: `PEM-encoded trusted CA certificates for SCEP server validation`,
 			Type:        schema.TypeList,
 			Elem: &schema.Schema{
-				Type: schema.TypeString,
+				Type:         schema.TypeString,
+				ValidateFunc: validatePEMCertificate,
 			},
-			Optional: true,
+			Required: true,
+			MinItems: 1,
 		},
 
 		"csr_profile": {


### PR DESCRIPTION
- added validation for uploading cert while creating/updating cep.
-  making ca cert field as required.
-  Updated title field as optional