### PR TITLE
fix: panic due to manifest field type assertion in EdgeNodeClusterConfig (CI-875)

### DIFF
--- a/v2/schemas/edge_node_cluster_config.go
+++ b/v2/schemas/edge_node_cluster_config.go
@@ -1,6 +1,8 @@
 package schemas
 
 import (
+	"log"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/zededa/terraform-provider-zedcloud/v2/models"
@@ -10,7 +12,20 @@ func EdgeNodeClusterConfigModel(d *schema.ResourceData) *models.EdgeNodeClusterC
 	clusterPrefix, _ := d.Get("cluster_prefix").(string)
 	id, _ := d.Get("id").(string)
 	isMaster, _ := d.Get("is_master").(bool)
-	manifest, _ := d.Get("manifest").(strfmt.Base64)
+
+	manifest := strfmt.Base64{}
+	switch v := d.Get("manifest").(type) {
+	case strfmt.Base64:
+		manifest = v
+	case string:
+		if err := manifest.UnmarshalText([]byte(v)); err != nil {
+			log.Printf("[ERROR] failed to unmarshal manifest string as base64: %s", err)
+		}
+	case []byte:
+		if err := manifest.UnmarshalText(v); err != nil {
+			log.Printf("[ERROR] failed to unmarshal manifest bytes as base64: %s", err)
+		}
+	}
 	name, _ := d.Get("name").(string)
 	projectID, _ := d.Get("project_id").(string)
 	seedNodeID, _ := d.Get("seed_node_id").(string)
@@ -48,7 +63,20 @@ func EdgeNodeClusterConfigModelFromMap(m map[string]interface{}) *models.EdgeNod
 	clusterPrefix := m["cluster_prefix"].(string)
 	id := m["id"].(string)
 	isMaster := m["is_master"].(bool)
-	manifest := m["manifest"].(strfmt.Base64)
+
+	manifest := strfmt.Base64{}
+	switch v := m["manifest"].(type) {
+	case strfmt.Base64:
+		manifest = v
+	case string:
+		if err := manifest.UnmarshalText([]byte(v)); err != nil {
+			log.Printf("[ERROR] failed to unmarshal manifest string as base64: %s", err)
+		}
+	case []byte:
+		if err := manifest.UnmarshalText(v); err != nil {
+			log.Printf("[ERROR] failed to unmarshal manifest bytes as base64: %s", err)
+		}
+	}
 	name := m["name"].(string)
 	projectID := m["project_id"].(string)
 	seedNodeID := m["seed_node_id"].(string)

--- a/v2/schemas/edge_node_cluster_config_test.go
+++ b/v2/schemas/edge_node_cluster_config_test.go
@@ -1,0 +1,125 @@
+package schemas
+
+import (
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// TestEdgeNodeClusterConfigModelFromMap_ExampleJSON verifies that
+// EdgeNodeClusterConfigModelFromMap does not panic when the manifest
+// field is provided as a plain string (as returned from Terraform state).
+func TestEdgeNodeClusterConfigModelFromMap_ExampleJSON(t *testing.T) {
+	m := map[string]interface{}{
+		"cluster_prefix":      "10.244.244.0/28",
+		"id":                  "afec1006-4a0d-41e6-bccf-ffdb065deb7d",
+		"is_master":           true,
+		"manifest":            "", // comes in as string from Terraform state
+		"name":                "test-cluster",
+		"project_id":          "4fdc30c8-0bc8-4f78-b649-94053514f106",
+		"seed_node_id":        "e523cb50-7e82-4193-8879-0d687efef70c",
+		"seed_node_ip":        "10.244.244.2",
+		"tags":                map[string]interface{}{},
+		"tie_breaker_node_id": "14ba9bc9-31f6-4986-bcd8-4d545a5317e9",
+		"token":               "WAi6N8OI6D1wqYjWzNMd7N5tNGnM9zsrKh0eZIKg6EE=",
+	}
+
+	result := EdgeNodeClusterConfigModelFromMap(m)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.ID != "afec1006-4a0d-41e6-bccf-ffdb065deb7d" {
+		t.Errorf("expected id 'afec1006-4a0d-41e6-bccf-ffdb065deb7d', got %q", result.ID)
+	}
+	if result.Name != "test-cluster" {
+		t.Errorf("expected name 'test-cluster', got %q", result.Name)
+	}
+}
+
+// TestEdgeNodeClusterConfigModelFromMap_StringManifest verifies that
+// a non-empty base64 string manifest is parsed correctly without panicking.
+func TestEdgeNodeClusterConfigModelFromMap_StringManifest(t *testing.T) {
+	// "hello world" base64 encoded
+	b64manifest := "aGVsbG8gd29ybGQ="
+	m := map[string]interface{}{
+		"cluster_prefix":      "10.244.244.0/28",
+		"id":                  "afec1006-4a0d-41e6-bccf-ffdb065deb7d",
+		"is_master":           false,
+		"manifest":            b64manifest,
+		"name":                "test-cluster",
+		"project_id":          "4fdc30c8-0bc8-4f78-b649-94053514f106",
+		"seed_node_id":        "e523cb50-7e82-4193-8879-0d687efef70c",
+		"seed_node_ip":        "10.244.244.2",
+		"tags":                map[string]interface{}{},
+		"tie_breaker_node_id": "14ba9bc9-31f6-4986-bcd8-4d545a5317e9",
+		"token":               "WAi6N8OI6D1wqYjWzNMd7N5tNGnM9zsrKh0eZIKg6EE=",
+	}
+
+	result := EdgeNodeClusterConfigModelFromMap(m)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if string(result.Manifest) != "hello world" {
+		t.Errorf("expected manifest 'hello world', got %q", string(result.Manifest))
+	}
+}
+
+// TestEdgeNodeClusterConfigModelFromMap_Base64Manifest verifies that
+// a strfmt.Base64 manifest value is handled correctly.
+func TestEdgeNodeClusterConfigModelFromMap_Base64Manifest(t *testing.T) {
+	manifest := strfmt.Base64("hello world")
+	m := map[string]interface{}{
+		"cluster_prefix":      "10.244.244.0/28",
+		"id":                  "afec1006-4a0d-41e6-bccf-ffdb065deb7d",
+		"is_master":           false,
+		"manifest":            manifest,
+		"name":                "test-cluster",
+		"project_id":          "4fdc30c8-0bc8-4f78-b649-94053514f106",
+		"seed_node_id":        "e523cb50-7e82-4193-8879-0d687efef70c",
+		"seed_node_ip":        "10.244.244.2",
+		"tags":                map[string]interface{}{},
+		"tie_breaker_node_id": "14ba9bc9-31f6-4986-bcd8-4d545a5317e9",
+		"token":               "WAi6N8OI6D1wqYjWzNMd7N5tNGnM9zsrKh0eZIKg6EE=",
+	}
+
+	result := EdgeNodeClusterConfigModelFromMap(m)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if string(result.Manifest) != "hello world" {
+		t.Errorf("expected manifest 'hello world', got %q", string(result.Manifest))
+	}
+}
+
+// TestEdgeNodeClusterConfigModel_ExampleJSON verifies that
+// EdgeNodeClusterConfigModel reads from ResourceData without panicking,
+// including when manifest is stored as a string in Terraform state.
+func TestEdgeNodeClusterConfigModel_ExampleJSON(t *testing.T) {
+	raw := map[string]interface{}{
+		"cluster_prefix":      "10.244.244.0/28",
+		"id":                  "afec1006-4a0d-41e6-bccf-ffdb065deb7d",
+		"is_master":           true,
+		"manifest":            "aGVsbG8gd29ybGQ=",
+		"name":                "test-cluster",
+		"project_id":          "4fdc30c8-0bc8-4f78-b649-94053514f106",
+		"seed_node_id":        "e523cb50-7e82-4193-8879-0d687efef70c",
+		"seed_node_ip":        "10.244.244.2",
+		"tags":                map[string]interface{}{},
+		"tie_breaker_node_id": "14ba9bc9-31f6-4986-bcd8-4d545a5317e9",
+		"token":               "WAi6N8OI6D1wqYjWzNMd7N5tNGnM9zsrKh0eZIKg6EE=",
+	}
+
+	d := schema.TestResourceDataRaw(t, EdgeNodeClusterConfigSchema(), raw)
+
+	result := EdgeNodeClusterConfigModel(d)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.Name != "test-cluster" {
+		t.Errorf("expected name 'test-cluster', got %q", result.Name)
+	}
+	if string(result.Manifest) != "hello world" {
+		t.Errorf("expected manifest 'hello world', got %q", string(result.Manifest))
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a provider crash when updating an edge node that has an `edge_node_cluster` config.

## Root Cause

In `EdgeNodeClusterConfigModel` and `EdgeNodeClusterConfigModelFromMap`, the `manifest` field was directly type-asserted as `strfmt.Base64`:

```go
manifest := m["manifest"].(strfmt.Base64)  // panics when Terraform state stores it as string
```

Terraform stores the value as a plain `string` in state (since the schema type is `TypeString`), so this assertion panics at runtime.

## Fix

Replaced the direct assertion with a type switch handling `strfmt.Base64`, `string`, and `[]byte` inputs. Invalid base64 strings are logged as `[ERROR]` rather than silently discarded.

## Tests

Added `edge_node_cluster_config_test.go` covering:
- Empty string manifest (the exact crash scenario)
- Non-empty base64 string manifest
- `strfmt.Base64` manifest (the pre-existing path)
- `ResourceData`-based variant via `EdgeNodeClusterConfigModel`

```
--- PASS: TestEdgeNodeClusterConfigModelFromMap_ExampleJSON (0.00s)
--- PASS: TestEdgeNodeClusterConfigModelFromMap_StringManifest (0.00s)
--- PASS: TestEdgeNodeClusterConfigModelFromMap_Base64Manifest (0.00s)
--- PASS: TestEdgeNodeClusterConfigModel_ExampleJSON (0.00s)
PASS
```

Fixes [CI-875](https://zededa.atlassian.net/browse/CI-875)

[CI-875]: https://zededa.atlassian.net/browse/CI-875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ