### PR TITLE
feat: add zedcloud_deployment data source (CI-816)

### DIFF
--- a/v2/resources/deployment.go
+++ b/v2/resources/deployment.go
@@ -22,7 +22,7 @@ func DeploymentResource() *schema.Resource {
 	return &schema.Resource{
 		Description: `Resource "zedcloud_deployment" manages deployments in ZedCloud. A deployment is a collection of policies applied to a device.
 The api design does not support updates on a deployment. If you want to add changes to a deployment, you need to create a new version.
-When you create a new version of a deployment, it makes sense to show that it depends on the previous version. 
+When you create a new version of a deployment, it makes sense to show that it depends on the previous version.
 It will help create a proper dependency graph for the Terraform plan.`,
 		CreateContext: CreateDeployment,
 		DeleteContext: DeleteDeployment,
@@ -33,6 +33,115 @@ It will help create a proper dependency graph for the Terraform plan.`,
 			StateContext: deploymentImportStateContext,
 		},
 	}
+}
+
+// DeploymentDataSource returns the schema and read function for the
+// zedcloud_deployment data source. It supports lookup by id or name; in
+// both cases project_id is required. When multiple versions of a
+// deployment share a name, the latest revision is returned.
+func DeploymentDataSource() *schema.Resource {
+	s := zschema.Deployment()
+	s["id"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Computed:    true,
+		Description: "system generated unique id for a deployment",
+	}
+	s["name"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Computed:    true,
+		Description: "user defined name for the deployment",
+	}
+	return &schema.Resource{
+		Description: `Data source "zedcloud_deployment" reads an existing deployment from ZedCloud. Look up by ` + "`id`" + ` or ` + "`name`" + ` within a ` + "`project_id`" + `.`,
+		ReadContext: GetDeployment,
+		Schema:      s,
+	}
+}
+
+// GetDeployment is the read function for the zedcloud_deployment data
+// source. Dispatches to id- or name-based lookup; project_id is required
+// either way.
+func GetDeployment(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if _, ok := d.GetOk("project_id"); !ok {
+		return append(diags, diag.Errorf("missing required parameter: project_id")...)
+	}
+
+	_, hasID := d.GetOk("id")
+	_, hasName := d.GetOk("name")
+	if !hasID && !hasName {
+		return append(diags, diag.Errorf("one of `id` or `name` must be set")...)
+	}
+
+	if hasID {
+		return GetDeploymentByID(ctx, d, m)
+	}
+	return getDeploymentByName(ctx, d, m)
+}
+
+// getDeploymentByName lists deployments in a project, filters by the
+// configured name, picks the latest revision, then fetches the full
+// deployment by id to populate state.
+func getDeploymentByName(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	client := m.(*api_client.ZedcloudAPI)
+	projectID := d.Get("project_id").(string)
+	wantName := d.Get("name").(string)
+
+	listParams := deployment.NewGetListbyIdParams()
+	listParams.SetProjectID(projectID)
+
+	listResp, err := client.Deployment.GetListByProjectID(listParams, nil)
+	if err != nil {
+		log.Printf("[TRACE] deployment list error: %s", spew.Sdump(err))
+		if ds, ok := ZsrvResponderToDiags(err); ok {
+			return append(diags, ds...)
+		}
+		return append(diags, diag.Errorf("unexpected: %s", err)...)
+	}
+
+	var matchID string
+	var matchVersion int
+	for _, dep := range listResp.GetPayload().List {
+		if dep.Name != wantName {
+			continue
+		}
+		if dep.Revision == nil || dep.Revision.Curr == nil {
+			continue
+		}
+		v, err := strconv.Atoi(*dep.Revision.Curr)
+		if err != nil {
+			continue
+		}
+		if matchID == "" || v > matchVersion {
+			matchID = dep.ID
+			matchVersion = v
+		}
+	}
+
+	if matchID == "" {
+		return append(diags, diag.Errorf("no deployment named %q found in project %s", wantName, projectID)...)
+	}
+
+	getParams := deployment.NewGetByIDParams()
+	getParams.ID = matchID
+	getParams.ProjectID = projectID
+	resp, err := client.Deployment.GetByID(getParams, nil)
+	if err != nil {
+		log.Printf("[TRACE] deployment get by id error: %s", spew.Sdump(err))
+		if ds, ok := ZsrvResponderToDiags(err); ok {
+			return append(diags, ds...)
+		}
+		return append(diags, diag.Errorf("unexpected: %s", err)...)
+	}
+
+	zschema.SetDeploymentResourceData(d, resp.GetPayload())
+	d.SetId(matchID)
+	return diags
 }
 
 // deploymentImportStateContext is a custom import function that accepts a

--- a/v2/resources/deployment.go
+++ b/v2/resources/deployment.go
@@ -330,6 +330,7 @@ func GetDeploymentByID(ctx context.Context, d *schema.ResourceData, m interface{
 
 	respModel := resp.GetPayload()
 	zschema.SetDeploymentResourceData(d, respModel)
+	d.SetId(id)
 
 	return diags
 }

--- a/v2/resources/deployment_data_source_test.go
+++ b/v2/resources/deployment_data_source_test.go
@@ -1,0 +1,64 @@
+package resources
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	testhelper "github.com/zededa/terraform-provider-zedcloud/v2/testing"
+)
+
+func TestDeployment_DataSource(t *testing.T) {
+	createCfg := testhelper.MustGetTestInput(t, "deployment/create.tf")
+	dsCfg := testhelper.MustGetTestInput(t, "deployment/datasource.tf")
+	combined := createCfg + "\n" + dsCfg
+
+	uuidPattern := regexp.MustCompile("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[8|9|aA|bB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testhelper.CheckEnv(t) },
+		CheckDestroy: testDeploymentDestroy,
+		Providers:    testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:             combined,
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.zedcloud_deployment.by_name",
+						"name",
+						"test_tf_provider-deployment",
+					),
+					resource.TestCheckResourceAttr(
+						"data.zedcloud_deployment.by_name",
+						"deployment_tag",
+						"depl:1234",
+					),
+					resource.TestMatchResourceAttr(
+						"data.zedcloud_deployment.by_name",
+						"id",
+						uuidPattern,
+					),
+					resource.TestCheckResourceAttrPair(
+						"data.zedcloud_deployment.by_name",
+						"id",
+						"zedcloud_deployment.tf_deployment",
+						"id",
+					),
+					resource.TestCheckResourceAttrPair(
+						"data.zedcloud_deployment.by_id",
+						"name",
+						"zedcloud_deployment.tf_deployment",
+						"name",
+					),
+					resource.TestCheckResourceAttrPair(
+						"data.zedcloud_deployment.by_id",
+						"deployment_tag",
+						"zedcloud_deployment.tf_deployment",
+						"deployment_tag",
+					),
+				),
+			},
+		},
+	})
+}

--- a/v2/resources/deployment_data_source_test.go
+++ b/v2/resources/deployment_data_source_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestDeployment_DataSource(t *testing.T) {
-	createCfg := testhelper.MustGetTestInput(t, "deployment/create.tf")
+	createCfg := testhelper.MustGetTestInput(t, "deployment/datasource_create.tf")
 	dsCfg := testhelper.MustGetTestInput(t, "deployment/datasource.tf")
 	combined := createCfg + "\n" + dsCfg
 
@@ -27,7 +27,7 @@ func TestDeployment_DataSource(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.zedcloud_deployment.by_name",
 						"name",
-						"test_tf_provider-deployment",
+						"test_tf_provider-deployment-ds",
 					),
 					resource.TestCheckResourceAttr(
 						"data.zedcloud_deployment.by_name",

--- a/v2/resources/provider.go
+++ b/v2/resources/provider.go
@@ -50,6 +50,7 @@ func Provider() *schema.Provider {
 			"zedcloud_datastore":                 DatastoreDataSource(),
 			"zedcloud_volume_instance":           VolumeInstanceDataSource(),
 			"zedcloud_project":                   ProjectDataSource(),
+			"zedcloud_deployment":                DeploymentDataSource(),
 			"zedcloud_user":                      UserDataSource(),
 			"zedcloud_role":                      RoleDataSource(),
 			"zedcloud_credential":                CredentialDataSource(),

--- a/v2/resources/testdata/deployment/datasource.tf
+++ b/v2/resources/testdata/deployment/datasource.tf
@@ -1,0 +1,17 @@
+data "zedcloud_deployment" "by_name" {
+  depends_on = [
+    zedcloud_deployment.tf_deployment,
+  ]
+
+  name       = zedcloud_deployment.tf_deployment.name
+  project_id = zedcloud_project.test_tf_project.id
+}
+
+data "zedcloud_deployment" "by_id" {
+  depends_on = [
+    zedcloud_deployment.tf_deployment,
+  ]
+
+  id         = zedcloud_deployment.tf_deployment.id
+  project_id = zedcloud_project.test_tf_project.id
+}

--- a/v2/resources/testdata/deployment/datasource_create.tf
+++ b/v2/resources/testdata/deployment/datasource_create.tf
@@ -1,0 +1,290 @@
+resource "zedcloud_project" "test_tf_project" {
+  # required
+  name  = "test_tf_project-deployment-ds"
+  title = "test_tf_project-deployment-ds"
+  type = "TAG_TYPE_DEPLOYMENT"
+  tag_level_settings {
+    flow_log_transmission = "NETWORK_INSTANCE_FLOW_LOG_TRANSMISSION_DISABLED"
+    interface_ordering    = "INTERFACE_ORDERING_DISABLED"
+  }
+}
+
+resource "zedcloud_brand" "test_tf_provider" {
+  name        = "test_tf_provider-qemu-ds"
+  title       = "test_tf_provider-QEMU-ds"
+  description = "qemu"
+  origin_type = "ORIGIN_LOCAL"
+}
+
+resource "zedcloud_model" "test_tf_provider" {
+  brand_id    = zedcloud_brand.test_tf_provider.id
+  name        = "test_tf_provider-create_edgenode-ds"
+  title       = "test_tf_provider-create_edgenode-ds"
+  type        = "AMD64"
+  origin_type = "ORIGIN_LOCAL"
+  state       = "SYS_MODEL_STATE_ACTIVE"
+  attr = {
+    memory  = "8G"
+    storage = "100G"
+    Cpus    = "4"
+  }
+  io_member_list {
+    ztype     = "IO_TYPE_ETH"
+    phylabel  = "firstEth"
+    usage     = "ADAPTER_USAGE_MANAGEMENT"
+    assigngrp = "eth0"
+    phyaddrs = {
+      Ifname  = "eth0"
+      PciLong = "0000:02:00.0"
+    }
+    logicallabel = "ethernet0"
+    usage_policy = {
+      FreeUplink = true
+    }
+    cost = 0
+  }
+  depends_on = [
+    zedcloud_brand.test_tf_provider
+  ]
+}
+
+resource "zedcloud_datastore" "test_datastore" {
+  depends_on = [
+    zedcloud_project.test_tf_project
+  ]
+  # required
+  ds_fqdn             = "docker://docker.io"
+  ds_path             = ""
+  ds_type             = "DATASTORE_TYPE_CONTAINERREGISTRY"
+  name                = "test_tf_provider-dockerhub-ds"
+  title               = "test_tf_provider-dockerhub-ds"
+  description         = "test_tf_provider-dockerhub-ds"
+  region              = "eu"
+  project_access_list = [zedcloud_project.test_tf_project.id]
+}
+
+resource "zedcloud_image" "test_image" {
+  depends_on = [
+    zedcloud_project.test_tf_project,
+    zedcloud_datastore.test_datastore
+  ]
+  name                = "test_tf_provider-alpine-ds"
+  datastore_id        = zedcloud_datastore.test_datastore.id
+  image_arch          = "ARM64"
+  image_format        = "CONTAINER"
+  image_rel_url       = "alpine:latest"
+  image_size_bytes    = 1024
+  image_type          = "IMAGE_TYPE_APPLICATION"
+  title               = "alpine"
+  project_access_list = [zedcloud_project.test_tf_project.id]
+}
+
+
+resource "zedcloud_application" "alpine_vm_app" {
+  name                 = "test_tf_provider-alpine_vm_app-ds"
+  title                = "test_tf_provider-alpine_vm_app-ds"
+  user_defined_version = "24.0.4"
+  depends_on           = [zedcloud_image.test_image]
+  project_access_list  = [zedcloud_project.test_tf_project.id]
+  manifest {
+    ac_kind             = "VMManifest"
+    ac_version          = "1.2.0"
+    name                = "alpine_24"
+    vmmode              = "HV_HVM"
+    enablevnc           = true
+    app_type            = "APP_TYPE_VM"
+    deployment_type     = "DEPLOYMENT_TYPE_STAND_ALONE"
+    cpu_pinning_enabled = false
+    resources {
+      name  = "cpus"
+      value = 2
+    }
+    resources {
+      name  = "memory"
+      value = 8000000
+    }
+  }
+}
+
+resource "zedcloud_deployment" "tf_deployment" {
+  depends_on = [
+    zedcloud_application.alpine_vm_app,
+    zedcloud_brand.test_tf_provider,
+    zedcloud_project.test_tf_project
+  ]
+
+  name           = "test_tf_provider-deployment-ds"
+  title          = "test_tf_provider-deployment-ds"
+  deployment_tag = "depl:1234"
+
+  project_id = zedcloud_project.test_tf_project.id
+
+  device_policies {
+    meta_data {
+      name  = "test_tf_provider-edge-node-policy-ds"
+      title = "test_tf_provider-edge-node-policy-ds"
+      policy_target_condition = {
+        "depl" : "1234"
+      }
+      tags = {
+        "depl" : "1234"
+      }
+    }
+    policy_sub_type = "DEVICE_POLICY_TYPE_ATTESTATION"
+    attestation_policy {
+      type = "DEVICE_ATTEST_POLICY_TYPE_ACCEPT"
+    }
+  }
+
+  network_inst_policies {
+    meta_data {
+      name  = "test_tf_provider-network-instance-policy-ds"
+      title = "test_tf_provider-network-instance-policy-ds"
+      policy_target_condition = {
+        "depl" : "1234"
+      }
+    }
+    net_inst_config {
+      port = "uplink"
+      kind = "NETWORK_INSTANCE_KIND_LOCAL"
+      type = "NETWORK_INSTANCE_DHCP_TYPE_V4"
+    }
+  }
+
+  app_inst_policies {
+    meta_data {
+      name  = "test_tf_provider-app-instance-policy-ds"
+      title = "test_tf_provider-app-instance-policy-ds"
+      policy_target_condition = {
+        "depl" : "1234"
+      }
+      tags = {
+        "depl" : "1234"
+      }
+    }
+    app_inst_config {
+      naming_scheme          = "APP_NAMING_SCHEMEV2_PROJECT_APP_DEVICE"
+      name_project_part      = "depl-project"
+      start_delay_in_seconds = 0
+      name_app_part          = "test_tf_provider"
+      bundle_id              = zedcloud_application.alpine_vm_app.id
+      origin_type            = "ORIGIN_LOCAL"
+      interfaces {
+        intforder    = 1
+        intfname     = "indirect"
+        directattach = false
+        netinstname  = ""
+        privateip    = false
+      }
+      tags = {
+        "depl" : "1234"
+      }
+      manifest_json {
+        name            = "tf-app-instance"
+        ac_kind         = "VMManifest"
+        ac_version      = "1.2.0"
+        deployment_type = "DEPLOYMENT_TYPE_STAND_ALONE"
+        app_type        = "APP_TYPE_VM"
+        owner {
+          user    = "testuser"
+          group   = "testgroup"
+          company = "Zededa Inc."
+          website = "https://www.zededa.com"
+          email   = "test@zededa.com"
+        }
+        description         = "test app instance"
+        cpu_pinning_enabled = false
+        images {
+          imagename   = zedcloud_image.test_image.name
+          imageid     = zedcloud_image.test_image.id
+          maxsize = "0"
+          imageformat = "CONTAINER"
+          preserve    = false
+          readonly    = false
+          ignorepurge = false
+          cleartext   = false
+        }
+        desc {
+          category     = "APP_CATEGORY_CLOUD_APPLICATION"
+          app_category = "APP_CATEGORY_UNSPECIFIED"
+          support      = "support"
+        }
+        vmmode    = "HV_HVM"
+        enablevnc = false
+        resources {
+          name  = "resourceType"
+          value = "Custom"
+        }
+        resources {
+          name  = "cpus"
+          value = "2"
+        }
+        resources {
+          name  = "memory"
+          value = "1024000.00"
+        }
+        configuration {
+          custom_config {
+            name                 = "custom_config_name"
+            add                  = false
+            override             = false
+            allow_storage_resize = false
+            field_delimiter      = ""
+            template             = ""
+          }
+        }
+      }
+    }
+  }
+
+  volume_inst_policies {
+    meta_data {
+      name  = "test_tf_provider-volume-instance-policy-ds"
+      title = "test_tf_provider-volume-instance-policy-ds"
+      policy_target_condition = {
+        "depl" : "1234"
+      }
+      tags = {
+        "depl" : "1234"
+      }
+    }
+    vol_inst_config {
+      type       = "VOLUME_INSTANCE_TYPE_BLOCKSTORAGE"
+      accessmode = "VOLUME_INSTANCE_ACCESS_MODE_READWRITE"
+      size_bytes = "1048576"
+      cleartext  = true
+    }
+  }
+
+  edgeview_policy {
+    meta_data {
+      name  = "test_tf_provider-edgeview-policy-ds"
+      title = "test_tf_provider-edgeview-policy-ds"
+      policy_target_condition = {
+        "depl" : "1234"
+      }
+    }
+    edgeviewcfg {
+      jwt_info {
+        disp_url  = "zedcloud.local.zededa.net/api/v1/edge-view"
+        allow_sec = 18000
+        num_inst  = 1
+        encrypt   = false
+      }
+      dev_policy {
+        allow_dev = true
+      }
+      app_policy {
+        allow_app = true
+      }
+
+      ext_policy {
+        allow_ext = false
+      }
+    }
+    access_allow_change = true
+    max_expire_sec      = 2592000
+    max_inst            = 3
+    edgeview_allow      = true
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a `zedcloud_deployment` data source so customers can read deployments created outside Terraform (e.g., via the ZedCloud UI/controller) and use their attributes as inputs to other resources.
- Lookup supports either `id` or `name`, with `project_id` required either way. When multiple revisions share a name, the latest revision is returned.
- Implementation reuses the existing `Deployment` schema, `SetDeploymentResourceData` flatten helper, and swagger client — no schema, model, or API client changes.

Unblocks Speedcast (ZD #3244), who cannot manage pre-existing Edge View deployments via Terraform.

Refs: ZEDCLOUD-2472, NFR-197.

## Test plan
- [ ] `go vet ./v2/...` and `go build ./v2/...` pass locally.
- [ ] `TF_ACC=1 go test -run TestDeployment_DataSource ./v2/resources/` against a real cluster — exercises both lookup paths (by name and by id) and verifies attributes against the source resource.
- [ ] Existing `TestDeployment_Create` still passes (no resource-side changes).
- [ ] Run `make docs` to regenerate `docs/data-sources/deployment.md` (tfplugindocs not installed locally; left for CI/owner to run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)