### PR TITLE
fix: treat 404 on delete as success (CI-723)

### DIFF
--- a/v2/resources/app_profile_service_resource.go
+++ b/v2/resources/app_profile_service_resource.go
@@ -260,6 +260,10 @@ func DeleteAppProfile(ctx context.Context, d *schema.ResourceData, m interface{}
 
 	_, err := client.AppProfile.AppProfileServiceDeleteAppProfile(params, nil)
 	if err != nil {
+		if isStatusNotFound(err) {
+			d.SetId("")
+			return diags
+		}
 		log.Printf("[TRACE] AppProfileService.AppProfileServiceDeleteAppProfile error: %s", spew.Sdump(err))
 		if ds, ok := ZsrvResponderToDiags(err); ok {
 			diags = append(diags, ds...)

--- a/v2/resources/application.go
+++ b/v2/resources/application.go
@@ -310,6 +310,10 @@ func DeleteApplication(ctx context.Context, d *schema.ResourceData, m interface{
 
 	_, err := client.Application.Delete(params, nil)
 	if err != nil {
+		if isStatusNotFound(err) {
+			d.SetId("")
+			return diags
+		}
 		log.Printf("[TRACE] edge application delete error: %s", spew.Sdump(err))
 		if ds, ok := ZsrvResponderToDiags(err); ok {
 			diags = append(diags, ds...)

--- a/v2/resources/application_instance.go
+++ b/v2/resources/application_instance.go
@@ -263,6 +263,10 @@ func DeleteApplicationInstance(ctx context.Context, d *schema.ResourceData, m in
 
 	_, err := client.ApplicationInstance.Delete(params, nil)
 	if err != nil {
+		if isStatusNotFound(err) {
+			d.SetId("")
+			return diags
+		}
 		log.Printf("[TRACE] edge application instance delete error: %s", spew.Sdump(err))
 		if ds, ok := ZsrvResponderToDiags(err); ok {
 			diags = append(diags, ds...)

--- a/v2/resources/asset_group_service_resource.go
+++ b/v2/resources/asset_group_service_resource.go
@@ -260,6 +260,10 @@ func DeleteAssetGroup(ctx context.Context, d *schema.ResourceData, m interface{}
 
 	_, err := client.AssetGroup.AssetGroupServiceDeleteAssetGroup(params, nil)
 	if err != nil {
+		if isStatusNotFound(err) {
+			d.SetId("")
+			return diags
+		}
 		log.Printf("[TRACE] AssetGroupService.AssetGroupServiceDeleteAssetGroup error: %s", spew.Sdump(err))
 		if ds, ok := ZsrvResponderToDiags(err); ok {
 			diags = append(diags, ds...)

--- a/v2/resources/brand.go
+++ b/v2/resources/brand.go
@@ -270,6 +270,10 @@ func DeleteHardwareBrand(ctx context.Context, d *schema.ResourceData, m interfac
 
 	_, err := client.HardwareModel.HardwareModelDeleteHardwareBrand(params, nil)
 	if err != nil {
+		if isStatusNotFound(err) {
+			d.SetId("")
+			return diags
+		}
 		log.Printf("[TRACE] brand delete error: %s", spew.Sdump(err))
 		if ds, ok := ZsrvResponderToDiags(err); ok {
 			diags = append(diags, ds...)

--- a/v2/resources/cep_profile.go
+++ b/v2/resources/cep_profile.go
@@ -251,6 +251,10 @@ func DeleteCEPProfile(ctx context.Context, d *schema.ResourceData, m interface{}
 
 	_, err := client.CertificateEnrollmentProfile.Delete(params, nil)
 	if err != nil {
+		if isStatusNotFound(err) {
+			d.SetId("")
+			return diags
+		}
 		log.Printf("[TRACE] CEP profile delete error: %s", spew.Sdump(err))
 		if ds, ok := ZsrvResponderToDiags(err); ok {
 			diags = append(diags, ds...)

--- a/v2/resources/cluster.go
+++ b/v2/resources/cluster.go
@@ -255,6 +255,10 @@ func DeleteCluster(ctx context.Context, d *schema.ResourceData, m interface{}) d
 
 	_, err := client.Cluster.DeleteCluster(params, nil)
 	if err != nil {
+		if isStatusNotFound(err) {
+			d.SetId("")
+			return diags
+		}
 		log.Printf("[TRACE] edge node cluster delete error: %s", spew.Sdump(err))
 		if ds, ok := ZsrvResponderToDiags(err); ok {
 			diags = append(diags, ds...)

--- a/v2/resources/cluster_group.go
+++ b/v2/resources/cluster_group.go
@@ -104,6 +104,10 @@ func DeleteClusterGroup(ctx context.Context, d *schema.ResourceData, m interface
 
 	_, err := client.ClusterGroup.DeleteClusterGroup(params, nil)
 	if err != nil {
+		if isStatusNotFound(err) {
+			d.SetId("")
+			return diags
+		}
 		log.Printf("[TRACE] DeleteClusterGroup error: %s", spew.Sdump(err))
 		if ds, ok := ZsrvResponderToDiags(err); ok {
 			diags = append(diags, ds...)

--- a/v2/resources/datastore.go
+++ b/v2/resources/datastore.go
@@ -260,6 +260,10 @@ func DeleteDatastore(ctx context.Context, d *schema.ResourceData, m interface{})
 
 	_, err := client.Datastore.Delete(params, nil)
 	if err != nil {
+		if isStatusNotFound(err) {
+			d.SetId("")
+			return diags
+		}
 		log.Printf("[TRACE] datastore delete error: %s", spew.Sdump(err))
 		if ds, ok := ZsrvResponderToDiags(err); ok {
 			diags = append(diags, ds...)

--- a/v2/resources/deployment.go
+++ b/v2/resources/deployment.go
@@ -277,6 +277,10 @@ func DeleteDeployment(ctx context.Context, d *schema.ResourceData, m interface{}
 	resp, err := client.Deployment.Delete(params, nil)
 	log.Printf("[TRACE] response: %v", resp)
 	if err != nil {
+		if isStatusNotFound(err) {
+			d.SetId("")
+			return diags
+		}
 		log.Printf("[TRACE] deployment delete error: %s", spew.Sdump(err))
 		if ds, ok := ZsrvResponderToDiags(err); ok {
 			diags = append(diags, ds...)

--- a/v2/resources/enterprise.go
+++ b/v2/resources/enterprise.go
@@ -254,6 +254,10 @@ func DeleteEnterprise(ctx context.Context, d *schema.ResourceData, m interface{}
 
 	_, err := client.IdentityAccessManagement.IdentityAccessManagementDeleteEnterprise(params, nil)
 	if err != nil {
+		if isStatusNotFound(err) {
+			d.SetId("")
+			return diags
+		}
 		log.Printf("[TRACE] IdentityAccessManagement.IdentityAccessManagementDeleteEnterprise error: %s", spew.Sdump(err))
 		if ds, ok := ZsrvResponderToDiags(err); ok {
 			diags = append(diags, ds...)

--- a/v2/resources/helm_chart_management.go
+++ b/v2/resources/helm_chart_management.go
@@ -219,6 +219,10 @@ func DeleteHelmChart(ctx context.Context, d *schema.ResourceData, m interface{})
 
 	_, err := client.HelmChartManagement.DeleteHelmChart(params, nil)
 	if err != nil {
+		if isStatusNotFound(err) {
+			d.SetId("")
+			return diags
+		}
 		log.Printf("[TRACE] HelmChartManagementDeleteHelmChart error: %s", spew.Sdump(err))
 		if ds, ok := ZsrvResponderToDiags(err); ok {
 			diags = append(diags, ds...)

--- a/v2/resources/image.go
+++ b/v2/resources/image.go
@@ -288,6 +288,10 @@ func DeleteImage(ctx context.Context, d *schema.ResourceData, m interface{}) dia
 
 	_, err := client.Image.Delete(params, nil)
 	if err != nil {
+		if isStatusNotFound(err) {
+			d.SetId("")
+			return diags
+		}
 		log.Printf("[TRACE] image delete error: %s", spew.Sdump(err))
 		if ds, ok := ZsrvResponderToDiags(err); ok {
 			diags = append(diags, ds...)

--- a/v2/resources/kubernetes_git_ops.go
+++ b/v2/resources/kubernetes_git_ops.go
@@ -212,6 +212,10 @@ func DeleteGitRepo(ctx context.Context, d *schema.ResourceData, m interface{}) d
 
 	_, err := client.KubernetesGitOps.DeleteGitRepo(params, nil)
 	if err != nil {
+		if isStatusNotFound(err) {
+			d.SetId("")
+			return diags
+		}
 		log.Printf("[TRACE] KubernetesGitOpsDeleteGitRepo error: %s", spew.Sdump(err))
 		if ds, ok := ZsrvResponderToDiags(err); ok {
 			diags = append(diags, ds...)

--- a/v2/resources/model.go
+++ b/v2/resources/model.go
@@ -251,6 +251,10 @@ func DeleteHardwareModel(ctx context.Context, d *schema.ResourceData, m interfac
 
 	_, err := client.HardwareModel.HardwareModelDeleteHardwareModel(params, nil)
 	if err != nil {
+		if isStatusNotFound(err) {
+			d.SetId("")
+			return diags
+		}
 		log.Printf("[TRACE] model delete error: %s", spew.Sdump(err))
 		if ds, ok := ZsrvResponderToDiags(err); ok {
 			diags = append(diags, ds...)

--- a/v2/resources/network.go
+++ b/v2/resources/network.go
@@ -249,6 +249,10 @@ func DeleteNetwork(ctx context.Context, d *schema.ResourceData, m interface{}) d
 
 	_, err := client.Network.DeleteNetwork(params, nil)
 	if err != nil {
+		if isStatusNotFound(err) {
+			d.SetId("")
+			return diags
+		}
 		log.Printf("[TRACE] network delete error: %s", spew.Sdump(err))
 		if ds, ok := ZsrvResponderToDiags(err); ok {
 			diags = append(diags, ds...)

--- a/v2/resources/network_instance.go
+++ b/v2/resources/network_instance.go
@@ -258,6 +258,10 @@ func DeleteNetworkInstance(ctx context.Context, d *schema.ResourceData, m interf
 
 	_, err := client.NetworkInstance.Delete(params, nil)
 	if err != nil {
+		if isStatusNotFound(err) {
+			d.SetId("")
+			return diags
+		}
 		log.Printf("[TRACE] network instance delete error: %s", spew.Sdump(err))
 		if ds, ok := ZsrvResponderToDiags(err); ok {
 			diags = append(diags, ds...)

--- a/v2/resources/node.go
+++ b/v2/resources/node.go
@@ -269,6 +269,10 @@ func DeleteNode(ctx context.Context, d *schema.ResourceData, m interface{}) diag
 
 	_, err := client.Node.Delete(params, nil)
 	if err != nil {
+		if isStatusNotFound(err) {
+			d.SetId("")
+			return diags
+		}
 		log.Printf("[TRACE] edge node delete error: %s", spew.Sdump(err))
 		if ds, ok := ZsrvResponderToDiags(err); ok {
 			diags = append(diags, ds...)

--- a/v2/resources/patch_envelope.go
+++ b/v2/resources/patch_envelope.go
@@ -257,6 +257,10 @@ func DeletePatchEnvelope(ctx context.Context, d *schema.ResourceData, m interfac
 
 	_, err := client.PatchEnvelope.PatchEnvelopeConfigurationDeletePatchEnvelope(params, nil)
 	if err != nil {
+		if isStatusNotFound(err) {
+			d.SetId("")
+			return diags
+		}
 		log.Printf("[TRACE] patch envelope delete error: %s", spew.Sdump(err))
 		if ds, ok := ZsrvResponderToDiags(err); ok {
 			diags = append(diags, ds...)

--- a/v2/resources/patch_reference_update.go
+++ b/v2/resources/patch_reference_update.go
@@ -87,6 +87,10 @@ func DeletePatchEnvelopeReference(ctx context.Context, d *schema.ResourceData, m
 
 	resp, err := client.ApplicationInstance.EdgeApplicationInstanceConfigurationUpdatePatchEnvelopeReferencetoAppInstance(params, nil)
 	if err != nil {
+		if isStatusNotFound(err) {
+			d.SetId("")
+			return diags
+		}
 		log.Printf("[TRACE] patch reference update delete error: %s", spew.Sdump(err))
 		if ds, ok := ZsrvResponderToDiags(err); ok {
 			diags = append(diags, ds...)

--- a/v2/resources/private_helm_repository.go
+++ b/v2/resources/private_helm_repository.go
@@ -252,6 +252,10 @@ func DeletePrivateRepo(ctx context.Context, d *schema.ResourceData, m interface{
 
 	_, err := client.PrivateHelmRepository.DeletePrivateRepo(params, nil)
 	if err != nil {
+		if isStatusNotFound(err) {
+			d.SetId("")
+			return diags
+		}
 		log.Printf("[TRACE] PrivateHelmRepositoriesDeletePrivateRepo error: %s", spew.Sdump(err))
 		if ds, ok := ZsrvResponderToDiags(err); ok {
 			diags = append(diags, ds...)

--- a/v2/resources/profile_deployment_service_resource.go
+++ b/v2/resources/profile_deployment_service_resource.go
@@ -261,6 +261,10 @@ func DeleteProfileDeployment(ctx context.Context, d *schema.ResourceData, m inte
 
 	_, err := client.ProfileDeployment.ProfileDeploymentServiceDeleteProfileDeployment(params, nil)
 	if err != nil {
+		if isStatusNotFound(err) {
+			d.SetId("")
+			return diags
+		}
 		log.Printf("[TRACE] ProfileDeploymentService.ProfileDeploymentServiceDeleteProfileDeployment error: %s", spew.Sdump(err))
 		if ds, ok := ZsrvResponderToDiags(err); ok {
 			diags = append(diags, ds...)

--- a/v2/resources/project.go
+++ b/v2/resources/project.go
@@ -251,6 +251,10 @@ func DeleteProject(ctx context.Context, d *schema.ResourceData, m interface{}) d
 
 	_, err := client.Project.Delete(params, nil)
 	if err != nil {
+		if isStatusNotFound(err) {
+			d.SetId("")
+			return diags
+		}
 		log.Printf("[TRACE] project delete error: %s", spew.Sdump(err))
 		if ds, ok := ZsrvResponderToDiags(err); ok {
 			diags = append(diags, ds...)

--- a/v2/resources/provider.go
+++ b/v2/resources/provider.go
@@ -200,11 +200,6 @@ func getRetryClient() *retryablehttp.Client {
 			return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
 		}
 
-		// If we have a response, check for 404 specifically and retry
-		if resp.StatusCode == http.StatusNotFound {
-			return true, fmt.Errorf("unexpected HTTP status %s", resp.Status)
-		}
-
 		// We cannot retry on other methods rather than GET. Our API is not idempotent.
 		if resp.Request == nil {
 			// Be conservative: defer to default policy if request is missing
@@ -213,6 +208,14 @@ func getRetryClient() *retryablehttp.Client {
 
 		if resp.Request.Method != http.MethodGet {
 			return false, nil
+		}
+
+		// On GET, retry 404 to absorb read-after-write eventual consistency.
+		// For non-GET methods we never retry 404: on DELETE it is the success
+		// case, and on POST/PUT it indicates a missing parent that retries
+		// won't resolve. See CI-723.
+		if resp.StatusCode == http.StatusNotFound {
+			return true, fmt.Errorf("unexpected HTTP status %s", resp.Status)
 		}
 
 		return retryablehttp.DefaultRetryPolicy(ctx, resp, err)

--- a/v2/resources/util.go
+++ b/v2/resources/util.go
@@ -2,12 +2,32 @@ package resources
 
 import (
 	"log"
+	"net/http"
 	"os"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/zededa/terraform-provider-zedcloud/v2/models"
 )
+
+// isStatusNotFound reports whether err represents an HTTP 404 from the
+// zedcloud API. It recognises both the typed swagger NotFound responses
+// (which implement Code() int) and the string-wrapped error emitted by
+// retryablehttp after it gives up retrying a 404. Used by Delete
+// handlers so a missing resource is treated as success, making deletes
+// idempotent against cascading server-side cleanup.
+func isStatusNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	type statusCoder interface {
+		Code() int
+	}
+	if sc, ok := err.(statusCoder); ok && sc.Code() == http.StatusNotFound {
+		return true
+	}
+	return strings.Contains(err.Error(), "404 Not Found")
+}
 
 // HTLogger is a logger which satisfies the go-openapi/runtime/logger.Logger
 // interface using go stdlib "log". It appends a prefix to each message to make

--- a/v2/resources/util_test.go
+++ b/v2/resources/util_test.go
@@ -1,0 +1,36 @@
+package resources
+
+import (
+	"errors"
+	"testing"
+)
+
+type codedErr struct {
+	code int
+	msg  string
+}
+
+func (e *codedErr) Error() string { return e.msg }
+func (e *codedErr) Code() int     { return e.code }
+
+func TestIsStatusNotFound(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"typed 404", &codedErr{code: 404, msg: "not found"}, true},
+		{"typed 500", &codedErr{code: 500, msg: "boom"}, false},
+		{"retryablehttp wrapped 404", errors.New(`giving up after 5 attempt(s): unexpected HTTP status 404 Not Found`), true},
+		{"unrelated error", errors.New("connection reset"), false},
+		{"500 substring not matched", errors.New("500 Internal Server Error"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isStatusNotFound(tc.err); got != tc.want {
+				t.Errorf("isStatusNotFound(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/v2/resources/volume_instance.go
+++ b/v2/resources/volume_instance.go
@@ -260,6 +260,10 @@ func DeleteVolumeInstance(ctx context.Context, d *schema.ResourceData, m interfa
 
 	_, err := client.VolumeInstance.Delete(params, nil)
 	if err != nil {
+		if isStatusNotFound(err) {
+			d.SetId("")
+			return diags
+		}
 		log.Printf("[TRACE] volume instance delete error: %s", spew.Sdump(err))
 		if ds, ok := ZsrvResponderToDiags(err); ok {
 			diags = append(diags, ds...)

--- a/v2/resources/z_k_s_cluster_instance.go
+++ b/v2/resources/z_k_s_cluster_instance.go
@@ -365,6 +365,10 @@ func DeleteZKSInstance(ctx context.Context, d *schema.ResourceData, m interface{
 
 	_, err := client.ZksClusterInstance.DeleteZKSInstance(params, nil)
 	if err != nil {
+		if isStatusNotFound(err) {
+			d.SetId("")
+			return diags
+		}
 		log.Printf("[TRACE] DeleteZKSInstance error: %s", spew.Sdump(err))
 		if ds, ok := ZsrvResponderToDiags(err); ok {
 			diags = append(diags, ds...)


### PR DESCRIPTION
## Summary
When the zedcloud API removes a resource server-side (e.g. cascade from an `application_instance` modification that drops the associated Docker Compose TAR images), the next `terraform apply` would hit 404 on the image deletes and surface a hard error, leaving Terraform unable to converge state.

Two changes make Delete idempotent:

1. **Retry policy ([v2/resources/provider.go](v2/resources/provider.go))** — scope the existing 404 retry to GET only. On DELETE a 404 is the success case; on POST/PUT it indicates a missing parent that retries will not resolve. Previously the policy retried 404 on every method, burning 5 attempts before bubbling a string-wrapped error that obscured the typed swagger response.
2. **404-as-success in Delete handlers ([v2/resources/util.go](v2/resources/util.go) + all 25 Delete handlers)** — new `isStatusNotFound` helper that recognises both the typed swagger NotFound responses and the retryablehttp-wrapped error string. Each Delete handler short-circuits on it, clearing the ID and returning no diags.

Resolves the customer-blocking issue Speedcast reported (Docker Compose TAR image deletes failing with 404 after the parent app instance is modified). Same fix protects against any other server-side cleanup race.

## Test plan
- [x] `go build ./v2/...` and `go vet ./v2/resources/...` pass locally.
- [x] New unit test `TestIsStatusNotFound` covers nil, typed 404, retryablehttp-wrapped 404, and unrelated errors.
- [ ] Acceptance tests against a real cluster (`TF_ACC=1 go test ./v2/resources/`).
- [ ] Manual repro of the customer scenario: create + modify an app_instance referencing a Docker Compose TAR image such that the image is cascade-deleted, then `terraform destroy` should succeed cleanly.

JIRA: https://zededa.atlassian.net/browse/CI-723

🤖 Generated with [Claude Code](https://claude.com/claude-code)