### PR TITLE
fix: use freshly-read revision on edgenode update to avoid 409 (CI-790)

### DIFF
--- a/v2/resources/node.go
+++ b/v2/resources/node.go
@@ -154,6 +154,12 @@ func UpdateNode(ctx context.Context, d *schema.ResourceData, m interface{}) diag
 		return diag.Errorf("missing client parameter: id")
 	}
 	newNode := zschema.NodeModel(d)
+	// Use the revision we just fetched from the server as the optimistic-lock
+	// token instead of the (possibly stale) value cached in Terraform state.
+	// The device version can advance out-of-band between Terraform's last
+	// refresh and this update; sending the stale revision makes the API reject
+	// the update with HTTP 409 "Version mismatch".
+	newNode.Revision = existingNode.Revision
 	params.SetBody(newNode)
 
 	// Call node update


### PR DESCRIPTION
## Problem

`terraform apply` intermittently fails on `zedcloud_edgenode` updates with paired errors per node:

```
Error: Zedcloud API call returned HTTP status code: 409
Error: Version mismatch
```

The errors are harmless and disappear on a second apply, but they're noisy and confusing (CI-790).

## Root cause

`UpdateNode` fetches the current node via `readNodeByID` (for the base-image/admin-state diffs) but then builds the update body from Terraform **state** via `NodeModel(d)`, which carries a possibly-stale `revision.curr`. `revision` is `Optional + Computed` with all-Computed sub-fields, so its value is whatever was cached at the last refresh.

The device version is bumped by any writer (the edge node checking in, background controllers, a saved plan going stale between `plan -out` and `apply`). When the server version has advanced past the cached one, the stale optimistic-lock token is rejected by the backend:

- seine `deviceUpdate`: `exists.Version != dev.Version` → `ZsrvCustomVerConflict` (HTTP 409, `Details: "Version mismatch"`).
- The provider surfaces the one response as two diagnostics (HTTP code + error detail) via `ZsrvResponderToDiags`.

## Fix

Reuse the revision from the node already fetched via `readNodeByID` as the optimistic-lock token, so the update always sends the current server version:

```go
newNode.Revision = existingNode.Revision
```

No extra API call (reuses the existing `existingNode`), no schema change. Because `revision` is Computed, `plan` shows no version diff and the post-apply readback still reconciles state cleanly.

## Testing

- `go build ./resources/` — passes
- `go vet ./resources/` — passes

End-to-end reproduction requires a live Zedcloud device whose version drifts between refresh and apply, so this is verified at the compile/logic level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)