### PR TITLE
ci: categorize auto-generated release notes by PR label

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,25 @@
+# Configuration for GitHub's automatically generated release notes.
+# Categorization is driven by the labels applied to each merged PR.
+# See: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+changelog:
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - wontfix
+  categories:
+    - title: 🚀 Features
+      labels:
+        - enhancement
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+    - title: 📖 Documentation
+      labels:
+        - documentation
+    - title: ⬆️ Dependencies
+      labels:
+        - dependencies
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,70 @@
+# Copyright (c) 2018-2021 Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Auto-labels pull requests based on their conventional-commit title prefix
+# (e.g. "feat:", "fix:"), so GitHub's auto-generated release notes can be
+# categorized via .github/release.yml.
+name: PR Labeler
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label from title prefix
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Map conventional-commit type -> repo label.
+            const typeToLabel = {
+              feat: 'enhancement',
+              fix: 'bug',
+              docs: 'documentation',
+              build: 'dependencies',
+              deps: 'dependencies',
+            };
+
+            const title = context.payload.pull_request.title || '';
+            // Match "type" or "type(scope)" optionally followed by "!", then ":".
+            const m = title.match(/^(\w+)(\([^)]*\))?!?:/);
+            if (!m) {
+              core.info(`Title "${title}" has no conventional-commit prefix; skipping.`);
+              return;
+            }
+
+            let type = m[1].toLowerCase();
+            // Treat "chore(deps)"/"build(deps)" as dependency updates.
+            const scope = (m[2] || '').toLowerCase();
+            if (scope.includes('deps')) {
+              type = 'deps';
+            }
+
+            const label = typeToLabel[type];
+            if (!label) {
+              core.info(`No label mapping for type "${type}"; skipping.`);
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const existing = context.payload.pull_request.labels.map(l => l.name);
+            if (existing.includes(label)) {
+              core.info(`Label "${label}" already present; nothing to do.`);
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number,
+              labels: [label],
+            });
+            core.info(`Added label "${label}" for type "${type}".`);


### PR DESCRIPTION
## What

- Add `.github/release.yml` so GitHub's auto-generated release notes are grouped into **🚀 Features / 🐛 Bug Fixes / 📖 Documentation / ⬆️ Dependencies** (plus an "Other Changes" catch-all), mapped to the repo's existing labels.
- Add `.github/workflows/pr-labeler.yml`, a labeler that applies the matching label from each PR's conventional-commit title prefix (`feat:` → `enhancement`, `fix:` → `bug`, `docs:` → `documentation`, `build:`/`*(deps):` → `dependencies`).

## Why

The `Release` workflow runs GoReleaser with `changelog: skip: true`, so it doesn't produce a changelog. Release notes today come from GitHub's native "Generate release notes", which categorizes strictly by **PR label** — but PRs in this repo are almost never labeled (the team uses `feat:`/`fix:` titles). The labeler bridges the title convention to labels so the categorization actually populates.

## Notes

- The labeler uses `actions/github-script` with inline logic — no new third-party action dependency.
- It uses `pull_request_target` so it can label fork PRs, and deliberately **does not** check out or run PR code (only reads the title and calls the labels API). Keep it that way.
- Only affects PRs opened after this merges; already-merged PRs aren't retroactively labeled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)