### PR TITLE
ci: auto-detect prerelease in goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -52,5 +52,8 @@ signs:
 release:
 # If you want to manually examine the release before its live, uncomment this line:
 # draft: true
+  # Mark the GitHub release as a prerelease when the tag has a prerelease
+  # suffix (e.g. v2.8.0-rc), and a full release otherwise.
+  prerelease: auto
 changelog:
   skip: true


### PR DESCRIPTION
## What

Add `release.prerelease: auto` to `.goreleaser.yml`.

## Why

When cutting `v2.8.0-rc`, GoReleaser published the GitHub release with `prerelease=false`, so it had to be flipped to prerelease by hand. With `auto`, GoReleaser marks the release as a prerelease when the tag has a prerelease suffix (e.g. `v2.8.0-rc`, `-RC`, `-beta`) and as a full release for plain semver tags (e.g. `v2.8.0`).

## Notes

- This only fixes the prerelease flag. The release **body** is still empty from GoReleaser because `changelog: skip: true`; categorized notes continue to come from GitHub's native "Generate release notes" (`.github/release.yml`, added in #220), run after publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)