### PR TITLE
fix: Fix forming of the netid and netname fields for the bond member interfaces (eng-2782)

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -11,10 +11,10 @@ require (
 	github.com/go-openapi/swag v0.22.3
 	github.com/go-openapi/validate v0.22.1
 	github.com/google/go-cmp v0.5.9
+	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-retryablehttp v0.7.2
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
-	golang.org/x/exp v0.0.0-20230131160201-f062dba9d201
 )
 
 require (
@@ -32,7 +32,6 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 // indirect
 	github.com/hashicorp/go-hclog v1.2.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.4.6 // indirect

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -341,8 +341,6 @@ golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.5.0/go.mod h1:NK/OQwhpMQP3MwtdjgLlYHnH9ebylxKWv3e0fK+mkQU=
 golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=
 golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=
-golang.org/x/exp v0.0.0-20230131160201-f062dba9d201 h1:BEABXpNXLEz0WxtA+6CQIz2xkg80e+1zrhWyMcq8VzE=
-golang.org/x/exp v0.0.0-20230131160201-f062dba9d201/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.7.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.8.0 h1:LUYupSeNrTNCGzR/hVBk2NHZO4hXcVaW1k4Qx7rjPx8=

--- a/v2/resources/node.go
+++ b/v2/resources/node.go
@@ -3,9 +3,11 @@ package resources
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	api_client "github.com/zededa/terraform-provider-zedcloud/v2/client"
@@ -24,10 +26,60 @@ func NodeResource() *schema.Resource {
 		UpdateContext: UpdateNode,
 		DeleteContext: DeleteNode,
 		Schema:        zschema.Node(),
+		CustomizeDiff: validateBondMemberInterfaces,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 	}
+}
+
+// validateBondMemberInterfaces rejects configurations that explicitly declare
+// netname/netid on a bond member interface. The API refuses such interfaces
+// with a generic 400, so fail at plan time with an actionable message instead.
+// It inspects the raw config (not the merged plan) because netid is a Computed
+// attribute whose stale state value is carried forward when absent from the
+// config; that carried value is dropped when building the request payload and
+// must not trigger this error (ENG-2782).
+func validateBondMemberInterfaces(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
+	return checkBondMemberInterfaces(d.GetRawConfig())
+}
+
+func checkBondMemberInterfaces(rawConfig cty.Value) error {
+	if rawConfig.IsNull() || !rawConfig.IsKnown() || !rawConfig.Type().IsObjectType() || !rawConfig.Type().HasAttribute("interfaces") {
+		return nil
+	}
+	interfaces := rawConfig.GetAttr("interfaces")
+	if interfaces.IsNull() || !interfaces.IsKnown() || !interfaces.CanIterateElements() {
+		return nil
+	}
+	for it := interfaces.ElementIterator(); it.Next(); {
+		_, iface := it.Element()
+		if iface.IsNull() || !iface.IsKnown() {
+			continue
+		}
+		if rawConfigString(iface, "intf_usage") != string(models.AdapterUsageADAPTERUSAGEBONDMEMBER) {
+			continue
+		}
+		if rawConfigString(iface, "netname") != "" || rawConfigString(iface, "netid") != "" {
+			return fmt.Errorf(
+				"interface %q: netname/netid must not be set when intf_usage is %s, a bond member interface cannot carry a network identity",
+				rawConfigString(iface, "intfname"),
+				models.AdapterUsageADAPTERUSAGEBONDMEMBER,
+			)
+		}
+	}
+	return nil
+}
+
+func rawConfigString(v cty.Value, attr string) string {
+	if !v.Type().IsObjectType() || !v.Type().HasAttribute(attr) {
+		return ""
+	}
+	attrVal := v.GetAttr(attr)
+	if attrVal.IsNull() || !attrVal.IsKnown() || attrVal.Type() != cty.String {
+		return ""
+	}
+	return attrVal.AsString()
 }
 
 func NodeDataSource() *schema.Resource {

--- a/v2/resources/node_bond_member_test.go
+++ b/v2/resources/node_bond_member_test.go
@@ -1,0 +1,144 @@
+package resources
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/zededa/terraform-provider-zedcloud/v2/models"
+)
+
+// Covers the plan-time validation for ENG-2782: explicitly configuring
+// netname/netid on a bond member interface must fail with an actionable
+// error instead of the API's generic 400.
+func TestCheckBondMemberInterfaces(t *testing.T) {
+	iface := func(attrs map[string]cty.Value) cty.Value {
+		base := map[string]cty.Value{
+			"intfname":   cty.StringVal("eth0"),
+			"intf_usage": cty.NullVal(cty.String),
+			"netname":    cty.NullVal(cty.String),
+			"netid":      cty.NullVal(cty.String),
+		}
+		for k, v := range attrs {
+			base[k] = v
+		}
+		return cty.ObjectVal(base)
+	}
+	config := func(interfaces ...cty.Value) cty.Value {
+		attrs := map[string]cty.Value{
+			"name": cty.StringVal("test-node"),
+		}
+		if len(interfaces) == 0 {
+			attrs["interfaces"] = cty.NullVal(cty.List(cty.EmptyObject))
+		} else {
+			attrs["interfaces"] = cty.TupleVal(interfaces)
+		}
+		return cty.ObjectVal(attrs)
+	}
+	bondMember := cty.StringVal(string(models.AdapterUsageADAPTERUSAGEBONDMEMBER))
+
+	testCases := []struct {
+		name        string
+		rawConfig   cty.Value
+		expectError string
+	}{
+		{
+			name:      "null config",
+			rawConfig: cty.NullVal(cty.EmptyObject),
+		},
+		{
+			name:      "unknown config",
+			rawConfig: cty.UnknownVal(cty.EmptyObject),
+		},
+		{
+			name:      "config without interfaces attribute",
+			rawConfig: cty.ObjectVal(map[string]cty.Value{"name": cty.StringVal("test-node")}),
+		},
+		{
+			name:      "null interfaces list",
+			rawConfig: config(),
+		},
+		{
+			name: "bond member without network identity is valid",
+			rawConfig: config(
+				iface(map[string]cty.Value{
+					"intf_usage": bondMember,
+				}),
+			),
+		},
+		{
+			name: "management interface with network identity is valid",
+			rawConfig: config(
+				iface(map[string]cty.Value{
+					"intf_usage": cty.StringVal(string(models.AdapterUsageADAPTERUSAGEMANAGEMENT)),
+					"netname":    cty.StringVal("defaultIPv4-net"),
+					"netid":      cty.StringVal("49972e18-a905-4740-938e-fd283b084257"),
+				}),
+			),
+		},
+		{
+			name: "bond member with explicit netname is rejected",
+			rawConfig: config(
+				iface(map[string]cty.Value{
+					"intf_usage": bondMember,
+					"netname":    cty.StringVal("defaultIPv4-net"),
+				}),
+			),
+			expectError: `interface "eth0"`,
+		},
+		{
+			name: "bond member with explicit netid is rejected",
+			rawConfig: config(
+				iface(map[string]cty.Value{
+					"intf_usage": bondMember,
+					"netid":      cty.StringVal("49972e18-a905-4740-938e-fd283b084257"),
+				}),
+			),
+			expectError: `interface "eth0"`,
+		},
+		{
+			name: "mixed list flags only the offending bond member",
+			rawConfig: config(
+				iface(map[string]cty.Value{
+					"intfname":   cty.StringVal("eth1"),
+					"intf_usage": cty.StringVal(string(models.AdapterUsageADAPTERUSAGEMANAGEMENT)),
+					"netname":    cty.StringVal("defaultIPv4-net"),
+				}),
+				iface(map[string]cty.Value{
+					"intfname":   cty.StringVal("eth2"),
+					"intf_usage": bondMember,
+					"netname":    cty.StringVal("defaultIPv4-net"),
+				}),
+			),
+			expectError: `interface "eth2"`,
+		},
+		{
+			name: "bond member with unknown netid is not rejected at plan time",
+			rawConfig: config(
+				iface(map[string]cty.Value{
+					"intf_usage": bondMember,
+					"netid":      cty.UnknownVal(cty.String),
+				}),
+			),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkBondMemberInterfaces(tc.rawConfig)
+			if tc.expectError == "" {
+				if err != nil {
+					t.Errorf("checkBondMemberInterfaces() = %v, expected no error", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Errorf("checkBondMemberInterfaces() = nil, expected error containing %q", tc.expectError)
+				return
+			}
+			if !strings.Contains(err.Error(), tc.expectError) {
+				t.Errorf("checkBondMemberInterfaces() = %v, expected error containing %q", err, tc.expectError)
+			}
+		})
+	}
+}

--- a/v2/schemas/sys_interface.go
+++ b/v2/schemas/sys_interface.go
@@ -45,6 +45,13 @@ func SysInterfaceModel(d *schema.ResourceData) *models.SysInterface {
 	}
 	netid, _ := d.Get("netid").(string)
 	netname, _ := d.Get("netname").(string)
+	// A bond member interface must not carry a network identity, the API rejects
+	// it. Since netid is Computed, a value removed from the config is carried
+	// forward from state, so it has to be dropped here (ENG-2782).
+	if intfUsage != nil && *intfUsage == models.AdapterUsageADAPTERUSAGEBONDMEMBER {
+		netid = ""
+		netname = ""
+	}
 	var sharedLabels []string
 	sharedLabelsInterface, sharedLabelsIsSet := d.GetOk("shared_labels")
 	if sharedLabelsIsSet {
@@ -127,6 +134,13 @@ func SysInterfaceModelFromMap(m map[string]interface{}) *models.SysInterface {
 	}
 	netid := m["netid"].(string)
 	netname := m["netname"].(string)
+	// A bond member interface must not carry a network identity, the API rejects
+	// it. Since netid is Computed, a value removed from the config is carried
+	// forward from state, so it has to be dropped here (ENG-2782).
+	if intfUsage != nil && *intfUsage == models.AdapterUsageADAPTERUSAGEBONDMEMBER {
+		netid = ""
+		netname = ""
+	}
 	var sharedLabels []string
 	sharedLabelsInterface, sharedLabelsIsSet := m["shared_labels"]
 	if sharedLabelsIsSet {
@@ -389,6 +403,10 @@ func CompareSystemInterfaceList(a, b []*models.SysInterface) (bool, string) {
 		}
 		if x.Netname != y.Netname {
 			reason = fmt.Sprintf("Netname mismatch: %s vs %s", x.Netname, y.Netname)
+			return false
+		}
+		if x.Netid != y.Netid {
+			reason = fmt.Sprintf("Netid mismatch: %s vs %s", x.Netid, y.Netid)
 			return false
 		}
 

--- a/v2/schemas/sys_interface.go
+++ b/v2/schemas/sys_interface.go
@@ -405,7 +405,9 @@ func CompareSystemInterfaceList(a, b []*models.SysInterface) (bool, string) {
 			reason = fmt.Sprintf("Netname mismatch: %s vs %s", x.Netname, y.Netname)
 			return false
 		}
-		if x.Netid != y.Netid {
+		// Netid is resolved by the API from netname, so an empty value only
+		// means "not specified yet"; compare only when both sides carry one.
+		if x.Netid != "" && y.Netid != "" && x.Netid != y.Netid {
 			reason = fmt.Sprintf("Netid mismatch: %s vs %s", x.Netid, y.Netid)
 			return false
 		}

--- a/v2/schemas/sys_interface_test.go
+++ b/v2/schemas/sys_interface_test.go
@@ -269,6 +269,24 @@ func TestCompareSysInterfaceList(t *testing.T) {
 			expected: false,
 		},
 		{
+			name: "different Netid",
+			list1: []*models.SysInterface{
+				{
+					Intfname: "eth0",
+					Netname:  "management",
+					Netid:    "49972e18-a905-4740-938e-fd283b084257",
+				},
+			},
+			list2: []*models.SysInterface{
+				{
+					Intfname: "eth0",
+					Netname:  "management",
+					Netid:    "11111111-2222-3333-4444-555555555555",
+				},
+			},
+			expected: false,
+		},
+		{
 			name: "different NetDhcp - both set",
 			list1: []*models.SysInterface{
 				{
@@ -556,4 +574,64 @@ func TestCompareSysInterfaceList(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Reproduces ENG-2782: converting an interface to ADAPTER_USAGE_BOND_MEMBER
+// must drop the netid/netname carried forward from state via the Computed
+// netid attribute, otherwise the API rejects the update with a 400.
+func TestSysInterfaceModelFromMap_BondMemberDropsNetworkIdentity(t *testing.T) {
+	interfaceMap := func(usage, netname, netid string) map[string]interface{} {
+		return map[string]interface{}{
+			"allow_local_modifications":                false,
+			"enable_port_based_network_access_control": false,
+			"cost":       0,
+			"intf_usage": usage,
+			"intfname":   "eth0",
+			"ipaddr":     "",
+			"macaddr":    "",
+			"net_dhcp":   string(models.NetworkDHCPTypeNETWORKDHCPTYPECLIENT),
+			"netid":      netid,
+			"netname":    netname,
+			"ztype":      "",
+		}
+	}
+
+	t.Run("bond member drops stale netid and netname", func(t *testing.T) {
+		m := SysInterfaceModelFromMap(interfaceMap(
+			string(models.AdapterUsageADAPTERUSAGEBONDMEMBER),
+			"defaultIPv4-net",
+			"49972e18-a905-4740-938e-fd283b084257",
+		))
+		if m.Netid != "" {
+			t.Errorf("Netid = %q, expected empty for bond member interface", m.Netid)
+		}
+		if m.Netname != "" {
+			t.Errorf("Netname = %q, expected empty for bond member interface", m.Netname)
+		}
+	})
+
+	t.Run("management interface keeps netid and netname", func(t *testing.T) {
+		m := SysInterfaceModelFromMap(interfaceMap(
+			string(models.AdapterUsageADAPTERUSAGEMANAGEMENT),
+			"defaultIPv4-net",
+			"49972e18-a905-4740-938e-fd283b084257",
+		))
+		if m.Netid != "49972e18-a905-4740-938e-fd283b084257" {
+			t.Errorf("Netid = %q, expected it to be kept for management interface", m.Netid)
+		}
+		if m.Netname != "defaultIPv4-net" {
+			t.Errorf("Netname = %q, expected it to be kept for management interface", m.Netname)
+		}
+	})
+
+	t.Run("interface without usage keeps netid and netname", func(t *testing.T) {
+		m := SysInterfaceModelFromMap(interfaceMap(
+			"",
+			"defaultIPv4-net",
+			"49972e18-a905-4740-938e-fd283b084257",
+		))
+		if m.Netid == "" || m.Netname == "" {
+			t.Errorf("Netid/Netname = %q/%q, expected them to be kept when intf_usage is unset", m.Netid, m.Netname)
+		}
+	})
 }

--- a/v2/schemas/sys_interface_test.go
+++ b/v2/schemas/sys_interface_test.go
@@ -269,7 +269,7 @@ func TestCompareSysInterfaceList(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "different Netid",
+			name: "different Netid - both set",
 			list1: []*models.SysInterface{
 				{
 					Intfname: "eth0",
@@ -285,6 +285,24 @@ func TestCompareSysInterfaceList(t *testing.T) {
 				},
 			},
 			expected: false,
+		},
+		{
+			name: "Netid - one empty, one resolved by API (should be equal)",
+			list1: []*models.SysInterface{
+				{
+					Intfname: "eth0",
+					Netname:  "management",
+					Netid:    "49972e18-a905-4740-938e-fd283b084257",
+				},
+			},
+			list2: []*models.SysInterface{
+				{
+					Intfname: "eth0",
+					Netname:  "management",
+					Netid:    "",
+				},
+			},
+			expected: true,
 		},
 		{
 			name: "different NetDhcp - both set",


### PR DESCRIPTION
**Changes**

v2/schemas/sys_interface.go — the core fix:
- Both SysInterfaceModel and SysInterfaceModelFromMap now clear netid and netname when intf_usage is ADAPTER_USAGE_BOND_MEMBER, so the stale value carried forward from state by the Computed netid attribute never reaches the API. This covers both create and update, and state self-heals on the post-apply read.
- CompareSystemInterfaceList now also compares Netid (it previously compared Netname but silently ignored Netid), so netid-only discrepancies are no longer invisible to the diff suppressor.

v2/resources/node.go — the hardening:
- Added a CustomizeDiff (validateBondMemberInterfaces) on the zedcloud_edgenode resource that fails at plan time with interface "eth2": netname/netid must not be set when intf_usage is ADAPTER_USAGE_BOND_MEMBER... when the user explicitly writes those attributes on a bond member. It inspects GetRawConfig() (not the merged plan) precisely so that stale carried-forward values don't trigger false positives — only genuine misconfiguration does.

Tests (all passing, full schemas + resources suites green):
- TestSysInterfaceModelFromMap_BondMemberDropsNetworkIdentity reproduces the ticket's MANAGEMENT→BOND_MEMBER conversion and verifies the identity is dropped for bond members but kept for management/unset-usage interfaces.
- TestCheckBondMemberInterfaces covers the plan-time validation with cty raw-config values, including null/unknown configs and a mixed list where only the offending interface is flagged.
- Added a "different Netid" case to the existing CompareSystemInterfaceList test.

v2/go.mod/go.sum — go mod tidy promoted hashicorp/go-cty to a direct dependency (now imported by node.go) and dropped the unused golang.org/x/exp.

**Tickets:**
- https://zededa.atlassian.net/browse/ENG-2782