### PR TITLE
fix: Fix the issue with the vlan/bond adapters removal (eng-2805)

### DIFF
--- a/v2/resources/node_adapter_removal_test.go
+++ b/v2/resources/node_adapter_removal_test.go
@@ -179,6 +179,107 @@ func TestNodeResource_BondAdapterUnchanged_SuppressesDiff(t *testing.T) {
 	}
 }
 
+// TestNodeResource_BondAdapterAddition_PlansDiff pins the ENG-2782 forward
+// scenario (convert interfaces to BOND_MEMBER and add a bond_adapter block)
+// at the plan level, proving the ENG-2805 raw-config guard does not interfere
+// with it: the guard is inert on addition because the config still carries the
+// bond_adapter key, so GetChange never falls back to state.
+func TestNodeResource_BondAdapterAddition_PlansDiff(t *testing.T) {
+	r := NodeResource()
+
+	// state: no bond adapter, members still MANAGEMENT with netid/netname
+	state := &terraform.InstanceState{
+		ID: "609fe5d4-d6a6-4063-a8a5-fbd5cfdcb8d6",
+		Attributes: map[string]string{
+			"id":    "609fe5d4-d6a6-4063-a8a5-fbd5cfdcb8d6",
+			"name":  "lag-device",
+			"title": "lag-device",
+
+			"interfaces.#":            "2",
+			"interfaces.0.intfname":   "eth0",
+			"interfaces.0.intf_usage": "ADAPTER_USAGE_MANAGEMENT",
+			"interfaces.0.netname":    "defaultIPv4-net",
+			"interfaces.0.netid":      "49972e18-a905-4740-938e-fd283b084257",
+			"interfaces.0.net_dhcp":   "NETWORK_DHCP_TYPE_CLIENT",
+			"interfaces.0.cost":       "0",
+			"interfaces.0.tags.%":     "0",
+			"interfaces.1.intfname":   "eth2",
+			"interfaces.1.intf_usage": "ADAPTER_USAGE_MANAGEMENT",
+			"interfaces.1.netname":    "defaultIPv4-net",
+			"interfaces.1.netid":      "49972e18-a905-4740-938e-fd283b084257",
+			"interfaces.1.net_dhcp":   "NETWORK_DHCP_TYPE_CLIENT",
+			"interfaces.1.cost":       "0",
+			"interfaces.1.tags.%":     "0",
+
+			"bond_adapter.#": "0",
+		},
+	}
+	// raw config declares one bond_adapter block
+	state.RawConfig = cty.ObjectVal(map[string]cty.Value{
+		"bond_adapter": cty.ListVal([]cty.Value{
+			cty.ObjectVal(map[string]cty.Value{
+				"logical_label": cty.StringVal("lag-test-01"),
+			}),
+		}),
+	})
+
+	config := terraform.NewResourceConfigRaw(map[string]interface{}{
+		"name":  "lag-device",
+		"title": "lag-device",
+		"interfaces": []interface{}{
+			map[string]interface{}{
+				"intfname":   "eth0",
+				"intf_usage": "ADAPTER_USAGE_BOND_MEMBER",
+			},
+			map[string]interface{}{
+				"intfname":   "eth2",
+				"intf_usage": "ADAPTER_USAGE_BOND_MEMBER",
+			},
+		},
+		"bond_adapter": []interface{}{
+			map[string]interface{}{
+				"logical_label":     "lag-test-01",
+				"bond_mode":         "BOND_MODE_802_3AD",
+				"lacp_rate":         "LACP_RATE_FAST",
+				"lower_layer_names": []interface{}{"eth0", "eth2"},
+				"interface": []interface{}{
+					map[string]interface{}{
+						"intfname":   "lag-test-01",
+						"intf_usage": "ADAPTER_USAGE_MANAGEMENT",
+						"netname":    "defaultIPv4-net",
+						"netid":      "49972e18-a905-4740-938e-fd283b084257",
+						"net_dhcp":   "NETWORK_DHCP_TYPE_CLIENT",
+					},
+				},
+			},
+		},
+	})
+
+	diff, err := r.Diff(context.Background(), state, config, nil)
+	if err != nil {
+		t.Fatalf("diff error: %s", err)
+	}
+	if diff == nil {
+		t.Fatal("diff is nil, expected bond_adapter addition and interface conversion to be planned")
+	}
+
+	countDiff, ok := diff.Attributes["bond_adapter.#"]
+	if !ok {
+		t.Fatal("bond_adapter.# missing from diff, addition not planned")
+	}
+	if countDiff.Old != "0" || countDiff.New != "1" {
+		t.Errorf("bond_adapter.# diff = %q => %q, expected \"0\" => \"1\"", countDiff.Old, countDiff.New)
+	}
+
+	usageDiff, ok := diff.Attributes["interfaces.0.intf_usage"]
+	if !ok {
+		t.Fatal("interfaces.0.intf_usage missing from diff, conversion not planned")
+	}
+	if usageDiff.New != "ADAPTER_USAGE_BOND_MEMBER" {
+		t.Errorf("interfaces.0.intf_usage new = %q, expected ADAPTER_USAGE_BOND_MEMBER", usageDiff.New)
+	}
+}
+
 func TestNodeResource_VlanAdapterRemoval_PlansDiff(t *testing.T) {
 	r := NodeResource()
 

--- a/v2/resources/node_adapter_removal_test.go
+++ b/v2/resources/node_adapter_removal_test.go
@@ -1,0 +1,241 @@
+package resources
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// Regression tests for ENG-2805: removing the last bond_adapter (or
+// vlan_adapters) block from the config must produce a plan diff. GetChange's
+// "new" side merges config over state, and the hcl2 shim omits empty block
+// lists from the legacy config entirely, so the merge falls back to state and
+// the list diff-suppress functions used to see old==new and suppress the
+// removal. The suppress functions now consult the raw config (which always
+// carries the attribute, mirroring what PlanResourceChange provides via
+// InstanceState.RawConfig) to detect the removed blocks.
+
+// nodeStateWithBondAdapter returns an InstanceState for a node with one bond
+// adapter (lag-test-01 over eth0/eth2) and its two bond member interfaces.
+func nodeStateWithBondAdapter() *terraform.InstanceState {
+	return &terraform.InstanceState{
+		ID: "609fe5d4-d6a6-4063-a8a5-fbd5cfdcb8d6",
+		Attributes: map[string]string{
+			"id":    "609fe5d4-d6a6-4063-a8a5-fbd5cfdcb8d6",
+			"name":  "lag-device",
+			"title": "lag-device",
+
+			"interfaces.#":            "2",
+			"interfaces.0.intfname":   "eth0",
+			"interfaces.0.intf_usage": "ADAPTER_USAGE_BOND_MEMBER",
+			"interfaces.0.net_dhcp":   "NETWORK_DHCP_TYPE_UNSPECIFIED",
+			"interfaces.0.cost":       "0",
+			"interfaces.0.tags.%":     "0",
+			"interfaces.1.intfname":   "eth2",
+			"interfaces.1.intf_usage": "ADAPTER_USAGE_BOND_MEMBER",
+			"interfaces.1.net_dhcp":   "NETWORK_DHCP_TYPE_UNSPECIFIED",
+			"interfaces.1.cost":       "0",
+			"interfaces.1.tags.%":     "0",
+
+			"bond_adapter.#":                        "1",
+			"bond_adapter.0.logical_label":          "lag-test-01",
+			"bond_adapter.0.bond_mode":              "BOND_MODE_802_3AD",
+			"bond_adapter.0.lacp_rate":              "LACP_RATE_FAST",
+			"bond_adapter.0.lower_layer_names.#":    "2",
+			"bond_adapter.0.lower_layer_names.0":    "eth0",
+			"bond_adapter.0.lower_layer_names.1":    "eth2",
+			"bond_adapter.0.interface.#":            "1",
+			"bond_adapter.0.interface.0.intfname":   "lag-test-01",
+			"bond_adapter.0.interface.0.intf_usage": "ADAPTER_USAGE_MANAGEMENT",
+			"bond_adapter.0.interface.0.netname":    "defaultIPv4-net",
+			"bond_adapter.0.interface.0.netid":      "49972e18-a905-4740-938e-fd283b084257",
+			"bond_adapter.0.interface.0.net_dhcp":   "NETWORK_DHCP_TYPE_CLIENT",
+			"bond_adapter.0.interface.0.cost":       "0",
+			"bond_adapter.0.interface.0.tags.%":     "0",
+		},
+	}
+}
+
+// diffKeysWithPrefix returns the diff attribute keys starting with prefix.
+func diffKeysWithPrefix(diff *terraform.InstanceDiff, prefix string) []string {
+	var keys []string
+	if diff == nil {
+		return keys
+	}
+	for k := range diff.Attributes {
+		if strings.HasPrefix(k, prefix) {
+			keys = append(keys, k)
+		}
+	}
+	return keys
+}
+
+func TestNodeResource_BondAdapterRemoval_PlansDiff(t *testing.T) {
+	r := NodeResource()
+
+	state := nodeStateWithBondAdapter()
+	// PlanResourceChange always attaches the raw config to the prior state
+	// before diffing; a removed block list is present there as an empty list.
+	state.RawConfig = cty.ObjectVal(map[string]cty.Value{
+		"bond_adapter": cty.ListValEmpty(cty.EmptyObject),
+	})
+
+	// config: bond_adapter removed entirely, members flipped to MANAGEMENT
+	config := terraform.NewResourceConfigRaw(map[string]interface{}{
+		"name":  "lag-device",
+		"title": "lag-device",
+		"interfaces": []interface{}{
+			map[string]interface{}{
+				"intfname":   "eth0",
+				"intf_usage": "ADAPTER_USAGE_MANAGEMENT",
+				"netname":    "defaultIPv4-net",
+				"netid":      "49972e18-a905-4740-938e-fd283b084257",
+				"net_dhcp":   "NETWORK_DHCP_TYPE_CLIENT",
+			},
+			map[string]interface{}{
+				"intfname":   "eth2",
+				"intf_usage": "ADAPTER_USAGE_MANAGEMENT",
+				"netname":    "defaultIPv4-net",
+				"netid":      "49972e18-a905-4740-938e-fd283b084257",
+				"net_dhcp":   "NETWORK_DHCP_TYPE_CLIENT",
+			},
+		},
+	})
+
+	diff, err := r.Diff(context.Background(), state, config, nil)
+	if err != nil {
+		t.Fatalf("diff error: %s", err)
+	}
+	if diff == nil {
+		t.Fatal("diff is nil, expected the bond_adapter removal to be planned")
+	}
+
+	countDiff, ok := diff.Attributes["bond_adapter.#"]
+	if !ok {
+		t.Fatalf(
+			"bond_adapter removal missing from diff, bond_adapter keys: %v",
+			diffKeysWithPrefix(diff, "bond_adapter"),
+		)
+	}
+	if countDiff.Old != "1" || countDiff.New != "0" {
+		t.Errorf("bond_adapter.# diff = %q => %q, expected \"1\" => \"0\"", countDiff.Old, countDiff.New)
+	}
+}
+
+func TestNodeResource_BondAdapterUnchanged_SuppressesDiff(t *testing.T) {
+	r := NodeResource()
+
+	bondConfig := map[string]interface{}{
+		"logical_label":     "lag-test-01",
+		"bond_mode":         "BOND_MODE_802_3AD",
+		"lacp_rate":         "LACP_RATE_FAST",
+		"lower_layer_names": []interface{}{"eth0", "eth2"},
+		"interface": []interface{}{
+			map[string]interface{}{
+				"intfname":   "lag-test-01",
+				"intf_usage": "ADAPTER_USAGE_MANAGEMENT",
+				"netname":    "defaultIPv4-net",
+				"netid":      "49972e18-a905-4740-938e-fd283b084257",
+				"net_dhcp":   "NETWORK_DHCP_TYPE_CLIENT",
+			},
+		},
+	}
+
+	state := nodeStateWithBondAdapter()
+	state.RawConfig = cty.ObjectVal(map[string]cty.Value{
+		"bond_adapter": cty.ListVal([]cty.Value{
+			cty.ObjectVal(map[string]cty.Value{
+				"logical_label": cty.StringVal("lag-test-01"),
+			}),
+		}),
+	})
+
+	config := terraform.NewResourceConfigRaw(map[string]interface{}{
+		"name":  "lag-device",
+		"title": "lag-device",
+		"interfaces": []interface{}{
+			map[string]interface{}{
+				"intfname":   "eth0",
+				"intf_usage": "ADAPTER_USAGE_BOND_MEMBER",
+			},
+			map[string]interface{}{
+				"intfname":   "eth2",
+				"intf_usage": "ADAPTER_USAGE_BOND_MEMBER",
+			},
+		},
+		"bond_adapter": []interface{}{bondConfig},
+	})
+
+	diff, err := r.Diff(context.Background(), state, config, nil)
+	if err != nil {
+		t.Fatalf("diff error: %s", err)
+	}
+
+	if keys := diffKeysWithPrefix(diff, "bond_adapter"); len(keys) > 0 {
+		t.Errorf("unchanged bond_adapter produced diff keys: %v", keys)
+	}
+}
+
+func TestNodeResource_VlanAdapterRemoval_PlansDiff(t *testing.T) {
+	r := NodeResource()
+
+	state := &terraform.InstanceState{
+		ID: "609fe5d4-d6a6-4063-a8a5-fbd5cfdcb8d6",
+		Attributes: map[string]string{
+			"id":    "609fe5d4-d6a6-4063-a8a5-fbd5cfdcb8d6",
+			"name":  "vlan-device",
+			"title": "vlan-device",
+
+			"interfaces.#":            "1",
+			"interfaces.0.intfname":   "eth0",
+			"interfaces.0.intf_usage": "ADAPTER_USAGE_VLANS_ONLY",
+			"interfaces.0.net_dhcp":   "NETWORK_DHCP_TYPE_UNSPECIFIED",
+			"interfaces.0.cost":       "0",
+			"interfaces.0.tags.%":     "0",
+
+			"vlan_adapters.#":                  "1",
+			"vlan_adapters.0.logical_label":    "vlan-100",
+			"vlan_adapters.0.interface_name":   "vlan-100",
+			"vlan_adapters.0.lower_layer_name": "eth0",
+			"vlan_adapters.0.vlan_id":          "100",
+		},
+	}
+	state.RawConfig = cty.ObjectVal(map[string]cty.Value{
+		"vlan_adapters": cty.ListValEmpty(cty.EmptyObject),
+	})
+
+	config := terraform.NewResourceConfigRaw(map[string]interface{}{
+		"name":  "vlan-device",
+		"title": "vlan-device",
+		"interfaces": []interface{}{
+			map[string]interface{}{
+				"intfname":   "eth0",
+				"intf_usage": "ADAPTER_USAGE_MANAGEMENT",
+				"netname":    "defaultIPv4-net",
+				"net_dhcp":   "NETWORK_DHCP_TYPE_CLIENT",
+			},
+		},
+	})
+
+	diff, err := r.Diff(context.Background(), state, config, nil)
+	if err != nil {
+		t.Fatalf("diff error: %s", err)
+	}
+	if diff == nil {
+		t.Fatal("diff is nil, expected the vlan_adapters removal to be planned")
+	}
+
+	countDiff, ok := diff.Attributes["vlan_adapters.#"]
+	if !ok {
+		t.Fatalf(
+			"vlan_adapters removal missing from diff, vlan_adapters keys: %v",
+			diffKeysWithPrefix(diff, "vlan_adapters"),
+		)
+	}
+	if countDiff.Old != "1" || countDiff.New != "0" {
+		t.Errorf("vlan_adapters.# diff = %q => %q, expected \"1\" => \"0\"", countDiff.Old, countDiff.New)
+	}
+}

--- a/v2/schemas/schema_helpers.go
+++ b/v2/schemas/schema_helpers.go
@@ -192,6 +192,14 @@ func diffSuppressVlanAdapterListOrder(mapKey string) schema.SchemaDiffSuppressFu
 
 		old := oldData.([]interface{})
 		new := newData.([]interface{})
+		// GetChange's "new" side merges config over state; when the last block
+		// is removed from the config, the key is absent and the merge falls
+		// back to state, making old==new. The raw config is the source of
+		// truth for the declared block count — if it disagrees, there is a
+		// real change (same defect as ENG-2805).
+		if rawLen := rawConfigListLength(d, mapKey); rawLen >= 0 && rawLen != len(new) {
+			return false
+		}
 		if len(old) != len(new) {
 			return false
 		}
@@ -504,6 +512,23 @@ func diffSuppressIfFieldValueEqual(field, value string) schema.SchemaDiffSuppres
 	}
 }
 
+// rawConfigListLength returns the number of elements the raw Terraform config
+// declares for the given top-level list attribute, or -1 when it cannot tell
+// (raw config unavailable, e.g. during destroy, or the value is not fully
+// known yet). Unlike GetChange, the raw config always carries the attribute,
+// even when the config declares zero blocks.
+func rawConfigListLength(d *schema.ResourceData, field string) int {
+	rawConfig := d.GetRawConfig()
+	if rawConfig.IsNull() || !rawConfig.Type().IsObjectType() || !rawConfig.Type().HasAttribute(field) {
+		return -1
+	}
+	attr := rawConfig.GetAttr(field)
+	if attr.IsNull() || !attr.IsKnown() || !attr.CanIterateElements() {
+		return -1
+	}
+	return attr.LengthInt()
+}
+
 func isFieldDefinedInTerraformConfig(d *schema.ResourceData, field string) bool {
 	rawConfig := d.GetRawConfig()
 	if !rawConfig.IsKnown() || rawConfig.IsNull() {
@@ -608,6 +633,14 @@ func diffSuppressBondAdapterListOrder(mapKey string) schema.SchemaDiffSuppressFu
 
 		old := oldData.([]interface{})
 		new := newData.([]interface{})
+		// GetChange's "new" side merges config over state; when the last block
+		// is removed from the config, the key is absent and the merge falls
+		// back to state, making old==new. The raw config is the source of
+		// truth for the declared block count — if it disagrees, there is a
+		// real change (ENG-2805).
+		if rawLen := rawConfigListLength(d, mapKey); rawLen >= 0 && rawLen != len(new) {
+			return false
+		}
 		if len(old) != len(new) {
 			return false
 		}


### PR DESCRIPTION
**Changes**:

Problem

Removing the last bond_adapter block from a zedcloud_edgenode config (while reassigning its member interfaces away from ADAPTER_USAGE_BOND_MEMBER) was invisible to terraform plan — the block was folded into "unchanged blocks hidden". On apply, the provider resent the stale bond adapter alongside interfaces now declared as ADAPTER_USAGE_MANAGEMENT, and the ZedCloud API rejected the contradictory payload with a generic 400:

bond lag-test-01: lower layer eth0 must have intfUsage set to BOND_MEMBER, got ADAPTER_USAGE_MANAGEMENT

Root cause

A chain of three SDK behaviors in terraform-plugin-sdk v2:

1. The hcl2 shim omits empty block lists from the legacy config map entirely (hcl2shim/values.go), so when the config declares zero bond_adapter blocks, the key is simply absent.
2. ResourceData.GetChange's "new" side is a state→config merge (ReadFieldMerge); with the key absent from config, it falls back to the state value — so inside the diff-suppress function, old and new were the same one-element list.
3. The SDK applies a list-level DiffSuppressFunc to every diff key the list generates, including the count key. Since diffSuppressBondAdapterListOrder compared the old list against itself, it suppressed all bond_adapter.* keys — wiping the correctly computed bond_adapter.#: 1 → 0 removal.

diffSuppressVlanAdapterListOrder is a line-for-line clone and had the identical defect for vlan_adapters removal.

Fix

v2/schemas/schema_helpers.go (+41 lines):
- New helper rawConfigListLength(d, field) — reads the block count a list attribute actually declares from d.GetRawConfig(), which (unlike GetChange) always carries the attribute, even when empty; it's reliably populated during plan because PlanResourceChange attaches the raw config to the prior state before diffing. Returns -1 when unavailable (destroy) or not fully known (e.g. unresolved for_each), in which case behavior is unchanged.
- Guard added to diffSuppressBondAdapterListOrder and diffSuppressVlanAdapterListOrder: if the raw config's declared block count disagrees with what GetChange reported, there is a real change — suppression is refused. When counts agree, the existing order-insensitive comparison runs untouched, so reordering-only diffs are still suppressed as before.

Tests

v2/resources/node_adapter_removal_test.go (new, 3 tests) — drive NodeResource().Diff() directly with state.RawConfig populated the same way a real plan does:
- TestNodeResource_BondAdapterRemoval_PlansDiff — the ticket's exact scenario (lag-test-01 over eth0/eth2 in state; config with the block removed and members flipped to ADAPTER_USAGE_MANAGEMENT); asserts the diff contains bond_adapter.# "1" => "0". Fails without the fix (zero bond_adapter.* keys survive).
- TestNodeResource_BondAdapterUnchanged_SuppressesDiff — identical bond in state and config yields no bond_adapter.* diff keys (suppression behavior preserved).
- TestNodeResource_VlanAdapterRemoval_PlansDiff — same removal scenario for vlan_adapters, asserting vlan_adapters.# "1" => "0".

All unit suites (./schemas/..., ./resources/...) pass; build and vet are clean.

**Tickets**:
- https://zededa.atlassian.net/browse/ENG-2805