### PR TITLE
ci: self-hosted runner e2e workflow and virtual EVE node harness (UE-138, UE-137)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -89,7 +89,17 @@ jobs:
       ZEDAMIGO_VERSION: "0.13.1"
 
     steps:
+      # fetch-tags because the Makefile derives the binary name from
+      # `git describe --always --abbrev=0 --tags`. With checkout's default
+      # shallow fetch there are no tags, `describe` falls back to a bare
+      # commit SHA, and the build produces
+      # terraform-provider-zedcloud_<sha> -- which matches neither
+      # Terraform's expected terraform-provider-NAME_vX.Y.Z form nor the
+      # `rm -f ./v2/terraform-provider-zedcloud_v*` cleanup in the same
+      # target, so stale binaries pile up run after run.
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
 
       # The runner's PATH comes from services.github-runners.extraPackages in
       # hosts/h-m-dl20/github-runners.nix. Fail loudly and early if something
@@ -127,7 +137,22 @@ jobs:
           test -w /dev/kvm || { echo "/dev/kvm not writable"; exit 1; }
           echo "toolchain ok: $(tofu version | head -1), $(go version)"
 
+      # CGO_ENABLED=0 to match how the provider is actually released.
+      # .goreleaser.yml sets it, with the comment "goreleaser does not work
+      # with CGO", so every published binary is built without cgo -- and the
+      # only `import "C"` in the tree is vendored x/sys code for hurd and aix,
+      # which never builds on linux/amd64 anyway.
+      #
+      # Without this the runner needs a C toolchain purely to satisfy
+      # runtime/cgo, and the build fails with
+      # `cgo: C compiler "gcc" not found`. Adding gcc to the runner would
+      # work, but it would make this step LESS faithful than the release --
+      # it would be the only place the provider gets built with cgo. Note
+      # go.yml on ubuntu-latest does exactly that today, silently, because
+      # the hosted image ships gcc.
       - name: Build provider under test
+        env:
+          CGO_ENABLED: "0"
         run: make build
 
       # zedamigo drives QEMU locally on this host. Installed under the runner's

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,6 +33,27 @@ jobs:
     runs-on: [self-hosted, berlin-lab]
     timeout-minutes: 60
 
+    # INFORMATIONAL ONLY -- this job must not gate a merge yet.
+    #
+    # The job has never completed a green run on the real runner (UE-138), and
+    # its failure modes are still host-level rather than code-level: rootless
+    # podman without a login session, capacity claims against a tree shared
+    # with humans' manual runs, an EVE tag that could go stale. A red X from
+    # any of those says nothing about the pull request it is attached to, and
+    # a check that is routinely wrong is a check people learn to ignore.
+    #
+    # `continue-on-error` reports the job as successful whatever the outcome,
+    # so the result stays visible on the PR (and the step-level status shows
+    # what actually failed) without ever blocking a merge. This is belt and
+    # braces alongside branch protection, where `main` currently requires no
+    # status checks at all -- but that is a setting anyone can change, and it
+    # should not be the only thing standing between a flaky lab host and a
+    # blocked merge queue.
+    #
+    # REMOVE in UE-141, once the job has been stable for several weeks and is
+    # deliberately promoted to a required check.
+    continue-on-error: true
+
     # ---------------------------------------------------------------------
     # SECURITY GATE -- DO NOT REMOVE
     #

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -155,8 +155,27 @@ jobs:
 
       # CGO_ENABLED=0 comes from the job-level env above -- see the note
       # there for why, and why it is not step-level.
+      #
+      # The unsuffixed symlink is what makes this step's output actually get
+      # used. `make build` emits terraform-provider-zedcloud_<version> (the
+      # name a filesystem mirror or release archive wants), but a
+      # `dev_overrides` directory is scanned for a plain
+      # terraform-provider-<TYPE>. Without the link, tofu silently falls back
+      # to the registry and `test/e2e` applies a RELEASED provider -- which is
+      # what it did until now, making the step name a lie.
+      #
+      # `make build` starts with `rm -f ./v2/terraform-provider-zedcloud_v*`,
+      # which does not match the unsuffixed name, so the link survives and is
+      # re-pointed here on every run.
       - name: Build provider under test
-        run: make build
+        run: |
+          set -euo pipefail
+          make build
+          cd v2
+          bin="$(ls -1t terraform-provider-zedcloud_* | head -1)"
+          ln -sf "$bin" terraform-provider-zedcloud
+          echo "provider under test: $bin"
+          ls -l terraform-provider-zedcloud
 
       # zedamigo drives QEMU locally on this host. Installed under the runner's
       # HOME so each runner account is self-contained.
@@ -166,14 +185,32 @@ jobs:
           curl -fsSL "https://raw.githubusercontent.com/andrei-zededa/terraform-provider-zedamigo/v${ZEDAMIGO_VERSION}/install.sh" \
             | bash -s -- --binary-only "${ZEDAMIGO_VERSION}"
 
-      # Generated rather than committed: the filesystem_mirror path depends on
-      # the runner account's HOME, and the repo's own dev.tfrc breaks zedamigo
-      # resolution (its dev_overrides + direct{} block shadow the mirror).
+      # Generated rather than committed: both paths below are run-specific --
+      # the filesystem_mirror depends on the runner account's HOME and the
+      # dev_overrides on the workspace checkout. The repo's own dev.tfrc is
+      # not usable here either; its dev_overrides path is relative ("./v2"),
+      # so it resolves against whatever directory tofu happens to run in.
+      #
+      # dev_overrides is what makes this job test the PULL REQUEST's provider
+      # rather than a released one. Before it, terraform.tf resolved
+      # zededa/zedcloud from the public registry, so every cloud object the
+      # harness created -- project, brand, model, network instance, image,
+      # edgenode -- was created by whatever version the registry served. A PR
+      # that broke edgenode creation would have sailed straight through node
+      # setup. (The acceptance test itself was always fine: the SDK links the
+      # provider in-process from source and never resolves it from disk.)
+      #
+      # dev_overrides must come first in provider_installation, and it makes
+      # tofu ignore version constraints for that provider with a warning --
+      # which is why terraform.tf no longer pins one.
       - name: Write provider CLI config
         run: |
           set -euo pipefail
           cat > "${RUNNER_TEMP}/e2e.tfrc" <<EOF
           provider_installation {
+            dev_overrides {
+              "zededa/zedcloud" = "${GITHUB_WORKSPACE}/v2"
+            }
             filesystem_mirror {
               path    = "${HOME}/.terraform.d/plugins"
               include = ["localhost/andrei-zededa/zedamigo"]
@@ -183,6 +220,11 @@ jobs:
             }
           }
           EOF
+          echo "--- e2e.tfrc ---"
+          cat "${RUNNER_TEMP}/e2e.tfrc"
+          # Fail here rather than let tofu quietly fall back to the registry.
+          test -x "${GITHUB_WORKSPACE}/v2/terraform-provider-zedcloud" \
+            || { echo "dev_overrides target missing or not executable"; exit 1; }
 
       # Creates the cloud objects, builds the EVE installer, installs it,
       # boots the VM, and blocks on zedamigo_wait_until until the controller

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -88,6 +88,22 @@ jobs:
       # by its own install.sh.
       ZEDAMIGO_VERSION: "0.13.1"
 
+      # JOB-level, not step-level, because EVERY Go invocation here needs it
+      # and there is more than one. This started as a step-level setting on
+      # `make build`, and the acceptance step then failed identically --
+      # `go test` compiles the package too, so it wanted a C compiler just as
+      # much as the build did.
+      #
+      # Why 0 rather than installing gcc: .goreleaser.yml sets CGO_ENABLED=0
+      # ("goreleaser does not work with CGO"), so every published binary is
+      # built without cgo, and the only `import "C"` in the tree is vendored
+      # x/sys code for hurd and aix that never builds on linux/amd64. Adding
+      # a C toolchain would make this the one place the provider is compiled
+      # WITH cgo -- less faithful to the release, not more. (go.yml on
+      # ubuntu-latest does exactly that today, silently, because the hosted
+      # image ships gcc.)
+      CGO_ENABLED: "0"
+
     steps:
       # fetch-tags because the Makefile derives the binary name from
       # `git describe --always --abbrev=0 --tags`. With checkout's default
@@ -137,22 +153,9 @@ jobs:
           test -w /dev/kvm || { echo "/dev/kvm not writable"; exit 1; }
           echo "toolchain ok: $(tofu version | head -1), $(go version)"
 
-      # CGO_ENABLED=0 to match how the provider is actually released.
-      # .goreleaser.yml sets it, with the comment "goreleaser does not work
-      # with CGO", so every published binary is built without cgo -- and the
-      # only `import "C"` in the tree is vendored x/sys code for hurd and aix,
-      # which never builds on linux/amd64 anyway.
-      #
-      # Without this the runner needs a C toolchain purely to satisfy
-      # runtime/cgo, and the build fails with
-      # `cgo: C compiler "gcc" not found`. Adding gcc to the runner would
-      # work, but it would make this step LESS faithful than the release --
-      # it would be the only place the provider gets built with cgo. Note
-      # go.yml on ubuntu-latest does exactly that today, silently, because
-      # the hosted image ships gcc.
+      # CGO_ENABLED=0 comes from the job-level env above -- see the note
+      # there for why, and why it is not step-level.
       - name: Build provider under test
-        env:
-          CGO_ENABLED: "0"
         run: make build
 
       # zedamigo drives QEMU locally on this host. Installed under the runner's

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,191 @@
+# End-to-end test against a real, virtual EVE-OS edge node.
+#
+# Runs on a SELF-HOSTED runner on the Berlin lab host (h-m-dl20), because that
+# is where the QEMU VMs live. The host is RFC1918 and reachable only over the
+# office VPN, so a GitHub-hosted runner could not drive it; putting the runner
+# on the host removes the network problem entirely.
+#
+# See docs/design/e2e-virtual-eve-node-testing.md.
+
+name: E2E (virtual EVE node)
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+# Per-BRANCH coalescing only: a new push supersedes its own in-flight run.
+#
+# Deliberately NOT a single global group. A concurrency group holds at most one
+# pending run and cancels the older one when a newer arrives, which starves the
+# PR that has been waiting longest. Serialisation is instead a property of
+# having ONE self-hosted runner: GitHub dispatches jobs to a runner label one at
+# a time, in arrival order, which is the behaviour we actually want.
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: Virtual EVE node
+    runs-on: [self-hosted, berlin-lab]
+    timeout-minutes: 60
+
+    # ---------------------------------------------------------------------
+    # SECURITY GATE -- DO NOT REMOVE
+    #
+    # This repository is PUBLIC and the runner is self-hosted on a machine
+    # inside the Berlin lab network. Without this condition, anyone opening a
+    # pull request from a fork would execute their code on that host.
+    #
+    # Note this is a stronger requirement than for a GitHub-hosted runner:
+    # GitHub withholds repository secrets from fork `pull_request` workflows,
+    # so a hosted runner would hand a fork nothing useful. Here the code is
+    # already running on the target, so no secret is needed to do damage.
+    #
+    # With this gate, only branches pushed to this repository reach the runner,
+    # making the trust boundary "who has push access".
+    # ---------------------------------------------------------------------
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+
+    env:
+      # Control API. The device API (zedcloud.alpha) is baked into the EVE
+      # image by the Terraform config, not needed here.
+      TF_VAR_zedcloud_url: ${{ vars.TF_VAR_ZEDCLOUD_URL }}
+      TF_VAR_zedcloud_token: ${{ secrets.TF_VAR_ZEDCLOUD_TOKEN }}
+
+      # Unique per run, threaded through every created object name so
+      # concurrent or leftover runs cannot collide on the shared alpha
+      # enterprise (~233 devices, ~334 projects belonging to other people).
+      RUN_ID: gh${{ github.run_id }}
+
+      # Pin the zedamigo provider. Not on a public registry, so it is fetched
+      # by its own install.sh.
+      ZEDAMIGO_VERSION: "0.13.1"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # The runner's PATH comes from services.github-runners.extraPackages in
+      # hosts/h-m-dl20/github-runners.nix. Fail loudly and early if something
+      # is missing, rather than midway through an apply that has already
+      # started a VM.
+      - name: Verify host toolchain
+        run: |
+          set -euo pipefail
+          for t in go tofu qemu-system-x86_64 qemu-img docker ip flock jq curl unzip; do
+            command -v "$t" >/dev/null || { echo "missing: $t"; exit 1; }
+          done
+          test -w /dev/kvm || { echo "/dev/kvm not writable"; exit 1; }
+          echo "toolchain ok: $(tofu version | head -1), $(go version)"
+
+      - name: Build provider under test
+        run: make build
+
+      # zedamigo drives QEMU locally on this host. Installed under the runner's
+      # HOME so each runner account is self-contained.
+      - name: Install zedamigo provider
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://raw.githubusercontent.com/andrei-zededa/terraform-provider-zedamigo/v${ZEDAMIGO_VERSION}/install.sh" \
+            | bash -s -- --binary-only "${ZEDAMIGO_VERSION}"
+
+      # Generated rather than committed: the filesystem_mirror path depends on
+      # the runner account's HOME, and the repo's own dev.tfrc breaks zedamigo
+      # resolution (its dev_overrides + direct{} block shadow the mirror).
+      - name: Write provider CLI config
+        run: |
+          set -euo pipefail
+          cat > "${RUNNER_TEMP}/e2e.tfrc" <<EOF
+          provider_installation {
+            filesystem_mirror {
+              path    = "${HOME}/.terraform.d/plugins"
+              include = ["localhost/andrei-zededa/zedamigo"]
+            }
+            direct {
+              exclude = ["localhost/andrei-zededa/zedamigo"]
+            }
+          }
+          EOF
+
+      # Creates the cloud objects, builds the EVE installer, installs it,
+      # boots the VM, and blocks on zedamigo_wait_until until the controller
+      # reports the device RUN_STATE_ONLINE. `target` is localhost, so the
+      # provider uses its local executor -- no SSH.
+      - name: Create virtual EVE node
+        id: node
+        working-directory: test/e2e
+        env:
+          TF_CLI_CONFIG_FILE: ${{ runner.temp }}/e2e.tfrc
+          TF_VAR_run_id: ${{ env.RUN_ID }}
+          TF_VAR_edge_node_ssh_pub_key: ""
+        run: |
+          set -euo pipefail
+          tofu init -input=false
+          tofu apply -auto-approve -input=false
+          {
+            echo "device_id=$(tofu output -raw device_id)"
+            echo "device_name=$(tofu output -raw device_name)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run real-node acceptance tests
+        working-directory: v2/resources
+        env:
+          TF_ACC: "1"
+          CI: "true"
+          TF_CLI_CONFIG_FILE: ${{ github.workspace }}/dev.tfrc
+          ZEDCLOUD_ACC_REAL_NODE: "1"
+          ZEDCLOUD_TEST_NODE_NAME: ${{ steps.node.outputs.device_name }}
+          ZEDCLOUD_TEST_SUFFIX: _${{ env.RUN_ID }}
+        run: go test -v -timeout 40m -run TestApplicationInstance_RealNode .
+
+      # Console logs are the only place EVE's silent failures show up (TLS
+      # trust, console misconfiguration), so collect them regardless of result.
+      - name: Collect diagnostics
+        if: always()
+        working-directory: test/e2e
+        env:
+          TF_CLI_CONFIG_FILE: ${{ runner.temp }}/e2e.tfrc
+          TF_VAR_run_id: ${{ env.RUN_ID }}
+        run: |
+          mkdir -p "${RUNNER_TEMP}/diag"
+          for o in install_console_log run_console_log; do
+            p="$(tofu output -raw "$o" 2>/dev/null || true)"
+            [ -n "$p" ] && [ -f "$p" ] && cp "$p" "${RUNNER_TEMP}/diag/" || true
+          done
+          cp apply.log "${RUNNER_TEMP}/diag/" 2>/dev/null || true
+
+      - name: Upload diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-diagnostics-${{ env.RUN_ID }}
+          path: ${{ runner.temp }}/diag
+          if-no-files-found: ignore
+          retention-days: 7
+
+      # Non-negotiable. Destroy releases the QEMU process, the disk images AND
+      # the host capacity reservation, which is durable and survives reboots --
+      # a skipped destroy leaks CPU and RAM slots for every later run.
+      - name: Destroy
+        if: always()
+        working-directory: test/e2e
+        env:
+          TF_CLI_CONFIG_FILE: ${{ runner.temp }}/e2e.tfrc
+          TF_VAR_run_id: ${{ env.RUN_ID }}
+          TF_VAR_edge_node_ssh_pub_key: ""
+        run: tofu destroy -auto-approve -input=false
+
+      # Belt and braces. zedamigo_edge_node.Delete treats a failed QMP quit as
+      # a warning and removes the state directory anyway, so an orphaned QEMU
+      # process with its files deleted is an expected outcome, not an exotic
+      # one. A cancelled job can also skip the destroy above entirely.
+      - name: Sweep orphans
+        if: always()
+        run: |
+          pkill -f "zedamigo/edge_nodes/" || true
+          pkill -f "terraform-provider-zedamigo -socket-tailer" || true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -233,6 +233,29 @@ jobs:
           TF_ACC_TERRAFORM_PATH="$(command -v tofu)"
           export TF_ACC_TERRAFORM_PATH
           echo "acceptance driver will use: $TF_ACC_TERRAFORM_PATH"
+
+          # ...and tell the SDK to address the reattached provider under
+          # OpenTofu's registry hostname.
+          #
+          # None of the fixtures declare required_providers, so the SDK
+          # registers the in-process provider under the LEGACY implied
+          # address -- helper/resource/plugin.go hardcodes
+          # host = "registry.terraform.io" and namespaces "-" and
+          # "hashicorp". OpenTofu accepts the legacy "-" namespace only
+          # under its own hostname, so the test died before running a single
+          # step with:
+          #
+          #   Invalid provider namespace: The legacy provider namespace "-"
+          #   can be used only with hostname registry.opentofu.org
+          #
+          # TF_ACC_PROVIDER_HOST overrides just the hostname and leaves the
+          # namespace pair alone, which is what we want -- setting
+          # TF_ACC_PROVIDER_NAMESPACE instead would REPLACE both "-" and
+          # "hashicorp" with a single value and break the implied address.
+          # Supported by the vendored SDK v2.24.1; confirmed in
+          # vendor/.../helper/resource/environment_variables.go.
+          export TF_ACC_PROVIDER_HOST="registry.opentofu.org"
+
           go test -v -timeout 40m -run TestApplicationInstance_RealNode .
 
       # Console logs are the only place EVE's silent failures show up (TLS

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -103,19 +103,19 @@ jobs:
       # this unit's PATH -- `docker` was missing for exactly that reason,
       # since it is a dockerCompat symlink in the system profile.
       #
-      # `make` and `terraform` were absent from this list for the same reason
-      # they were absent from the runner: nobody checked. Both are needed.
-      # `terraform` in particular is NOT interchangeable with `tofu` here:
-      # the plugin-SDK acceptance driver looks for TF_ACC_TERRAFORM_PATH,
-      # then a binary literally named `terraform`, and failing both downloads
-      # an unpinned Terraform from releases.hashicorp.com. OpenTofu is never
-      # a candidate, so `tofu` alone leaves the test step silently pulling a
-      # random version over the network.
+      # `make` was absent from this list for the same reason it was absent
+      # from the runner: nobody checked.
+      #
+      # `terraform` is deliberately NOT checked for, and must not be added.
+      # The acceptance step needs a Terraform CLI, but nixpkgs' terraform is
+      # BUSL-licensed and the lab flake does not allow unfree packages, so
+      # installing it is a policy change rather than a fix. TF_ACC_TERRAFORM_PATH
+      # points the test driver at OpenTofu instead -- see that step.
       - name: Verify host toolchain
         run: |
           set -euo pipefail
           missing=()
-          for t in go make tofu terraform qemu-system-x86_64 qemu-img docker \
+          for t in go make tofu qemu-system-x86_64 qemu-img docker \
                    ip flock jq curl unzip; do
             command -v "$t" >/dev/null || missing+=("$t")
           done
@@ -176,6 +176,21 @@ jobs:
             echo "device_name=$(tofu output -raw device_name)"
           } >> "$GITHUB_OUTPUT"
 
+      # WHY TF_ACC_TERRAFORM_PATH IS SET HERE
+      #
+      # The plugin-SDK test driver needs a Terraform CLI, and finds one by
+      # checking TF_ACC_TERRAFORM_PATH, then hc-install's search for a binary
+      # literally named `terraform`, then -- failing both -- DOWNLOADING the
+      # latest Terraform from releases.hashicorp.com at test time. OpenTofu is
+      # never discovered on its own, whatever `tofu` is on PATH.
+      #
+      # That default is wrong for us twice over: an unpinned version fetched
+      # over the network on every run, and a binary we cannot install anyway
+      # (nixpkgs' terraform is BUSL-licensed and the lab flake does not allow
+      # unfree packages). So point the driver at OpenTofu explicitly. This is
+      # the documented way to run acceptance tests against tofu, and
+      # `tofu version -json` still reports a `terraform_version` key for
+      # exactly this compatibility.
       - name: Run real-node acceptance tests
         working-directory: v2/resources
         env:
@@ -185,7 +200,12 @@ jobs:
           ZEDCLOUD_ACC_REAL_NODE: "1"
           ZEDCLOUD_TEST_NODE_NAME: ${{ steps.node.outputs.device_name }}
           ZEDCLOUD_TEST_SUFFIX: _${{ env.RUN_ID }}
-        run: go test -v -timeout 40m -run TestApplicationInstance_RealNode .
+        run: |
+          set -euo pipefail
+          TF_ACC_TERRAFORM_PATH="$(command -v tofu)"
+          export TF_ACC_TERRAFORM_PATH
+          echo "acceptance driver will use: $TF_ACC_TERRAFORM_PATH"
+          go test -v -timeout 40m -run TestApplicationInstance_RealNode .
 
       # Console logs are the only place EVE's silent failures show up (TLS
       # trust, console misconfiguration), so collect them regardless of result.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -95,12 +95,35 @@ jobs:
       # hosts/h-m-dl20/github-runners.nix. Fail loudly and early if something
       # is missing, rather than midway through an apply that has already
       # started a VM.
+      # NOTE ON WHAT BELONGS IN THIS LIST
+      #
+      # Every entry here has to be in `extraPackages` in github-runners.nix.
+      # systemd units do not inherit environment.systemPackages, so a tool
+      # that works in an interactive shell on the host is not necessarily on
+      # this unit's PATH -- `docker` was missing for exactly that reason,
+      # since it is a dockerCompat symlink in the system profile.
+      #
+      # `make` and `terraform` were absent from this list for the same reason
+      # they were absent from the runner: nobody checked. Both are needed.
+      # `terraform` in particular is NOT interchangeable with `tofu` here:
+      # the plugin-SDK acceptance driver looks for TF_ACC_TERRAFORM_PATH,
+      # then a binary literally named `terraform`, and failing both downloads
+      # an unpinned Terraform from releases.hashicorp.com. OpenTofu is never
+      # a candidate, so `tofu` alone leaves the test step silently pulling a
+      # random version over the network.
       - name: Verify host toolchain
         run: |
           set -euo pipefail
-          for t in go tofu qemu-system-x86_64 qemu-img docker ip flock jq curl unzip; do
-            command -v "$t" >/dev/null || { echo "missing: $t"; exit 1; }
+          missing=()
+          for t in go make tofu terraform qemu-system-x86_64 qemu-img docker \
+                   ip flock jq curl unzip; do
+            command -v "$t" >/dev/null || missing+=("$t")
           done
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "missing from the runner's PATH: ${missing[*]}"
+            echo "add them to extraPackages in hosts/h-m-dl20/github-runners.nix"
+            exit 1
+          fi
           test -w /dev/kvm || { echo "/dev/kvm not writable"; exit 1; }
           echo "toolchain ok: $(tofu version | head -1), $(go version)"
 
@@ -178,7 +201,10 @@ jobs:
             p="$(tofu output -raw "$o" 2>/dev/null || true)"
             [ -n "$p" ] && [ -f "$p" ] && cp "$p" "${RUNNER_TEMP}/diag/" || true
           done
-          cp apply.log "${RUNNER_TEMP}/diag/" 2>/dev/null || true
+          # No apply.log here on purpose: nothing in this job writes one. It
+          # exists only in the manual recipe in test/e2e/README.md, where a
+          # human redirects a detached `tofu apply`. A `cp` for it would be a
+          # no-op that reads like a collected artefact.
 
       - name: Upload diagnostics
         if: always()
@@ -205,8 +231,14 @@ jobs:
       # a warning and removes the state directory anyway, so an orphaned QEMU
       # process with its files deleted is an expected outcome, not an exotic
       # one. A cancelled job can also skip the destroy above entirely.
+      # One pattern, not two. The socket-tailer is spawned as the provider's
+      # own binary -- argv[0] is the installed path, so the real cmdline reads
+      # `terraform-provider-zedamigo_v0.13.1 -socket-tailer ...`. A pattern of
+      # "terraform-provider-zedamigo -socket-tailer" requires the two to be
+      # adjacent and therefore never matches. It was also redundant: the
+      # tailer's -st.connect/-st.out arguments both carry
+      # <lib_path>/edge_nodes/<id>/ paths, so the pattern below already
+      # catches it, along with QEMU, whose cmdline carries the same dir.
       - name: Sweep orphans
         if: always()
-        run: |
-          pkill -f "zedamigo/edge_nodes/" || true
-          pkill -f "terraform-provider-zedamigo -socket-tailer" || true
+        run: pkill -f "zedamigo/edge_nodes/" || true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -105,17 +105,22 @@ jobs:
       CGO_ENABLED: "0"
 
     steps:
-      # fetch-tags because the Makefile derives the binary name from
-      # `git describe --always --abbrev=0 --tags`. With checkout's default
-      # shallow fetch there are no tags, `describe` falls back to a bare
-      # commit SHA, and the build produces
-      # terraform-provider-zedcloud_<sha> -- which matches neither
-      # Terraform's expected terraform-provider-NAME_vX.Y.Z form nor the
-      # `rm -f ./v2/terraform-provider-zedcloud_v*` cleanup in the same
-      # target, so stale binaries pile up run after run.
+      # fetch-depth: 0 because the Makefile derives the binary name from
+      # `git describe --always --abbrev=0 --tags`, and describe needs the
+      # tagged COMMIT, not just the tag ref.
+      #
+      # fetch-tags: true alone was tried and does not work: with the default
+      # fetch-depth: 1 the tag refs arrive but the history to reach them does
+      # not, so describe still falls back through `--always` to a bare SHA.
+      # Verified in run 34111213613, which produced
+      # terraform-provider-zedcloud_c132819ec9... with fetch-tags already set.
+      #
+      # The name matters for one practical reason: `make build` starts with
+      # `rm -f ./v2/terraform-provider-zedcloud_v*`, which a SHA-named binary
+      # does not match, so every run left another one behind on the runner.
       - uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          fetch-depth: 0
 
       # The runner's PATH comes from services.github-runners.extraPackages in
       # hosts/h-m-dl20/github-runners.nix. Fail loudly and early if something

--- a/docs/design/e2e-implementation-plan.md
+++ b/docs/design/e2e-implementation-plan.md
@@ -204,7 +204,15 @@ not inherit `environment.systemPackages`, so anything the job shells out to must
 |---|---|
 | `docker` | Comes from `virtualisation.podman.dockerCompat`, which writes the symlink into the *system* profile. Needs an explicit shim in `runnerTools`, e.g. `(pkgs.writeShellScriptBin "docker" ''exec ${pkgs.podman}/bin/podman "$@"'')` |
 | `make` | Absent from `runnerTools` **and** `environment.systemPackages` — no fallback at all. `make build` fails with a bare `command not found` |
-| `terraform` | `runnerTools` provides `opentofu`. The plugin-SDK test driver looks for `TF_ACC_TERRAFORM_PATH`, then a binary named `terraform`, then downloads an unpinned Terraform from `releases.hashicorp.com`. OpenTofu is never a candidate — the `tofu` check in the toolchain guard does not cover the acceptance step |
+| a Terraform CLI | The plugin-SDK test driver checks `TF_ACC_TERRAFORM_PATH`, then searches for a binary named `terraform`, then **downloads an unpinned Terraform from `releases.hashicorp.com`**. OpenTofu is never discovered on its own, so the `tofu` entry in the toolchain guard did not cover the acceptance step at all |
+
+The third one does **not** get fixed by installing `terraform`. nixpkgs' `terraform` is
+BUSL-licensed and this flake does not allow unfree packages, so adding it would be a policy
+change smuggled in as a CI fix. `e2e.yml` sets `TF_ACC_TERRAFORM_PATH` to the `tofu` on the
+runner's PATH instead — the documented route, and `tofu version -json` still reports a
+`terraform_version` key for exactly this compatibility. The toolchain guard deliberately
+does not check for `terraform`, and a comment there says so, because the obvious "fix"
+is the wrong one.
 
 Rootless podman is still the *predicted* failure point beyond these — the EVE installer
 runs `docker run` as a system user with no login session — but the guard fires before

--- a/docs/design/e2e-implementation-plan.md
+++ b/docs/design/e2e-implementation-plan.md
@@ -1,0 +1,186 @@
+# E2E testing on virtual EVE nodes — final implementation plan
+
+Epic: [UE-131](https://zededa.atlassian.net/browse/UE-131) — Terraform test pipeline on virtual EVE nodes
+Status: **design settled, partially implemented.** This is the plan of record.
+
+Supersedes the runner and transport decisions in
+[`e2e-virtual-eve-node-testing.md`](./e2e-virtual-eve-node-testing.md); that document
+remains the detailed design and validation log. Rejected network transports are recorded
+in [`tailscale-trial-runbook.md`](./tailscale-trial-runbook.md).
+
+---
+
+## 1. What we are building
+
+Give `terraform-provider-zedcloud` end-to-end test coverage against a **real, onboarded
+EVE-OS edge node**, running as a QEMU VM on the Berlin lab host `h-m-dl20`, onboarded
+into the alpha cluster, exercised on every pull request.
+
+The gap today: all 41 acceptance tests fabricate a `zedcloud_edgenode` against a
+synthetic brand/model with an invented serial. Nothing ever checks in, so an application
+instance is "created" without ever running, and the drift/diff bugs that dominate recent
+commit history (CI-723, CI-790, CI-865, CI-875) are exactly the class a real device would
+catch earlier.
+
+## 2. Architecture
+
+```
+  h-m-dl20 (Berlin lab, NixOS, 16 cores / 62 GB)
+  ├── github-runner  (self-hosted, ephemeral, repo-scoped)
+  │     └── job: tofu apply  ->  zedamigo (target = localhost)
+  │                              ├── EVE installer  (podman, lfedge/eve)
+  │                              ├── install VM     (QEMU, synchronous)
+  │                              └── runtime VM     (QEMU, detached)
+  │           go test          ->  acceptance suite, in-process provider
+  └── /var/lib/zedamigo/reservations   (cooperative CPU/RAM claims)
+
+  EVE VM  ──HTTPS──>  zedcloud.alpha.zededa.net      (device API, onboarding)
+  runner  ──HTTPS──>  zedcontrol.alpha.zededa.net    (control API, tests)
+```
+
+Both cluster endpoints are public. **There is no private network hop**, which is what
+makes this design simple: the runner is already inside the lab.
+
+### Decisions and why
+
+| Decision | Rationale |
+|---|---|
+| **Self-hosted runner on `h-m-dl20`** | Removes the network-path problem entirely. Also gives "one job at a time, in arrival order" for free — GitHub dispatches serially per runner label. The accounts, group, sudo rules and age-encrypted tokens already existed in the lab repo; only the services were missing |
+| Rejected: hosted runner + tunnel/mesh | Evaluated Headscale on EC2 (built and validated, ~$22/mo + ops), Tailscale SaaS (~$12/mo, needs a tailnet), Cloudflare Tunnel ($0, already used internally). All solved a problem that disappears if the runner moves |
+| `zedamigo` with `target = "localhost"` | Local executor — no SSH, no SFTP over the network, no `--build-host`. Faster and fewer moving parts |
+| Cooperative capacity reservation | `zedamigo_host_reservation` against the shared tree, so CI cannot oversubscribe the host against a human's manual run |
+| `zedamigo_wait_until` for readiness | Provider-native barrier; replaces the custom polling helper the earlier design proposed |
+| Pinned EVE tag (`16.0.1-lts-kvm-amd64`) | A moving tag makes CI non-reproducible; a stale one tests nothing. Pin, with a scheduled bump |
+| Per-run `run_id` suffix on every object | Alpha is shared (~233 devices, ~334 projects). Without this, concurrent or leftover runs collide on unique-name constraints |
+
+## 3. Measured facts
+
+Not estimates — observed during iterations 1 and 2.
+
+| | |
+|---|---|
+| EVE installer (image cached) | 12s |
+| Install VM (synchronous) | 1m34s |
+| Boot → `RUN_STATE_ONLINE` | 1m21s (5 polls) |
+| **Node lifecycle total** | **~3m10s** |
+| Real-node app-instance test | 58s, including teardown |
+| Host capacity | 16 cores, 62 GB RAM, 399 GB free, nested virt on |
+
+The earlier 30–60 minute estimate was wrong by an order of magnitude — it came from a
+macOS/arm64 emulated run. A per-PR trigger is comfortably viable and the "warm node pool"
+idea is unnecessary.
+
+## 4. The security constraint
+
+`zededa/terraform-provider-zedcloud` is **PUBLIC**. A self-hosted runner on a public repo
+lets any fork PR execute code on a host inside the lab network.
+
+This is *strictly worse* than the hosted-runner design, for a reason worth stating
+plainly: GitHub withholds repository secrets from fork `pull_request` workflows, so a
+hosted runner hands a fork nothing useful. Here the attacker's code is already on the
+target and needs no secret.
+
+Mandatory, not optional:
+
+1. `if: github.event.pull_request.head.repo.full_name == github.repository`
+2. Runner registered **per repository**, never org-wide
+3. `ephemeral = true` — fresh registration per job
+4. GitHub → Settings → Actions → require approval for all outside collaborators
+
+With these the trust boundary is "who has push access" — roughly the same set who could
+read secrets anyway.
+
+## 5. Work already done
+
+| Item | Where |
+|---|---|
+| Node lifecycle Terraform config | `test/e2e/` (validated, node reached ONLINE) |
+| Real-node test helpers | `v2/testing/realnode.go` |
+| Real-node app-instance fixture + test | `v2/resources/testdata/application_instance/create_real_node.tf`, `application_instance_real_node_test.go` (passing) |
+| Runner NixOS config | `zededa-berlin-lab/hosts/h-m-dl20/github-runners.nix` (validated by full `nix eval`) |
+| E2E workflow | `.github/workflows/e2e.yml` (YAML validated; never executed) |
+| Reservation `.lock` permission fix | in `github-runners.nix` via tmpfiles |
+
+Removed as superseded: `hosts/hs-aws-euc1/` (Headscale on EC2) and
+`test/e2e/headscale-trial/`.
+
+## 6. Work remaining — the ticket breakdown
+
+Ordered by dependency. Each is independently reviewable and leaves the tree working.
+
+| Ticket | Summary | Depends on |
+|---|---|---|
+| [UE-135](https://zededa.atlassian.net/browse/UE-135) | T1 Runner token as a PAT | — |
+| [UE-136](https://zededa.atlassian.net/browse/UE-136) | T2 Deploy the runner to h-m-dl20 | UE-135 |
+| [UE-137](https://zededa.atlassian.net/browse/UE-137) | T3 Harden Actions settings (public repo) | with UE-136 |
+| [UE-138](https://zededa.atlassian.net/browse/UE-138) | T4 First green e2e run | UE-136, UE-137 |
+| [UE-139](https://zededa.atlassian.net/browse/UE-139) | T5 `__SUFFIX__` across 45 fixtures | — (parallel) |
+| [UE-140](https://zededa.atlassian.net/browse/UE-140) | T6 Un-skip `CreateCompose` | UE-138 |
+| [UE-141](https://zededa.atlassian.net/browse/UE-141) | T7 Enable `pull_request` trigger | UE-138, UE-139 |
+| [UE-142](https://zededa.atlassian.net/browse/UE-142) | T8 Nightly janitor | UE-138 |
+| [UE-143](https://zededa.atlassian.net/browse/UE-143) | T9 Fix `zedcloud_edgenode` data source (bug) | — (independent) |
+| [UE-144](https://zededa.atlassian.net/browse/UE-144) | T10 Rotate committed credentials | — (do soon) |
+
+Critical path: UE-135 → UE-136/137 → UE-138 → UE-141.
+
+### T1 — Provision the runner token as a PAT
+Confirm what `secrets/gh-run-tf-zedcloud.age` holds. `ephemeral = true` re-registers after
+every job, and **registration tokens expire after one hour**, so a registration token
+would break the second job of the day and leave the service restart-looping. Needs a
+fine-grained PAT scoped to the repo with `Administration: read and write`.
+*Blocks everything else.*
+
+### T2 — Deploy the runner to `h-m-dl20`
+`nixos-rebuild switch` with `github-runners.nix`. Confirm the runner appears in the repo's
+runner list with labels `self-hosted, berlin-lab, kvm, eve`. Requires the current flake
+from andrei — the local clone is behind, and rebuilding from a stale checkout would revert
+his work.
+
+### T3 — Harden the repo's Actions settings
+Require approval for outside collaborators; confirm the runner is repo-scoped. Pairs with
+the workflow's fork gate.
+
+### T4 — First green e2e run
+Trigger via `workflow_dispatch`, iterate on what the sandboxed unit actually permits.
+Rootless podman is the most likely failure point: the EVE installer runs `docker run` as a
+system user with no login session.
+
+### T5 — `__SUFFIX__` rollout across existing fixtures
+Add token expansion to the 45 `testdata/*.tf` files so every created object is per-run
+unique. Provably a no-op at `__SUFFIX__=""`, so it lands safely before any semantic
+change. Prerequisite for running the wider suite per-PR.
+
+### T6 — Un-skip `TestApplicationInstance_CreateCompose`
+Its skip comment says "until we decide how to provide a real device for testing" — that
+decision is now made. Re-gate from `CI` to `ZEDCLOUD_ACC_REAL_NODE`.
+
+### T7 — Enable the PR trigger
+Flip `e2e.yml` from `workflow_dispatch`-only to `pull_request`. Keep the check
+**non-required** in branch protection until it has been stable for several weeks.
+
+### T8 — Nightly janitor
+Sweep `lib_path` dirs and orphaned QEMU processes older than a few hours, and delete
+`tf_e2e_%` / `test_tf%` cloud objects older than a day. `zedamigo_edge_node.Delete` treats
+a failed QMP quit as a warning and removes state anyway, so orphans are an expected
+outcome, not an exotic one.
+
+### T9 — Fix the `zedcloud_edgenode` data source (independent)
+`NodeDataSource()` returns `Schema: zschema.Node()` — the *resource* schema — so it
+inherits every write-side `Required` field and a name-only lookup fails with
+`The argument "model_id" is required`. Data sources need a read-only schema variant. Found
+while building T-earlier work; not blocking, but a real defect.
+
+### T10 — Rotate committed credentials (independent, do soon)
+Branch `add-tf-agent-skill` contains plaintext alpha and local-cluster passwords plus
+Postgres credentials for both databases. Local-only in this clone; confirm it was never
+pushed, then rotate regardless.
+
+## 7. Open questions
+
+1. Which EVE tag should CI track — the supported LTS, or newest? Pinned to `16.0.1` now.
+2. Does alpha's owner accept per-PR churn (projects, models, brands, networks, images,
+   devices created and deleted on every run)?
+3. Should `h-m-dl20` also host the runner for `terraform-provider-zedamigo`? Account,
+   token and a disabled service already exist.
+4. The long-lived EVE node from iteration 1 is still running (2 QEMU processes, ~8 GB and
+   a CPU reservation). Keep for manual iteration, or destroy now that CI creates its own?

--- a/docs/design/e2e-implementation-plan.md
+++ b/docs/design/e2e-implementation-plan.md
@@ -5,8 +5,9 @@ Status: **design settled, partially implemented.** This is the plan of record.
 
 Supersedes the runner and transport decisions in
 [`e2e-virtual-eve-node-testing.md`](./e2e-virtual-eve-node-testing.md); that document
-remains the detailed design and validation log. Rejected network transports are recorded
-in [`tailscale-trial-runbook.md`](./tailscale-trial-runbook.md).
+remains the detailed design and validation log. The rejected network transports are
+summarised in the decisions table in §2 below — the Headscale and Tailscale trial
+runbooks were never committed.
 
 ---
 
@@ -80,15 +81,49 @@ plainly: GitHub withholds repository secrets from fork `pull_request` workflows,
 hosted runner hands a fork nothing useful. Here the attacker's code is already on the
 target and needs no secret.
 
-Mandatory, not optional:
+Mandatory, not optional — and **listed in order of what actually does the work**, which is
+not the order you would guess:
 
-1. `if: github.event.pull_request.head.repo.full_name == github.repository`
-2. Runner registered **per repository**, never org-wide
-3. `ephemeral = true` — fresh registration per job
-4. GitHub → Settings → Actions → require approval for all outside collaborators
+1. **Approval for all external contributors.** GitHub → Settings → Actions → General →
+   "Approval for running fork pull request workflows from contributors" → *Require
+   approval for all external contributors*. This is the boundary: nothing from outside the
+   `zededa` org runs until someone with write access clicks approve.
+   Set on 2026-09-04; verify with
+   `gh api repos/zededa/terraform-provider-zedcloud/actions/permissions/fork-pr-contributor-approval`,
+   which must read `all_external_contributors`. The GitHub **default** is
+   `first_time_contributors`, which exempts anyone who has ever had a commit merged — not
+   sufficient here.
+2. Runner registered **per repository**, never org-wide, so no other repo can target it.
+3. `ephemeral = true` — fresh registration per job, so one job cannot poison the next.
+4. `if: github.event.pull_request.head.repo.full_name == github.repository` in `e2e.yml`.
 
-With these the trust boundary is "who has push access" — roughly the same set who could
-read secrets anyway.
+### Why the workflow `if:` gate is #4 and not #1
+
+An earlier version of this section led with the `if:` gate and described the approval
+requirement as an additional measure. That was backwards, and worth recording so the
+mistake is not repeated.
+
+For `pull_request` events GitHub runs the workflow **from the pull request's merge commit,
+not from the base branch** — which is exactly why you can edit CI inside a PR and see the
+change take effect in that same PR. A fork therefore ships its *own* copy of
+`.github/workflows/e2e.yml` and can simply delete the `if:` line. It does not even need to
+touch `e2e.yml`: adding `runs-on: [self-hosted, berlin-lab]` to `go.yml`, which has no
+gate, reaches the same runner.
+
+GitHub says this plainly: "forks of your public repository can potentially run dangerous
+code on your self-hosted runner machine by creating a pull request that executes the code
+in a workflow", and "potentially malicious user-controlled workflow code will execute
+automatically if the user is allowed to bypass approval in the set approval policy."
+
+So the gate is a guardrail, not a boundary. It keeps honest fork PRs from queueing against
+a runner they cannot use, which is worth having for noise — but it stops nobody who does
+not want to be stopped. Keep it; do not rely on it.
+
+With control 1 in place the trust boundary is "who has push access" — roughly the same set
+who could read repository secrets anyway. That is the argument for accepting the residual
+risk. Without control 1, controls 2–4 do not establish any boundary at all.
+
+Ref: [Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use).
 
 ## 5. Work already done
 
@@ -97,53 +132,83 @@ read secrets anyway.
 | Node lifecycle Terraform config | `test/e2e/` (validated, node reached ONLINE) |
 | Real-node test helpers | `v2/testing/realnode.go` |
 | Real-node app-instance fixture + test | `v2/resources/testdata/application_instance/create_real_node.tf`, `application_instance_real_node_test.go` (passing) |
-| Runner NixOS config | `zededa-berlin-lab/hosts/h-m-dl20/github-runners.nix` (validated by full `nix eval`) |
-| E2E workflow | `.github/workflows/e2e.yml` (YAML validated; never executed) |
+| Runner NixOS config | `zededa-berlin-lab/hosts/h-m-dl20/github-runners.nix` (deployed; runner online) |
+| E2E workflow | `.github/workflows/e2e.yml` (dispatched on PR #228; fails at the toolchain guard — see T4) |
 | Reservation `.lock` permission fix | in `github-runners.nix` via tmpfiles |
+| Runner credential as a GitHub App | `githubApp` in `github-runners.nix` + `gh-run-tf-zedcloud-app-key.age` |
+| Actions settings hardened | `all_external_contributors`; `GITHUB_TOKEN` default read-only |
 
 Removed as superseded: `hosts/hs-aws-euc1/` (Headscale on EC2) and
-`test/e2e/headscale-trial/`.
+`test/e2e/headscale-trial/`. Neither was ever pushed, so the removal is not visible in
+either repo's history.
 
 ## 6. Work remaining — the ticket breakdown
 
 Ordered by dependency. Each is independently reviewable and leaves the tree working.
 
-| Ticket | Summary | Depends on |
-|---|---|---|
-| [UE-135](https://zededa.atlassian.net/browse/UE-135) | T1 Runner token as a PAT | — |
-| [UE-136](https://zededa.atlassian.net/browse/UE-136) | T2 Deploy the runner to h-m-dl20 | UE-135 |
-| [UE-137](https://zededa.atlassian.net/browse/UE-137) | T3 Harden Actions settings (public repo) | with UE-136 |
-| [UE-138](https://zededa.atlassian.net/browse/UE-138) | T4 First green e2e run | UE-136, UE-137 |
-| [UE-139](https://zededa.atlassian.net/browse/UE-139) | T5 `__SUFFIX__` across 45 fixtures | — (parallel) |
-| [UE-140](https://zededa.atlassian.net/browse/UE-140) | T6 Un-skip `CreateCompose` | UE-138 |
-| [UE-141](https://zededa.atlassian.net/browse/UE-141) | T7 Enable `pull_request` trigger | UE-138, UE-139 |
-| [UE-142](https://zededa.atlassian.net/browse/UE-142) | T8 Nightly janitor | UE-138 |
-| [UE-143](https://zededa.atlassian.net/browse/UE-143) | T9 Fix `zedcloud_edgenode` data source (bug) | — (independent) |
-| [UE-144](https://zededa.atlassian.net/browse/UE-144) | T10 Rotate committed credentials | — (do soon) |
+| Ticket | Summary | Depends on | Status |
+|---|---|---|---|
+| [UE-135](https://zededa.atlassian.net/browse/UE-135) | T1 Runner credential (shipped as a GitHub App, **not** a PAT) | — | Done |
+| [UE-136](https://zededa.atlassian.net/browse/UE-136) | T2 Deploy the runner to h-m-dl20 | UE-135 | Done |
+| [UE-137](https://zededa.atlassian.net/browse/UE-137) | T3 Harden Actions settings (public repo) | with UE-136 | Controls set; fork test outstanding |
+| [UE-138](https://zededa.atlassian.net/browse/UE-138) | T4 First green e2e run | UE-136, UE-137 | In progress — 3 tools missing on the runner |
+| [UE-139](https://zededa.atlassian.net/browse/UE-139) | T5 `__SUFFIX__` across 45 fixtures | — (parallel) | |
+| [UE-140](https://zededa.atlassian.net/browse/UE-140) | T6 Un-skip `CreateCompose` | UE-138 | |
+| [UE-141](https://zededa.atlassian.net/browse/UE-141) | T7 Promote e2e to a required check | UE-138, UE-139 | |
+| [UE-142](https://zededa.atlassian.net/browse/UE-142) | T8 Nightly janitor | UE-138 | |
+| [UE-143](https://zededa.atlassian.net/browse/UE-143) | T9 Fix `zedcloud_edgenode` data source (bug) | — (independent) | |
+| [UE-144](https://zededa.atlassian.net/browse/UE-144) | T10 Rotate committed credentials | — (do soon) | |
 
 Critical path: UE-135 → UE-136/137 → UE-138 → UE-141.
 
-### T1 — Provision the runner token as a PAT
-Confirm what `secrets/gh-run-tf-zedcloud.age` holds. `ephemeral = true` re-registers after
-every job, and **registration tokens expire after one hour**, so a registration token
-would break the second job of the day and leave the service restart-looping. Needs a
-fine-grained PAT scoped to the repo with `Administration: read and write`.
-*Blocks everything else.*
+### T1 — Provision the runner credential *(done — as a GitHub App, not a PAT)*
+This ticket was planned as a fine-grained PAT and **shipped as a GitHub App instead**. The
+reasoning is in `github-runners.nix` under "WHY NOT A PAT", and is worth repeating because
+the PAT plan looks adequate until you count the years: with `ephemeral = true` the runner
+re-registers after every job, so the credential has to still be valid months from now. A
+registration token lasts one hour and a fine-grained PAT at most 366 days — both eventually
+leave the service in a restart loop, failing in a way that reads like a runner bug rather
+than an expired credential. A PAT merely moves that cliff a year out, onto a date nobody
+will remember. An App private key does not expire, so the failure mode is designed out.
+It is also not tied to a person: a PAT acts as its creator in the audit log and dies when
+they are offboarded.
 
-### T2 — Deploy the runner to `h-m-dl20`
-`nixos-rebuild switch` with `github-runners.nix`. Confirm the runner appears in the repo's
-runner list with labels `self-hosted, berlin-lab, kvm, eve`. Requires the current flake
-from andrei — the local clone is behind, and rebuilding from a stale checkout would revert
-his work.
+App id 4807245 (`zededa-berlin-lab-runner`), key in
+`secrets/gh-run-tf-zedcloud-app-key.age`. `secrets/gh-run-tf-zedcloud.age` (the old PAT
+path) is no longer read by the runner. Requires a nixpkgs newer than the 2026-08-10
+revision the flake was pinned to — `services.github-runners.<name>.githubApp` exists in
+neither 25.11 nor 26.05.
 
-### T3 — Harden the repo's Actions settings
-Require approval for outside collaborators; confirm the runner is repo-scoped. Pairs with
-the workflow's fork gate.
+### T2 — Deploy the runner to `h-m-dl20` *(done)*
+`nixos-rebuild switch` with `github-runners.nix`. Registered as `h-m-dl20-tf-zedcloud`
+with labels `self-hosted, Linux, X64, berlin-lab, kvm, eve`; confirmed online and picking
+up jobs.
+
+### T3 — Harden the repo's Actions settings *(controls set; one test outstanding)*
+Done: `all_external_contributors`, repo-scoped registration confirmed,
+`default_workflow_permissions: read`, `can_approve_pull_request_reviews: false`.
+
+Outstanding: the fork test, and it must be run as the *hostile* case to mean anything —
+from a throwaway fork, delete the `if:` gate **and** point `go.yml` at
+`runs-on: [self-hosted, berlin-lab]`, then confirm the run sits in "waiting for approval"
+and nothing dispatches. An unmodified fork passes this test even with the approval policy
+wide open, so testing that way proves nothing. See §4.
 
 ### T4 — First green e2e run
-Trigger via `workflow_dispatch`, iterate on what the sandboxed unit actually permits.
-Rootless podman is the most likely failure point: the EVE installer runs `docker run` as a
-system user with no login session.
+First dispatch (PR #228) reached the runner and stopped at `Verify host toolchain` with
+`missing: docker`. Three tools are missing, all the same root cause — **systemd units do
+not inherit `environment.systemPackages`, so anything the job shells out to must be in
+`extraPackages`**:
+
+| Tool | Why it is missing |
+|---|---|
+| `docker` | Comes from `virtualisation.podman.dockerCompat`, which writes the symlink into the *system* profile. Needs an explicit shim in `runnerTools`, e.g. `(pkgs.writeShellScriptBin "docker" ''exec ${pkgs.podman}/bin/podman "$@"'')` |
+| `make` | Absent from `runnerTools` **and** `environment.systemPackages` — no fallback at all. `make build` fails with a bare `command not found` |
+| `terraform` | `runnerTools` provides `opentofu`. The plugin-SDK test driver looks for `TF_ACC_TERRAFORM_PATH`, then a binary named `terraform`, then downloads an unpinned Terraform from `releases.hashicorp.com`. OpenTofu is never a candidate — the `tofu` check in the toolchain guard does not cover the acceptance step |
+
+Rootless podman is still the *predicted* failure point beyond these — the EVE installer
+runs `docker run` as a system user with no login session — but the guard fires before
+reaching it, so that remains untested.
 
 ### T5 — `__SUFFIX__` rollout across existing fixtures
 Add token expansion to the 45 `testdata/*.tf` files so every created object is per-run
@@ -154,15 +219,30 @@ change. Prerequisite for running the wider suite per-PR.
 Its skip comment says "until we decide how to provide a real device for testing" — that
 decision is now made. Re-gate from `CI` to `ZEDCLOUD_ACC_REAL_NODE`.
 
-### T7 — Enable the PR trigger
-Flip `e2e.yml` from `workflow_dispatch`-only to `pull_request`. Keep the check
-**non-required** in branch protection until it has been stable for several weeks.
+### T7 — Promote e2e to a required check
+The `pull_request` trigger this ticket originally described is **already live** — it landed
+with the workflow itself, ahead of the first green run. What remains is the other half:
+the job currently carries `continue-on-error: true`, so it reports success whatever
+happens. Remove that once the job has been stable for several weeks, and only then add it
+to branch protection as a required check.
+
+Note that `main` presently requires **no** status checks at all — not `go.yml`, not
+`test.yml`. Making e2e the first required check is a larger change in habit than it looks,
+and probably wants the hosted checks required first.
 
 ### T8 — Nightly janitor
 Sweep `lib_path` dirs and orphaned QEMU processes older than a few hours, and delete
 `tf_e2e_%` / `test_tf%` cloud objects older than a day. `zedamigo_edge_node.Delete` treats
 a failed QMP quit as a warning and removes state anyway, so orphans are an expected
 outcome, not an exotic one.
+
+This is also the backstop for a leak the workflow cannot close on its own. The acceptance
+test's six alpha objects (project, datastore, image, network instance, application, app
+instance) are destroyed by the SDK *in process*, at the end of `resource.Test`. A
+`go test -timeout 40m` expiry, the job's own `timeout-minutes: 60`, or a cancellation all
+kill that process before destroy runs, and the workflow's `Destroy` step only tears down
+`test/e2e/`, not the test's objects. So `test_tf_real_*` leftovers are an expected outcome
+on any abnormal exit, and the janitor must match that prefix as well as `tf_e2e_%`.
 
 ### T9 — Fix the `zedcloud_edgenode` data source (independent)
 `NodeDataSource()` returns `Schema: zschema.Node()` — the *resource* schema — so it

--- a/docs/design/e2e-virtual-eve-node-testing.md
+++ b/docs/design/e2e-virtual-eve-node-testing.md
@@ -1,0 +1,1200 @@
+# E2E acceptance testing against virtual EVE nodes in CI
+
+Status: draft plan — **iteration 1 implemented and validated 2026-08-19** (see §0)
+Ticket: TBD
+Repos: `zededa/terraform-provider-zedcloud`, `andrei-zededa/terraform-provider-zedamigo`, `andrei-zededa/zededa-berlin-lab`
+
+---
+
+## 0. Validation log — what iteration 1 proved, and what it corrected
+
+A virtual EVE node was created on `h-m-dl20` and onboarded to alpha end-to-end. The
+config lives in [`test/e2e/`](../../test/e2e/); see its README for the exact procedure.
+Result: `ADMIN_STATE_REGISTERED` / `RUN_STATE_ONLINE`, `install_success = true`.
+
+Six assumptions in this document turned out to be wrong. They are corrected in place
+below; collected here so reviewers of the earlier draft can see the delta.
+
+| § | Assumption in the draft | Reality |
+|---|---|---|
+| 3.3 | `zedcontrold.alpha.zededa.net` might be the device endpoint | **It does not resolve.** The pair is `zedcontrol.alpha` (control) and `zedcloud.alpha` (device), both Cloudflare-fronted with a Google Trust Services cert — so **no `tls_ca` and no `additional_hosts` needed** |
+| 5.4 | zedamigo has no wait-for-online primitive; build a Go `waitonline` helper | **`zedamigo_wait_until` exists** (v0.13.0+). Runs the probe on the target, so it works unchanged for local and remote targets. The custom helper is unnecessary |
+| 7.2 | Serialization needs a bespoke `lab-lock.sh` ticket lock | **`zedamigo_host_reservation` exists** (v0.13.0+) and the capacity tree is already deployed on `h-m-dl20` (16 CPU slots, 58 GB slots, LVM devices), flock-atomic and cross-config. It is admission control, not a queue — so it complements rather than replaces the FIFO design, but the custom lock should be built *on top of* it, not instead of it |
+| 4.2 | Nested virtualization needs enabling | **Already enabled** (`kvm_intel nested=Y`). The host has drifted ahead of the `zededa-berlin-lab` checkout (host rev `21a8f219`, clone `48adfea`) |
+| 4.5 | Host capacity unknown | **16 cores, 62 GB RAM, 399 GB free on `/`.** `/dev/kvm` is `0666`, so no group membership needed |
+| 10.3 | 30–60 min per run, ~1 PR/hour | **~3m10s** total (installer 12s cached, install VM 1m34s, boot→ONLINE 1m21s). Roughly an order of magnitude cheaper than assumed. Per-PR is comfortably viable and the warm-node pool (§3.4B) is probably unnecessary |
+
+Also settled: **the onboarding certificate is a non-issue on alpha.** The 403
+`register` → "device not found" blocker documented against the local cluster
+(§10.2) did not occur; the default key `5d0767ee-…` is authorized. This was the
+highest-risk item in the plan (task 0.2) and it is now closed.
+
+Two new findings:
+
+- **The reservation lock is single-user.** `/var/lib/zedamigo/reservations/.lock` is
+  mode `0644` owned by `andrei` inside a group-writable directory, and the provider
+  opens it for writing — so cooperative reservation works for exactly one user and
+  everyone else gets `Permission denied`. Needs `0664`/`g+w`, declared in the lab's
+  `configuration.nix` so it survives a `nixos-rebuild`. Until then `test/e2e/` uses a
+  per-user tree with no cross-user coordination.
+- **Two GitHub Actions service accounts already exist** on the host —
+  `gh-run-tf-zedamigo` and `gh-run-tf-zedcloud`, both `nologin` with `/var/empty`
+  homes, in the `zedamigo_reservations` group. No runner service is registered yet.
+  Whatever CI identity this design lands on should use `gh-run-tf-zedcloud` rather
+  than inventing another.
+
+What iteration 1 did **not** cover: the SSH remote-target topology (OpenTofu ran on
+the lab host, `target = localhost`) and the network path from a GitHub-hosted runner
+(§3.2 is still entirely open).
+
+### Iteration 3 — runner decision reversed: self-hosted on the lab host
+
+**This supersedes the runner choice in §3.1 and most of §3.2 and §7.2.** The original
+decision was a GitHub-hosted runner reaching the lab over SSH, which made the network
+path the central problem. Three transports were evaluated for it — a self-hosted
+Headscale on EC2 (built, validated, ~$22/mo), Tailscale SaaS (~$12/mo, needs a
+tailnet), and Cloudflare Tunnel ($0, already used internally) — before the simpler
+question surfaced: put the runner *on* the lab host and there is no network path to
+solve at all.
+
+Decisive evidence that this was always the intent: `hosts/h-m-dl20/configuration.nix`
+already contains `gh-run-tf-zedcloud` and `gh-run-tf-zedamigo` service accounts in a
+`gh-runners` group, with restricted passwordless sudo for exactly `ip`/`kill`/`taskset`
+(zedamigo's set), membership in `zedamigo_reservations`, and committed
+age-encrypted tokens (`d39af16 feat: Add secrets for Github Runners`). Only the
+services were missing. Confirmed no runner was registered (`runners=0`).
+
+What this removes:
+
+| Was needed | Now |
+|---|---|
+| A network path from GitHub's egress (§3.2) | Gone — the runner is already inside |
+| `hosts/hs-aws-euc1/` (EC2, EIP, EBS, Route53, nginx, ACME) | Unnecessary |
+| The FIFO ticket lock, `lab-lock.sh` (§7.2) | Unnecessary — GitHub dispatches jobs to a runner label serially, in arrival order |
+| SSH, SFTP, `known_hosts`, `--build-host` | Gone — `target = "localhost"`, local executor |
+| ~$22/month | $0 |
+
+Implemented: `hosts/h-m-dl20/github-runners.nix` in `zededa-berlin-lab` (validated by
+a full `nix eval` of the system closure, not just a parse) and
+`.github/workflows/e2e.yml` here.
+
+**The one new risk, and it is serious.** This repository is **public**
+(`gh repo view` → `PUBLIC`). A self-hosted runner on a public repo lets any fork PR
+execute code on the lab host. That is *strictly worse* than the hosted-runner design,
+for a reason worth stating plainly: GitHub withholds repository secrets from fork
+`pull_request` workflows, so a hosted runner would hand a fork no credentials and it
+could reach nothing — whereas here the attacker's code is already on the target and
+needs no secret at all.
+
+The mitigation is in the workflow and is not optional:
+
+```yaml
+if: github.event.pull_request.head.repo.full_name == github.repository
+```
+
+plus repo-scoped (not org-scoped) registration, `ephemeral = true`, and GitHub's
+"require approval for all outside collaborators". With those, the trust boundary is
+"who has push access" — roughly the same set who could read secrets anyway.
+
+Also fixed here: the reservation `.lock` permission bug from §0 is now declarative
+(`systemd.tmpfiles` declares it `0664 root:zedamigo_reservations`), so `test/e2e/`
+uses the shared capacity tree again rather than a per-user workaround.
+
+Still open: §6's `__SUFFIX__` rollout across the 45 existing fixtures, and whether
+`h-m-dl20` should host the runner for `terraform-provider-zedamigo` too (the account
+and token exist; the service is declared but disabled).
+
+### Iteration 2 — first real-node acceptance test (2026-08-19)
+
+`TestApplicationInstance_RealNode` deploys an nginx container onto the live node and
+waits until the device reports it running. **Passes in 58s**, including teardown:
+
+```
+real node "tf_e2e_en_it1" resolved to 723397fb-... (RUN_STATE_ONLINE)
+attempt 1: swState=SW_STATE_UNSPECIFIED runState=RUN_STATE_UNKNOWN
+attempt 2: swState=SW_STATE_UNSPECIFIED runState=RUN_STATE_UNKNOWN
+attempt 3: swState=SW_STATE_RUNNING     runState=RUN_STATE_ONLINE
+--- PASS: TestApplicationInstance_RealNode (58.47s)
+```
+
+New code: `v2/testing/realnode.go` (env contract, name→UUID resolution, placeholder
+expansion, `WaitForAppInstanceSwState`), the fixture
+`v2/resources/testdata/application_instance/create_real_node.tf`, and the test
+`v2/resources/application_instance_real_node_test.go`. Teardown verified clean —
+zero `test_tf_real*` leftovers across instances, apps, projects, images, datastores
+and network instances.
+
+This validates the §6.3 capability-gating design: `ZEDCLOUD_ACC_REAL_NODE` plus
+`ZEDCLOUD_TEST_NODE_NAME`/`ZEDCLOUD_TEST_SUFFIX`, skipping when unset so the default
+suite is untouched. It also means §6.5's 90-minute timeout is generous: a real-node
+test costs ~1 minute, not tens.
+
+Two further corrections:
+
+| § | Assumption | Reality |
+|---|---|---|
+| 6.1 | Inject the node via `__NODE_ID__` **or** the `zedcloud_edgenode` data source | The **data source cannot be used at all** — see below. Node identity is injected as `__NODE_ID__`, resolved from a *name* by the helper so callers still pass a name |
+| 5.4 | The wait helper should live in `v2/testing/cmd/waitonline` for the workflow | Unnecessary — `zedamigo_wait_until` covers the workflow side and `WaitForAppInstanceSwState` covers the test side. No standalone command needed |
+
+**New defect found: `zedcloud_edgenode` data source is unusable.** `NodeDataSource()`
+(`v2/resources/node.go:33`) returns `Schema: zschema.Node()` — the *resource* schema —
+so the data source inherits every write-side `Required` field. A name-only lookup
+fails with `The argument "model_id" is required`, plus `project_id`, `title` and
+"At least 1 interfaces blocks are required". Data sources need a read-only schema
+variant. Worth a small standalone PR; it is not blocking, since the helper resolves
+names against the API.
+
+Five fixture-level API constraints, all discovered empirically and now recorded in
+comments in the fixture (none are documented anywhere):
+
+1. Container image `name` must be a plain identifier — `/` and `:` are rejected with
+   "Name field contains invalid characters". The pull reference goes in
+   **`image_rel_url`** (`"library/nginx:stable-alpine"`), and downstream references
+   (`images.imagename`, `drives.imagename`) use the image *name*.
+2. `vminfo.memory` is Computed-only; setting it fails with "Value for unconfigurable
+   attribute". Memory comes from the manifest's `resources` block.
+3. App-instance `interfaces` requires `privateip` alongside `intfname`/`netinstname`.
+4. An application's `project_access_list` must match its images' scope, else
+   "app project list cannot be set to all projects if all of it's images do not set
+   their project list to all projects".
+5. `datastore_id_list` on an application is compose-only — "datastore refs are only
+   supported for docker compose type app".
+
+Remaining from §6: the `__SUFFIX__` rollout across the existing 45 fixtures, and
+un-skipping `TestApplicationInstance_CreateCompose`. The scaffolding they need now
+exists.
+
+---
+
+## 1. Goal
+
+Replace the current PR test job — which runs acceptance tests against a controller with
+**no real devices** — with one that:
+
+1. Creates one or more **virtual EVE-OS edge nodes** as QEMU/KVM VMs on the Berlin lab host
+   `h-m-dl20`.
+2. Onboards them into the **alpha** Zedcloud cluster.
+3. Runs the **full** `v2/resources` acceptance suite against those real, online devices.
+4. Tears everything down, on every pull request.
+
+Decisions already taken (see §11 for the ones still open):
+
+| Decision | Choice |
+|---|---|
+| Runner | **GitHub-hosted** (`ubuntu-latest`); the zedamigo provider drives `h-m-dl20` over SSH |
+| Trigger | **Every pull request** |
+| Scope | **Full real-node acceptance suite**, not just a smoke test |
+| Capacity | **One run at a time** on the lab host; queued runs served **first-come-first-served** (§7.2) |
+| Lifecycle | Virtual EVE nodes are **destroyed after every run**, including on cancellation (§8) |
+
+---
+
+## 2. Summary of findings
+
+### 2.1 What already exists — more than expected
+
+**The zedamigo provider already supports exactly the topology we chose.** Commits
+`810ff20` ("Support running against a remote host over SSH") and `5372a17` ("Add SSH jump host
+(ProxyJump) support") added an `exec.Executor` abstraction with an `SSHExecutor` implementation.
+The provider plugin process runs on the runner; every command, file operation, process kill and
+socket dial happens on the target over SSH + SFTP. All paths in the config are *target* paths.
+Configuration is `provider "zedamigo" { target = "..." ssh { ... } }`, and every SSH
+attribute has an environment fallback — 11 of the 12 as `ZEDAMIGO_SSH_*`, plus
+`ZEDAMIGO_REMOTE_BINARY_PATH` for `remote_binary_path` — purpose-built for CI secrets
+(`internal/provider/ssh_config.go`).
+
+**The lab host is already provisioned for a CI identity.** `zededa-berlin-lab`
+`hosts/h-m-dl20/configuration.nix` defines a `github-runner` user that is deliberately *not* in
+`wheel`, is in the `kvm` group, has `autoSubUidGidRange` for rootless podman, and has exactly
+three passwordless sudo commands:
+
+```nix
+{ command = "/run/current-system/sw/bin/ip";      options = [ "NOPASSWD" ]; }
+{ command = "/run/current-system/sw/bin/kill";    options = [ "NOPASSWD" ]; }
+{ command = "/run/current-system/sw/bin/taskset"; options = [ "NOPASSWD" ]; }
+```
+
+That list is not arbitrary — it covers most of what zedamigo invokes under sudo: `ip`
+(`netns_resource.go`, `tap_resource.go`, and bridge/vlan/lag via
+`netns_helpers.go:buildIPCommand`), `kill` (`internal/exec/ssh.go:648-653`) and `taskset` (the
+`cpu_pins` path, which uses plain `sudo`, not `sudo -n` —
+`internal/hypervisor/qemu_cpupin_linux.go:110-112`). Someone clearly worked out a
+least-privilege set for this use case.
+
+It is **not complete**, though: zedamigo also self-invokes its own binary under `sudo -n` for
+the embedded daemons — `tap_resource.go:578-580` (tap-mover),
+`dhcp_server_resource.go:520-523`, `dhcp6_server_resource.go:459-461`,
+`radv_resource.go:503-505`. Those are only reached if we use the host-networking resources
+(§6.4), so phase 1 is unaffected, but phase 2 needs a fourth sudoers entry for the
+bootstrapped binary path. The `github-runner` SSH key is still the placeholder
+`ssh-ed25519 AAAA...REPLACE_ME`.
+
+**There is a proven, debugged reference config.** `andrei-zededa/local-en/` is a complete
+two-provider (zedamigo + zedcloud) stack that builds an EVE installer, installs it, boots the
+VM and onboards it — with `CLAUDE.md` and `RUNBOOK.md` documenting every failure mode hit along
+the way. It targets macOS/vfkit against a *local* cluster, so it is not directly reusable, but
+its findings are (private TLS CA, `additional_hosts`, the `depends_on` ordering, the onboarding
+cert blocker, teardown recipe). This is the single most valuable input to this work.
+
+**Alpha access already exists.** Branch `add-tf-agent-skill` in this repo carries
+`.agents/skills/terraform/scripts/set_api_token.sh`, which logs into
+`zedcontrol.alpha.zededa.net` as `ivan-icd-test@zededa.com` (enterprise
+`AAFlABBtJ0mP_lhJjIyVzjzgMXiR`) and mints a 90-day API token, and
+`clean_tf_objects_on_alpha.sh`, which sweeps `test_tf%`-named leftovers straight out of the
+alpha Postgres. Both are useful; both are also a problem — see §10.1.
+
+**The Berlin lab is not on the public internet.** `h-m-dl20` is `10.208.13.94`. The documented
+access path is the Berlin office L2TP/IPsec VPN, wrapped in
+`zededa-berlin-lab/berlin-vpn-in-a-container/` (strongswan + xl2tpd + pppd + squid + an sshd on
+port 11022 used as a jump host). Every documented remote command in the lab README goes through
+`ProxyJump=root@localhost:11022` (the one exception is the "rebuild on the host itself"
+alternative, which assumes you are already inside the lab network). **This is the load-bearing
+unknown for a GitHub-hosted runner** — see §3.2.
+
+### 2.2 Not related, despite the name
+
+The `tf-actions` and `tf-actions-hackaton` branches in this repo are about **Terraform provider
+Actions** (`provider.ProviderWithActions`, `v2/actions/node/RebootAction.go`), i.e. the
+plugin-framework feature, not GitHub Actions. They also migrate `v2/main.go` from SDKv2 to
+plugin-framework. Unrelated to this work, but the name collision will confuse people in
+review — worth saying so out loud in the PR description.
+
+### 2.3 The four hard constraints
+
+Everything below follows from these.
+
+**(a) The acceptance suite has no concept of a real device.** There are 41 acceptance test
+functions in `v2/resources/*_test.go`; 19 of the 45 fixtures create their own
+`zedcloud_edgenode` against a synthetic
+`zedcloud_brand` + `zedcloud_model` (`origin_type = "ORIGIN_LOCAL"`), with invented serials
+(`"def-netinst"`, `"2293dbe8-29ce-420c-8264-962857efc46b"`) and `onboarding_key = ""`. There
+is **zero** run-state awareness: grepping `v2/resources/` for `RunState`, `WaitForState`,
+`StateChangeConf` or `PollInterval` returns nothing. Nothing waits for a device to check in;
+nothing asserts an app instance actually runs.
+
+Consequence: pointing this suite at a real node changes *nothing* unless the fixtures are
+rewritten to reference that node. "Full real-node suite" is mostly a **test-suite refactor**,
+not a CI plumbing job. Budget accordingly.
+
+**(b) Fixtures are static HCL with hardcoded, colliding names.** `v2/resources/testdata/*.tf`
+are read verbatim by `testhelper.MustGetTestInput` and handed to `TestStep.Config` — no
+templating, no `variable` blocks, no `fmt.Sprintf`, no env reads. `name =
+"test_tf_provider-create_edgenode"` appears **34 times**; `serialno =
+"2293dbe8-29ce-420c-8264-962857efc46b"` is shared by `application_instance/create.tf` and
+`patch_reference_update/create.tf`. There is no `t.Parallel()` anywhere, so the suite is saved
+today only by Go's sequential default.
+
+Consequence: two concurrent runs against the same enterprise **will** collide on unique-name
+constraints. On a per-PR trigger this is not hypothetical.
+
+**(c) Six tests are gated on `CI`, one of them for exactly our reason.**
+`application_instance_test.go:65-71`:
+
+```go
+// TestApplicationInstance_CreateCompose is a test case for creating an ApplicationInstance using a Docker Compose file.
+// It's skipped until we decide how to provide a real device for testing.
+
+func TestApplicationInstance_CreateCompose(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("Skipping docker compose test for CI environment")
+	}
+```
+
+Also skipped on `CI`: `TestProfileDeployment_Create` (an acknowledged flake —
+*"failing in CI but passing locally"*) and four `TestEnterprise_*` tests
+(`TestEnterprise_Create`, `_WhiteLabeling`, `_WhiteLabelingControllerHostURL`,
+`_WhiteLabelingLegacyAttributes`) whose reason is **undocumented** — the skip message says only
+*"Skipping enterprise test for CI environment"*; a permissions gap on child-enterprise creation
+is the likely cause but needs confirming. The current workflow sets `CI: true`, so all six are
+dead today. `CI` is the wrong axis — it conflates "runs in automation" with "has a real device"
+and with "has elevated permissions".
+
+**(d) Timings do not fit a 20-minute budget.** `make test` uses `-timeout 20m` for the whole
+package. Add EVE install (a synchronous, *unbounded* QEMU run inside
+`zedamigo_installed_edge_node`), boot, onboarding and a wait-for-online poll, and the realistic
+end-to-end is 30-60 minutes. `local-en/RUNBOOK.md` records ~5-10 min just for
+installer-build → install VM → runtime VM, before onboarding.
+
+---
+
+## 3. Proposed architecture
+
+### 3.1 Topology
+
+```
+GitHub-hosted runner (ubuntu-latest, ephemeral)
+├── go build ./v2                      -> terraform-provider-zedcloud (under test)
+├── terraform / tofu                   -> runs the e2e config
+│    ├── provider "zedcloud"  ──────── HTTPS ───────▶ zedcontrol.alpha.zededa.net  (control API)
+│    └── provider "zedamigo"  ── SSH (see §3.2) ───▶ github-runner@10.208.13.94
+│                                                     └── QEMU/KVM: EVE-OS VM
+│                                                          │ SLIRP NAT, host uplink
+│                                                          └── HTTPS ▶ <device API>.alpha.zededa.net
+└── go test ./v2/resources/...         -> acceptance suite, real node injected via env
+```
+
+Key property: **the provider binary under test runs on the runner**, so the tests exercise the
+build from the PR. The zedamigo provider also runs on the runner and only reaches into the lab
+over SSH. Nothing needs to be installed on `h-m-dl20` per run except the zedamigo helper binary
+(auto-bootstrapped, §4.3).
+
+### 3.2 The network path — decide this first
+
+A GitHub-hosted runner cannot reach `10.208.13.94`. Three options, in order of preference:
+
+**Option 1 (recommended): Tailscale subnet router on `h-m-dl20`.**
+Add `services.tailscale` to `configuration.nix` and advertise `10.208.13.0/24` (or just
+`10.208.13.94/32`). In the workflow, `tailscale/github-action@v3` with an ephemeral, tagged
+auth key or OIDC. Userspace WireGuard, no kernel modules, no privileged container, no VPN
+credentials in secrets, works on every hosted runner, and gives a stable name
+(`h-m-dl20.<tailnet>.ts.net`) so `known_hosts` pinning is trivial. Cost: a new dependency and
+an ACL/tag policy to agree with IT.
+
+**Option 2: run `berlin-vpn-in-a-container` on the runner.** It already exists and is
+documented. But it needs `--privileged`, `--cap-add SYS_MODULE` and a `/lib/modules` bind mount
+to bring up IPsec/L2TP — on Azure-backed hosted runners that is unreliable at best, and the
+credentials (`ZEDEDA_VPN_PSK`/`USER`/`PASS`) become repo secrets used on every PR. Treat as a
+fallback and **spike it before committing** (a 15-line throwaway workflow answers the question).
+
+**Option 3: publish a narrow SSH ingress.** A Cloudflare Tunnel / `cloudflared` or an
+autossh reverse tunnel from `h-m-dl20` to a small public jump host, restricted to the
+`github-runner` key. More moving parts than Option 1 with fewer benefits.
+
+If none of the three clears review, the self-hosted-runner topology (register the runner *as*
+`github-runner` on `h-m-dl20`) sidesteps the problem entirely and should be reconsidered — it
+is also what the existing `github-runner` user and its sudo rules look designed for.
+
+Whichever is chosen, the zedamigo provider config stays the same; only how the runner resolves
+and routes to the host changes:
+
+```hcl
+provider "zedamigo" {
+  target   = var.lab_host              # ZEDAMIGO_TARGET
+  use_sudo = true                      # needed once we add eth1 (§6.4); harmless before that
+  lib_path = "/home/github-runner/.local/state/zedamigo-gh-${var.run_id}"
+
+  ssh {
+    user             = "github-runner"
+    private_key      = var.lab_ssh_key   # ZEDAMIGO_SSH_PRIVATE_KEY, from secrets
+    known_hosts_file = "./known_hosts"   # written in a workflow step; do NOT use insecure mode
+    # proxy_jump = var.lab_jump_host     # only if Option 2/3
+  }
+}
+```
+
+Note: a hosted runner has no `~/.ssh/known_hosts`, and `ssh_config.go:300` **fails closed** if
+neither `known_hosts_file`, `host_key` nor `insecure_ignore_host_key` is set. Write the host key
+into the workspace from a repo variable (not a secret — host public keys are not secret) and
+point `known_hosts_file` at it.
+
+### 3.3 Endpoint naming — resolve before writing HCL
+
+Zedcloud exposes **two different hostnames** and mixing them up is the classic failure:
+
+| Purpose | Consumer | Value on alpha |
+|---|---|---|
+| Control / REST API | `provider "zedcloud" { zedcloud_url }`, `TF_VAR_zedcloud_url` | `zedcontrol.alpha.zededa.net` (confirmed by `set_api_token.sh`) |
+| Device API (`/config/server` inside EVE) | `zedamigo_eve_installer.cluster` | **TBD — see below** |
+
+The request names `zedcontrold.alpha.zededa.net`. That is neither of the two names seen in the
+codebase: the control API is `zedcontrol.alpha...` and the device-facing convention in
+`local-en` is `zedcloud.<env>.zededa.net`. `zedcontrold` (with a `d`, plausibly "device") may
+well be the correct alpha device endpoint, but it is unverified. **Confirm with the cluster
+owners before writing the config, and keep the two as separate Terraform variables** — the
+top-level zedamigo `README.md:85-88` and `examples/other/1_node_3_vlans/README.md` contradict
+each other on this exact point, and `local-en/CLAUDE.md:46` resolves it in favour of two
+distinct values.
+
+### 3.4 Warm pool vs. create-per-PR
+
+"Every PR" plus "one shared lab host" plus "30-60 min per run" is a queueing problem. Two
+shapes:
+
+**(A) Create and destroy per PR.** Simplest, fully hermetic, no state to persist beyond the
+job. But every PR pays the full install+onboard cost, and concurrent PRs serialize behind
+`concurrency:`. On a busy day PR feedback is hours.
+
+**(B) Warm node + lease (recommended for per-PR).** A scheduled workflow keeps a small number of
+onboarded nodes alive on `h-m-dl20`, re-created nightly. A PR job *leases* one, runs the suite
+against it inside a per-run project, and releases it. Node lifecycle cost disappears from the PR
+critical path; PR runtime drops to roughly the suite runtime.
+
+Because the lab is a single-slot resource (§7.2), the pool is **N=1** — and that is the point:
+one node alive continuously costs the same RAM as one active run, but every PR after the first
+skips the installer build, install VM and onboarding wait entirely. The saving is most of the
+critical path, not a marginal one. The trade-off is that state accumulated by a previous PR's
+suite can leak into the next one, so per-run isolation (§5.3) has to be genuinely airtight
+before this is safe — which is another reason to build (A) first.
+
+The test-suite work in §6 is identical either way — the node identity arrives via environment
+variables regardless of who created it. **Build (A) first** because it is the only way to prove
+the node lifecycle works; add (B) once green. Do not design (A) in a way that blocks (B): keep
+"create the node" and "run the suite" in separate jobs with the node's identity passed as job
+outputs.
+
+---
+
+## 4. Host preparation — changes to `zededa-berlin-lab`
+
+All in `hosts/h-m-dl20/configuration.nix` unless noted. These are the concrete gaps between
+what the host provides today and what zedamigo requires.
+
+### 4.1 Replace the placeholder SSH key
+
+```nix
+github-runner = [ "ssh-ed25519 AAAA<real CI key> github-runner" ];
+```
+
+Generate a dedicated ed25519 keypair for this purpose only. Private key → repo secret
+`LAB_SSH_PRIVATE_KEY`; host's public key → repo variable `LAB_SSH_HOST_KEY`.
+
+### 4.2 Enable nested virtualization
+
+`hardware-configuration.nix` loads `kvm-intel`, but nesting is not enabled. Without it, EVE can
+boot and onboard, but **cannot run app instances** — which kills
+`TestApplicationInstance_*`, the most valuable real-node tests.
+
+```nix
+boot.extraModprobeConfig = "options kvm_intel nested=1";
+```
+
+Verify after rebuild: `cat /sys/module/kvm_intel/parameters/nested` → `Y`.
+
+### 4.3 Tool inventory
+
+zedamigo's `Configure()` hard-fails if any of these is missing from `PATH`, and warns for the
+rest:
+
+| Tool | Required? | Present on `h-m-dl20`? |
+|---|---|---|
+| `bash` | fatal (`Configure`, `provider.go:280`) | yes |
+| `qemu-system-x86_64`, `qemu-img` | fatal | yes (`qemu`) |
+| `ip` | fatal | yes (`iproute2`) |
+| `docker` | fatal | yes — via `virtualisation.podman.dockerCompat`, which symlinks `docker` → `podman` |
+| `sudo` | fatal when `use_sudo = true` | yes |
+| `curl`, `grep`, `sed`, `mktemp`, `unzip`, `tar` | needed by `install.sh:22` (not checked by `Configure`) | yes |
+| `taskset` | warn | yes (via the NixOS base system, not an explicit `systemPackages` entry) |
+| `swtpm` | warn | **no** — fine, we do not use `zedamigo_swtpm` (it is WIP anyway) |
+| `genisoimage` | warn | **no** — fine, we do not use `zedamigo_cloud_init_iso` |
+| OVMF firmware | not needed | embedded in the provider binary, extracted over SFTP to `<lib_path>/embedded_ovmf/` on the target — note this lives inside the per-run `lib_path` that §5.3/§8 propose wiping, so it is re-extracted each run |
+
+Rootless podman is fine for what we need: `zedamigo_eve_installer` runs
+`docker run --network none --rm -v <dir>/config:/in -v <dir>/out:/out docker.io/lfedge/eve:<tag> ...`
+(fully qualified — `eve_installer_resource.go:294` — which matters on podman, since it does not
+default to Docker Hub),
+which works rootless. No `docker` group is needed and no podman socket has to be enabled —
+zedamigo shells out to the CLI, not the API socket.
+
+### 4.4 Pre-pull the EVE image
+
+The `lfedge/eve:<tag>` pull is multi-GB and dominates `zedamigo_eve_installer` on a cold cache.
+Add a small systemd timer (or a step in the nightly pool workflow) that keeps the pinned tag
+warm for the `github-runner` user, and **pin the tag in a variable** so it is not silently
+re-pulled per run.
+
+### 4.5 Disk and capacity
+
+qcow2 images live under `~/.local/state/zedamigo/...` on `/` (the NVMe root). The LVM
+`reserve*` LVs on `vg_sdb`/`vg_sdc`/`vg_sdd` are unformatted and only usable as raw block
+devices via `disk { type = "device" }` — not what we want. Confirm NVMe free space: each node
+needs a 20 GB sparse overlay plus the installer artefacts; a warm pool of 3 plus a PR run is
+comfortable but not free.
+
+The install VM is hard-coded to `-m 4096 -smp 4,cores=2` and the runtime VM defaults to
+`4G`/4 vCPU, so budget ~4-8 GB and 4 vCPU per node. **The host's actual core count and RAM are
+not recorded in the repo** — measure it (§11), but note that the single-slot constraint (§7.2)
+means only ever one run's worth of VMs is live, so the sizing question is "can it host one node
+comfortably", not "how many in parallel". Since the install and runtime VMs briefly overlap
+during `apply`, size for two.
+
+### 4.6 Monitoring is already there
+
+`monitoring.nix` runs VictoriaMetrics + VictoriaLogs + node_exporter + a `process_exporter`
+whose match rules group by the QEMU `-name` argument. That gives per-VM CPU/RSS from
+`process_exporter`, and per-VM disk IO from node_exporter's `diskstats` on each VM's
+device-mapper node — for free. Worth wiring a dashboard link into the workflow summary; CI
+flakes on this host will mostly be resource flakes, and this is how they get diagnosed. Note the
+stack is loopback-only, so reaching it needs the same SSH tunnel as everything else.
+
+---
+
+## 5. The e2e Terraform config
+
+New directory in **this** repo: `test/e2e/` (a sibling of the existing `test/retry/`), so the
+config is versioned with the provider it tests.
+
+```
+test/e2e/
+├── terraform.tf        # required_providers + both provider blocks
+├── vars.tf             # lab_host, ssh key, cluster URLs, eve_tag, run_id, node_count
+├── cluster_objects.tf  # zedcloud_brand / model / project / network / edgenode
+├── node.tf             # zedamigo disk_image / eve_installer / installed_edge_node / edge_node
+├── outputs.tf          # serials, device UUIDs, project id, model id, ssh_port
+└── README.md
+```
+
+Base it on `terraform-provider-zedamigo/examples/other/1_node_1_container` (which has **no**
+`host_networking.tf` — SLIRP only, no root needed) and layer on the `local-en` corrections.
+
+### 5.1 Serial number flow
+
+On Linux/QEMU, choose the serial yourself and let it flow *down*: the cloud object is the source
+of truth, QEMU stamps it via `-smbios type=1,serial=<serial_no>`, EVE reads it as the hardware
+serial.
+
+```hcl
+resource "zedcloud_edgenode" "EN" {
+  name           = "tf_e2e_en_${var.run_id}"
+  title          = "tf_e2e_en_${var.run_id}"   # Required, alongside name/model_id/project_id
+  serialno       = "TF-E2E-${var.run_id}"
+  onboarding_key = var.onboarding_key      # 5d0767ee-0547-4569-b530-387e526f8cb9
+  model_id       = zedcloud_model.QEMU_VM.id
+  project_id     = zedcloud_project.PROJECT.id
+  admin_state    = "ADMIN_STATE_ACTIVE"
+
+  interfaces {
+    intfname   = "eth0"
+    intf_usage = "ADAPTER_USAGE_MANAGEMENT"
+    netname    = zedcloud_network.mgmt_dhcp.name
+    ztype      = "IO_TYPE_ETH"
+  }
+}
+
+resource "zedamigo_installed_edge_node" "INSTALL" {
+  serial_no       = zedcloud_edgenode.EN.serialno          # cloud object -> VM
+  installer_iso   = zedamigo_eve_installer.eve.filename
+  disk_image_base = zedamigo_disk_image.empty.filename
+}
+
+resource "zedamigo_edge_node" "VM" {
+  serial_no       = zedamigo_installed_edge_node.INSTALL.serial_no
+  disk_image_base = zedamigo_installed_edge_node.INSTALL.disk_image
+  ovmf_vars_src   = zedamigo_installed_edge_node.INSTALL.ovmf_vars
+  depends_on      = [zedcloud_edgenode.EN]   # cloud record must exist before EVE starts registering
+}
+```
+
+Do **not** use the macOS "soft-serial flip" (`serialno = ...INSTALL.soft_serial`). `local-en`
+documents it as a macOS/vfkit-specific workaround; the apparent reason is that
+Virtualization.framework offers no SMBIOS serial to stamp, but that rationale is our inference,
+not something the source states.
+
+### 5.2 Things to carry over from `local-en`
+
+- `grub_cfg` **must match** `serial_type`: `console=hvc0` for the default `virtio`,
+  `console=ttyS0` for `serial`. A mismatch produces an empty console log, so
+  `installed_edge_node.success` never flips true and `soft_serial` is never extracted — and the
+  failure is silent.
+- `tls_ca` — if alpha does not serve a publicly-trusted certificate, EVE's pre-onboarding
+  connectivity check fails **silently**. Check first:
+  `openssl s_client -connect <device-endpoint>:443 -servername <device-endpoint>`. If it is the
+  private Zededa chain, commit the intermediate CA under `test/e2e/cluster_certs/` and wire it
+  as `tls_ca`. Alpha is a shared long-lived cluster so this may well be a real cert — verify,
+  don't assume.
+- `additional_hosts` — not needed if alpha resolves publicly. Omit unless proven necessary.
+- `depends_on` on the VM, as above.
+- Avoid `cpu_pins` unless there is a reason to want it: there was a VM-start race between the
+  socket-tailer and `taskset` (fixed in `f7342b7`), it needs the `taskset` sudoers entry, and it
+  pins us to specific host cores, which conflicts with running a pool.
+
+### 5.3 Per-run isolation
+
+Thread `var.run_id = "gh${{ github.run_id }}"` through **every** name: cloud objects, VM names,
+`lib_path`. Two payoffs: concurrent runs cannot collide, and orphan cleanup becomes
+`rm -rf ~/.local/state/zedamigo-gh-*` filtered by age (§8).
+
+If `zedamigo_local_datastore` is ever used, override `listen` per run — the default `:8080` is a
+guaranteed conflict.
+
+### 5.4 Wait for ONLINE
+
+`installed_edge_node.success` only means the *installer* finished; `zedamigo_edge_node` returns
+as soon as QEMU is detached, and all of EVE's boot → `register` → `uuid` → `certs` → `config`
+handshake happens after `apply` returns. So a barrier is required, or the apply "succeeds"
+against a node that never onboarded.
+
+**Use `zedamigo_wait_until`** (v0.13.0+). It runs an idempotent single-shot probe on the
+provider `target` on an `interval` until it exits 0 or `timeout` expires, and fails the apply
+otherwise. Crucially the probe runs *on the target*, so the same config works whether the target
+is localhost or remote — which a `local-exec` provisioner could not do. Per-attempt logs land in
+`<lib_path>/wait_until/<id>/attempts/NNNN/` on the target and are deliberately retained on
+failure.
+
+The working probe (validated: 5 attempts, 1m21s to ONLINE) polls
+`GET /api/v1/devices/id/{id}/status` for `runState == RUN_STATE_ONLINE`; the progression is
+`RUN_STATE_UNPROVISIONED` → `RUN_STATE_PROVISIONED` → `RUN_STATE_ONLINE`. See
+`test/e2e/node.tf`. Do not put a retry loop inside the script — `interval`/`timeout` own the
+retrying.
+
+Regardless, always publish `zedamigo_edge_node.serial_console_log` and the install console log as
+artifacts: EVE fails silently on TLS trust and console misconfiguration, and those logs are the
+only place it shows up.
+
+One caveat for CI: the probe needs the API token, and the script is written to
+`<lib_path>/wait_until/<id>/wait_until.sh` on the target. Either accept that (the lab host is
+already trusted with the token) or have the probe read the token from a file placed out of band.
+
+---
+
+## 6. Test-suite changes — `v2/resources`
+
+This is the bulk of the work. Design goal: **the same suite runs in both modes** —
+API-only (today's behaviour, no device) and real-node — selected by environment, with the
+smallest possible diff to the 18 directories of fixtures.
+
+### 6.1 Placeholder expansion in `MustGetTestInput`
+
+`v2/testing/testhelper.go` currently returns fixture bytes verbatim. Add a token-expansion pass:
+
+```go
+// MustGetTestInput reads ./testdata/<path> and expands __TOKEN__ placeholders
+// from the test environment. Unknown tokens are a hard failure so a fixture can
+// never silently apply with a literal placeholder.
+func MustGetTestInput(t *testing.T, path string) string { ... }
+```
+
+Tokens (deliberately **not** `${...}`, which would break `terraform fmt`/`validate` on the
+fixtures):
+
+| Token | API-only mode | Real-node mode |
+|---|---|---|
+| `__SUFFIX__` | `""` | `_gh<run_id>` |
+| `__NODE_SERIALNO__` | today's literal | the real node's serial |
+| `__NODE_NAME__` | `test_tf_provider` | the real node's name |
+| `__MODEL_ID__` / `__PROJECT_ID__` | created by the fixture | the e2e config's IDs |
+
+`__SUFFIX__` alone fixes constraint (b): appending it to all 34 duplicated names makes every run
+namespaced, which is a prerequisite for a per-PR trigger regardless of real nodes.
+
+### 6.2 Fixture rewrite
+
+Mechanical, but touches 45 `.tf` files (11 of which carry the duplicated `create_edgenode`
+name, and 19 of which declare a `zedcloud_edgenode` at all). Sequence that keeps it reviewable:
+
+1. **Commit 1 — `__SUFFIX__` only.** Add the expansion helper; `sed` every `name =`/`title =`
+   in `testdata/**/*.tf` to append `__SUFFIX__`. With `__SUFFIX__=""` the suite behaves exactly
+   as today, so this is provably a no-op refactor. Golden `.yaml` comparisons ignore names? They
+   do not — check `testXAttributes` ignore lists and extend where a name is compared.
+2. **Commit 2 — node identity tokens.** Replace hardcoded `serialno` with `__NODE_SERIALNO__`
+   and, in the fixtures that create a node purely as a dependency, switch to referencing the
+   pre-existing node via `__NODE_NAME__`/ID injection.
+3. **Commit 3 — per-resource real-node variants** where the API-only and real-node shapes
+   genuinely differ (e.g. `network_instance` `port = "eth1"`, §6.4).
+
+### 6.3 Replace `CI` gating with capability gating
+
+Split the one overloaded `CI` axis into three explicit ones:
+
+| Env var | Gates |
+|---|---|
+| `ZEDCLOUD_ACC_REAL_NODE=1` | tests that need an onboarded device — un-skips `TestApplicationInstance_CreateCompose` |
+| `ZEDCLOUD_ACC_ELEVATED=1` | `TestEnterprise_*` (need operator/distributor permissions) |
+| *(unchanged skip)* | `TestProfileDeployment_Create` — this is a **real flake**, not a capability gap. Keep it skipped, but file a ticket; hiding it behind a new flag would launder a known bug. |
+
+Add `testhelper.RealNode(t) RealNodeInfo` returning serial / device UUID / project ID / model ID
+from the environment, `t.Skip`-ing when unset. Add `testhelper.WaitForRunState(t, deviceID,
+"ONLINE", timeout)` — the same poll helper §5.4 needs, so the workflow and the tests share one
+implementation.
+
+### 6.4 The `eth1` problem
+
+Every `network_instance` fixture sets `port = "eth1"`, and the test models declare only `eth0`
+in `io_member_list`. The controller accepts this today because nothing checks realizability. A
+real single-NIC SLIRP node **cannot** realize it.
+
+Two paths:
+
+- **Phase 1: leave it API-only.** Keep the network-instance tests on a synthetic node. Honest,
+  and unblocks everything else.
+- **Phase 2: give the VM a second NIC.** `zedamigo_bridge` + `zedamigo_tap` +
+  `zedamigo_dhcp_server`, attached via `extra_qemu_args`, exactly as
+  `examples/other/1_node_3_vlans` and `2_edge_nodes_bridged` do. This needs `use_sudo = true`
+  and it is the point at which the `github-runner` sudoers rule becomes insufficient:
+  `zedamigo_dhcp_server` and the `zedamigo_tap` mover daemon self-invoke the provider binary
+  under `sudo -n` (§2.1), so a fourth allow-list entry for the bootstrapped binary path is
+  needed — or use the netns variants, which go through `sudo ip netns exec …`. Names must carry
+  `__SUFFIX__` because interface names are kernel-global.
+
+Do not conflate the two. Phase 1 delivers real onboarding + real app instances; phase 2
+delivers real network instances.
+
+### 6.5 Timeout and ordering
+
+- Raise `-timeout` from `20m` to `90m` for the real-node target; keep `20m` for the API-only
+  target.
+- Add a `make test-e2e` target rather than overloading `make test`, so the existing PR job keeps
+  working unchanged while this is built.
+- Keep the suite sequential. Do **not** add `t.Parallel()` — with one shared device and a
+  ~120-entry ignore-list of API-assigned defaults (45 `cmpopts.IgnoreFields` blocks),
+  parallelism will produce noise, not speed.
+
+---
+
+## 7. The workflow
+
+New file `.github/workflows/e2e.yml`. Leave `test.yml` and `go.yml` alone.
+
+```yaml
+name: E2E (virtual EVE node)
+on: [pull_request]
+
+# PER-BRANCH coalescing only. Do NOT put the lab in a concurrency group (see §7.2).
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true       # a new push to the same PR supersedes its own older run
+
+jobs:
+  # Single-slot FIFO lock on the lab host. Nothing else runs until this returns.
+  lock:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tailscale/github-action@v3
+        with: { oauth-client-id: "${{ secrets.TS_OAUTH_CLIENT_ID }}", oauth-secret: "${{ secrets.TS_OAUTH_SECRET }}", tags: "tag:ci" }
+      - name: Take a ticket and wait for our turn
+        run: scripts/lab-lock.sh acquire "gh${{ github.run_id }}" --timeout 150m
+
+  node:
+    needs: lock
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    outputs:
+      serialno:  ${{ steps.tf.outputs.serialno }}
+      device_id: ${{ steps.tf.outputs.device_id }}
+      project_id: ${{ steps.tf.outputs.project_id }}
+      model_id:  ${{ steps.tf.outputs.model_id }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5            # 1.24+, not the 1.21 the old workflows pin
+      - uses: hashicorp/setup-terraform@v3   # pin it; do not rely on the SDK auto-download
+        with: { terraform_wrapper: false }
+
+      # --- network path (§3.2, Option 1) ---
+      - uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret:    ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
+      - name: Pin lab host key
+        run: printf '%s\n' "${{ vars.LAB_SSH_HOST_KEY }}" > test/e2e/known_hosts
+
+      - name: Build provider under test
+        run: make build                      # -> v2/terraform-provider-zedcloud_<ver>
+
+      - name: Create node
+        id: tf
+        working-directory: test/e2e
+        env:
+          TF_VAR_run_id:      gh${{ github.run_id }}
+          TF_VAR_lab_host:    ${{ vars.LAB_HOST }}
+          TF_VAR_lab_ssh_key: ${{ secrets.LAB_SSH_PRIVATE_KEY }}
+          TF_VAR_zedcloud_url:   ${{ vars.TF_VAR_ZEDCLOUD_URL }}     # zedcontrol.alpha...
+          TF_VAR_eve_cluster_host: ${{ vars.EVE_CLUSTER_HOST }}      # device API, §3.3
+          TF_VAR_zedcloud_token: ${{ secrets.TF_VAR_ZEDCLOUD_TOKEN }}
+        run: |
+          terraform init -input=false
+          terraform apply -auto-approve
+          terraform output -json | tee ../../outputs.json
+      - name: Wait for ONLINE
+        # NB: v2/ is a separate Go module, so this must be `go run -C v2`
+        run: go run -C v2 ./testing/cmd/waitonline -device "${{ steps.tf.outputs.device_id }}" -timeout 15m
+
+  suite:
+    needs: node
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    env:
+      TF_ACC: 1
+      CI: true
+      ZEDCLOUD_ACC_REAL_NODE: 1
+      ZEDCLOUD_TEST_SUFFIX: _gh${{ github.run_id }}
+      ZEDCLOUD_TEST_NODE_SERIALNO: ${{ needs.node.outputs.serialno }}
+      ZEDCLOUD_TEST_NODE_ID:       ${{ needs.node.outputs.device_id }}
+      TF_VAR_zedcloud_url:   ${{ vars.TF_VAR_ZEDCLOUD_URL }}
+      TF_VAR_zedcloud_token: ${{ secrets.TF_VAR_ZEDCLOUD_TOKEN }}
+    steps: [ checkout, setup-go, setup-terraform, "make test-e2e" ]
+
+  teardown:
+    needs: [lock, node, suite]
+    if: always()                             # non-negotiable
+    runs-on: ubuntu-latest
+    steps:
+      - tailscale, checkout, restore state artifact
+      - run: terraform destroy -auto-approve
+      - run: ssh github-runner@$LAB_HOST 'bash -s' < scripts/sweep_zedamigo.sh gh${{ github.run_id }}
+      - if: always()
+        run: scripts/lab-lock.sh release "gh${{ github.run_id }}"   # last thing, always
+      - uses: actions/upload-artifact@v4     # serial console logs + terraform.log, always
+```
+
+Two details that matter more than they look:
+
+- **State must survive between the `node` and `teardown` jobs.** Options: keep everything in one
+  job (simplest, but no parallel `suite`), upload `terraform.tfstate` as an artifact between
+  jobs, or use a real backend. `terraform-provider-zedamigo/misc/tf_state_backend_http` exists
+  but its own README says no locking, no auth, no TLS — **do not use it**. Prefer a proper
+  backend (S3/GCS) or the artifact hand-off plus the belt-and-braces sweep. A lost state file
+  means permanently orphaned VMs on a long-lived host.
+- **The destroy path must not depend on the runner surviving.** `if: always()` does run on
+  cancellation, but only within GitHub's cancellation grace period — a force-killed runner
+  skips teardown entirely. The host-side reaper in §7.2 is what actually guarantees the nodes
+  die.
+
+### 7.2 Serialization: the lab is a single-slot resource
+
+**Requirement:** the Berlin lab can host one run at a time; with several PRs open, they run
+one after another in the order they arrived (first-come-first-served by run).
+
+**GitHub's `concurrency:` cannot express this.** A concurrency group holds at most **one**
+pending run. When a third run arrives while one is running and one is pending, the *pending*
+one is **cancelled** and replaced — even with `cancel-in-progress: false`, which only protects
+the *running* job. So a global `group: lab-h-m-dl20` would give newest-wins, silently starving
+the PR that has been waiting longest. That is the opposite of the requirement, and it is why
+§7's `concurrency` block is scoped to `github.ref` and used only for per-branch coalescing
+(where newest-wins *is* what you want: a new push to the same PR should supersede its own
+in-flight run).
+
+Cross-PR serialization therefore needs an explicit queue.
+
+**Start from `zedamigo_host_reservation`, not from scratch.** zedamigo v0.13.0+ ships
+cooperative capacity reservation, and the tree is already deployed on `h-m-dl20`
+(`/var/lib/zedamigo/reservations`: 16 CPU slots, 58 GB slots, the LVM volumes as devices).
+Claims are atomic via `flock`, durable across reboots until the resource is destroyed, visible
+to *any* config on the host including a human's, and each slot records who holds it. That is
+most of what the bespoke lock below was invented to do, already built and already tested
+(validated in iteration 1: `reserved_cpus = [0,1,2,3]`).
+
+Its one gap: it is **admission control, not a queue** — if capacity is short the apply *fails*
+rather than waiting, which would turn a busy lab into spurious red PRs. So the remaining work is
+a *waiting* layer on top, not a whole lock. The cheapest version is a `zedamigo_wait_until`
+barrier that polls for free capacity before the `host_reservation` resource claims it; that
+reuses two shipped resources and needs no custom scripts. A FIFO ticket queue is only necessary
+if fairness across PRs turns out to matter in practice — measure first (§9 phase 4).
+
+Note also that the lock file's permissions currently make reservation single-user (§0), so this
+depends on that being fixed in the lab's `configuration.nix`.
+
+If a bespoke queue does prove necessary, the shape below is the proposal: a **ticket lock on the
+lab host**, driven over SSH by `scripts/lab-lock.sh` (`acquire` / `release` / `status` / `reap`),
+with state under `/home/gh-run-tf-zedcloud/.local/state/e2e-lab-lock/`:
+
+```
+queue        # append-only ticket list, one "<run_id> <epoch>" per line, mutated under flock
+lease        # "<run_id> <epoch_acquired>" — who currently owns the lab
+hb/<run_id>  # heartbeat file, mtime touched every 30s by waiters AND the holder
+```
+
+- **`acquire <run_id>`** appends a ticket under `flock`, then polls every 15s until (a) no live
+  lease exists and (b) our run is the oldest live ticket. Then it writes `lease` under `flock`
+  and returns. Ordering is by ticket position, so it is FIFO by arrival.
+- **Heartbeats are the liveness signal.** Both waiters and the holder touch `hb/<run_id>` every
+  30s. `reap` (called at the top of every poll iteration, and by the janitor) drops any ticket
+  or lease whose heartbeat is older than 2 minutes. This is what makes the design survive the
+  cases that matter:
+  - a **waiting** run is cancelled → its stale ticket is dropped, the queue advances, no
+    human involvement;
+  - the **holding** run is force-killed before teardown → the lease is broken after 2 minutes
+    *and* the reaper immediately runs `sweep_zedamigo.sh <run_id>`, so the orphaned QEMU
+    processes and `lib_path` go with it.
+- No GitHub credentials are needed on the host — liveness is inferred from heartbeats, not
+  from the Actions API.
+- **Humans can take the lock too.** `lab-lock.sh acquire manual` before an interactive debugging
+  session stops CI from stomping on the host mid-session; `release manual` hands it back. This
+  is a genuine advantage of putting the lock on the host rather than in GitHub: it covers *all*
+  users of the lab, not just Actions.
+
+Alternatives considered:
+
+- **`softprops/turnstyle`** (block until earlier runs of the same workflow finish) gets FIFO
+  by run number with no host-side state, but it only knows about this one workflow, cannot see
+  a human using the lab, and has no way to sweep after a killed holder. Reasonable fallback if
+  the host script proves fiddly; not the primary choice.
+- **A single self-hosted runner** would give all of this for free — GitHub queues jobs for a
+  runner label and dispatches them FIFO, one at a time, with no lock, no polling and no wasted
+  minutes. This was considered and set aside in favour of GitHub-hosted runners (§3.1). Worth
+  revisiting if the lock proves to be a maintenance burden, since the new single-slot constraint
+  is *exactly* what one runner models naturally.
+
+**Cost to be aware of:** a queued run occupies a GitHub-hosted runner while it polls. The `lock`
+job is deliberately a separate, near-empty job so a waiter burns one minimal runner rather than
+holding a fully provisioned one, but the minutes are still billed on a private repo. If queue
+depth becomes a problem, the knobs are: skip draft PRs, run only on `ready_for_review` +
+subsequent pushes, or fall back to a nightly-plus-label trigger. Cap the wait at 150 minutes and
+fail with an explicit "lab busy, re-run when free" message rather than hanging until the job
+timeout.
+
+### 7.3 Provider resolution
+
+Both providers must resolve to local builds, and the repo's existing `dev.tfrc`
+(`dev_overrides` + `direct {}`) actively **breaks zedamigo resolution** — this is recorded in
+`local-en/RUNBOOK.md`. Use a dedicated `test/e2e/e2e.tfrc` with a `filesystem_mirror` pattern
+copied from `local-en/zedamigo.tfrc`, set `TF_CLI_CONFIG_FILE` to it for the e2e config only,
+and leave `dev.tfrc` alone for the in-process acceptance tests. Those tests do not need it for
+provider resolution — `Providers: testAccProviders` makes the SDK reattach the in-process
+provider — but `testhelper.CheckEnv` (`v2/testing/testhelper.go:67-74`) **hard-fails** unless
+`TF_CLI_CONFIG_FILE` is set or a `dev.tfrc` exists in the CWD, so it must stay set to
+*something*.
+
+Also: zedamigo's remote-binary bootstrap **refuses versions `""`, `dev` and `test`**
+(`ssh_config.go:366-368`). So either pin a released zedamigo version and let `install.sh
+--binary-only` bootstrap it (requires outbound HTTPS from `h-m-dl20` to
+`raw.githubusercontent.com` and `github.com`), or pre-place a binary and set
+`ssh.remote_binary_path`. The bootstrap path is preferable — one less thing to keep in sync.
+
+---
+
+## 8. Cleanup and orphan control
+
+Four layers, because any one of them will fail eventually.
+
+1. **`terraform destroy`** in an `if: always()` job. Handles the happy and most unhappy paths.
+2. **A host sweep script** (`scripts/sweep_zedamigo.sh`, run over SSH), keyed on the per-run
+   `lib_path`:
+   ```bash
+   pkill -f "zedamigo-gh-${RUN_ID}/edge_nodes/" || true
+   pkill -f "terraform-provider-zedamigo -socket-tailer" || true
+   rm -rf "$HOME/.local/state/zedamigo-gh-${RUN_ID}"
+   ```
+   Note that `zedamigo_edge_node.Delete` treats a failed QMP `quit` as a *warning* and removes
+   the state directory anyway — so an orphaned QEMU process with its files deleted is a normal,
+   expected outcome, not an exotic one. The `pkill` is load-bearing.
+3. **The lock reaper** (§7.2). Because it is driven by heartbeats on the host rather than by the
+   workflow, it is the only layer that still works when the runner is force-killed — the case
+   `if: always()` does *not* cover. Breaking a stale lease also triggers layer 2 for that run's
+   id, so a cancelled run's VMs die within ~2 minutes and the lab slot is freed for the next
+   ticket in the queue. This is the layer that makes "one run at a time" safe in practice.
+4. **A scheduled janitor** (nightly): `lab-lock.sh reap`, sweep any `zedamigo-gh-*` directory
+   older than 4 hours and any matching QEMU process, and delete cloud objects whose names match
+   `tf_e2e_%`/`test_tf%` older than 24h. Belt and braces for whatever the first three missed.
+
+For the cloud side, prefer an **API-based** sweeper over
+`add-tf-agent-skill`'s `clean_tf_objects_on_alpha.sh`, which issues `DELETE` straight against
+the alpha Postgres — and not only for `test_tf%`: it also sweeps `openalpine%`, `open_ds%`,
+`qemu100_`, `default-app%` and `alphagroup13`. Deleting controller rows behind the API's back
+will desynchronise caches and mask exactly the kind of bug this suite exists to catch. The
+provider already tags test traffic with `User-Agent: zededa-terraform-provider/testbuild`
+(`v2/resources/provider.go:140,148-150`) — a usable server-side signal if a controller-side
+sweep endpoint is ever wanted.
+
+---
+
+## 9. Work breakdown
+
+Phases are ordered so each one ends somewhere shippable.
+
+### Phase 0 — Unblock (do before writing code)
+
+| # | Task | Owner |
+|---|---|---|
+| 0.1 | Confirm the device-facing endpoint name for alpha (`zedcontrold.alpha` vs `zedcloud.alpha`) and whether it serves a publicly-trusted cert | cluster owners |
+| 0.2 | **Manually onboard one virtual EVE node to alpha**, from a laptop, using the `local-en` recipe adapted to Linux/QEMU. Confirms the onboarding key `5d0767ee-…` is authorized in enterprise `AAFlABBtJ0mP_lhJjIyVzjzgMXiR`. This was the hard blocker on the local cluster (`register` → 403 "device not found") and it is **not fixable from Terraform** | us |
+| 0.3 | Agree the network path (§3.2). Spike Tailscale on a throwaway branch | us + IT |
+| 0.4 | Measure `h-m-dl20`: core count, RAM, NVMe free space; decide pool size | us |
+| 0.5 | **Rotate the credentials committed to `add-tf-agent-skill`** (§10.1) | us |
+
+Phase 0 is not optional overhead. 0.2 in particular is the difference between "three weeks of
+work" and "three weeks of work that cannot possibly succeed".
+
+### Phase 1 — Host + network (`zededa-berlin-lab`)
+
+1.1 Real `github-runner` SSH key. 1.2 `nested=1`. 1.3 Tailscale subnet router (or chosen
+alternative). 1.4 EVE image pre-pull. 1.5 `nixos-rebuild switch`, then verify from a hosted
+runner that a trivial workflow can `ssh github-runner@<host> 'qemu-img --version && docker
+version && ls /dev/kvm'`.
+
+**Exit criterion:** a hosted runner can run commands on `h-m-dl20`.
+
+### Phase 2 — Node lifecycle (`test/e2e/`)
+
+2.1 The Terraform config (§5). 2.2 `e2e.tfrc`. 2.3 The wait-for-online helper + `waitonline`
+command. 2.4 `sweep_zedamigo.sh`. 2.5 `lab-lock.sh` (`acquire`/`release`/`status`/`reap`) plus the
+heartbeat/reaper logic (§7.2) — test it standalone by racing three fake tickets before it goes
+anywhere near a workflow. 2.6 A minimal `e2e.yml` that takes the lock, creates a node, waits for
+ONLINE, destroys it and releases — no test suite yet.
+
+**Exit criterion:** green workflow that onboards and destroys a node, with the serial console log
+uploaded as an artifact on failure — and two concurrently-triggered runs demonstrably executing
+one after the other, in arrival order, with neither cancelled.
+
+### Phase 3 — Suite refactor (`v2/resources`, `v2/testing`)
+
+3.1 `__SUFFIX__` expansion + fixture `sed` (provable no-op at `__SUFFIX__=""`). 3.2
+`testhelper.RealNode` + `WaitForRunState`. 3.3 Replace `CI` gating with
+`ZEDCLOUD_ACC_REAL_NODE` / `ZEDCLOUD_ACC_ELEVATED`. 3.4 Node-identity tokens in fixtures. 3.5
+`make test-e2e` with a 90m timeout. 3.6 Un-skip `TestApplicationInstance_CreateCompose` and make
+it assert the app actually reaches running state.
+
+**Exit criterion:** the suite passes in both modes; `CreateCompose` passes against a real node.
+
+### Phase 4 — Per-PR viability
+
+4.1 Wire `e2e.yml` to `pull_request` with per-branch `concurrency` + the host lock (§7.2).
+4.2 The nightly janitor (including `lab-lock.sh reap`). 4.3 Measure wall-clock and queue depth
+over ~20 real PRs; publish `lab-lock.sh status` somewhere visible. 4.4 If PR latency is
+unacceptable — with one slot it probably will be — implement the warm node (§3.4 option B).
+
+### Phase 5 — Second NIC (optional, §6.4)
+
+5.1 `zedamigo_bridge`/`tap`/`dhcp_server` with `__SUFFIX__`-scoped names. 5.2 Model
+`io_member_list` gains `eth1`. 5.3 Real network-instance tests, asserting realization.
+
+Rough shape: Phase 0 is days of other people's calendars; Phases 1-2 about a week; Phase 3 is
+the big one (two to three weeks, mostly fixture archaeology); Phases 4-5 iterative.
+
+---
+
+## 10. Risks
+
+### 10.1 Committed credentials — fix this week, independent of everything else
+
+Branch `add-tf-agent-skill` contains, in plaintext:
+
+- `set_api_token.sh` — alpha UI password for `ivan-icd-test@zededa.com`, and the local-cluster
+  password for `watchdog-c20-local@zededa.com`
+- `clean_tf_objects_on_alpha.sh` — Postgres credentials for both the `alpha` and `local`
+  databases
+
+These are committed on the branch `add-tf-agent-skill`, which in the local clone is **not**
+present on `origin` (unlike `tf-actions`, which is). Confirm it was never pushed — then rotate
+all four regardless, move them to GitHub secrets, and rewrite the scripts to read from the
+environment. Do this independently of whether this design ships. `set_api_token.sh` also mints
+90-day tokens (`expires: 7776000`); shorten that for anything used by CI.
+
+### 10.2 The onboarding certificate
+
+The highest-probability project-killer. On the local cluster this manifested as
+`POST /api/v2/edgedevice/register` → 403 "device not found", because no onboarding cert for key
+`5d0767ee-0547-4569-b530-387e526f8cb9` was registered in the enterprise. Confirmed dead ends
+(all documented in `local-en/RUNBOOK.md`): the zedcloud provider exposes only `onboarding_key`,
+never the cert; REST `PUT` silently drops `onboarding.pemCert`; `zcli edge-node create
+--onboarding-certificate` works but only at create time and is mutually exclusive with
+`--onboarding-key`; zedamigo cannot inject `onboard.cert.pem`; and the `lf-edge/eve` repo's
+bundled cert **expired in 2020**. Alpha is long-lived and shared so it is *probably* seeded —
+but "probably" is why task 0.2 exists.
+
+### 10.3 One host, one slot, per-PR trigger
+
+Single point of failure and a hard serialization bottleneck: with a 30-60 minute run and one
+slot, throughput is at best ~1 PR/hour, and a queue of five PRs means the last one waits half a
+day. Mitigations: the FIFO ticket lock (§7.2), the four-layer cleanup (§8), and the warm node
+(§3.4B) to cut per-PR cost. Beyond that the only real lever is queue depth — skip drafts, or
+demote to nightly-plus-label if the queue is consistently deep.
+
+Two operational consequences to accept up front: a lab outage blocks the e2e check on **every**
+PR, and a single stuck run blocks everyone behind it. So (a) keep this check **non-required** in
+branch protection until it has been stable for several weeks, and (b) make `lab-lock.sh status`
+trivially runnable by a human, because "who is holding the lab and since when" will be the most
+frequently asked question about this system.
+
+### 10.4 Silent failure modes
+
+EVE fails *quietly* on TLS trust and on console misconfiguration. Both surface only in the
+serial console log. Always upload `zedamigo_edge_node.serial_console_log` and
+`installed_edge_node.serial_console_log` as artifacts — on success as well as failure, at least
+initially.
+
+### 10.5 Fixture refactor blast radius
+
+Touching 45 fixture files across 18 resource directories risks breaking the tests everyone
+relies on. This
+is why Phase 3.1 is structured as a provable no-op (`__SUFFIX__=""` → byte-identical config) and
+lands before any semantic change.
+
+### 10.6 Flakes we already know about
+
+`TestProfileDeployment_Create` (skipped on `CI`, passes locally). Nine steps across seven files
+set `ExpectNonEmptyPlan: true`, masking non-converging diffs. The provider retries GET 404s
+using `retryablehttp`'s defaults (4 attempts, exponential backoff — `RetryMax` is never set
+explicitly, `provider.go:188`), which inflates wall clock on failure paths. And the
+recent commit history — CI-723, CI-790, CI-865, CI-875 — is a steady stream of exactly the
+drift/diff bugs a real-node suite is supposed to catch earlier. That is the argument *for* this
+work; it is also a warning that the first few real-node runs will surface a queue of genuine
+bugs, and the suite will look flaky while they are fixed. Plan for that politically, not just
+technically.
+
+---
+
+## 11. Open questions
+
+1. **Device API hostname on alpha.** Is `zedcontrold.alpha.zededa.net` the device-facing
+   endpoint (`/config/server`), with `zedcontrol.alpha.zededa.net` remaining the control API?
+   Does it present a publicly-trusted certificate?
+2. **Is the default EVE onboarding key authorized in enterprise `AAFlABBtJ0mP_lhJjIyVzjzgMXiR`?**
+   (Task 0.2.)
+3. **Which EVE tag do we pin?** `local-en` used `14.5.3-lts-kvm-arm64`; the zedamigo examples
+   range across `14.5.3`, `16.0.0` and `16.0.1` LTS tags plus an `rc1` and a PR build — the
+   template we would copy (`1_node_1_container`) uses `16.0.0-lts-kvm-<arch>`. Should CI track
+   the LTS the product supports, or the newest?
+   Testing a provider against a stale EVE has limited value; testing against a moving tag makes
+   CI non-reproducible. Suggest pinning, with a scheduled bump PR.
+4. **`h-m-dl20` capacity** — cores, RAM, NVMe free. Determines pool size and whether concurrent
+   runs are ever viable.
+5. **Is Tailscale acceptable** in the lab network, and who owns the tailnet ACLs?
+6. **Terraform state backend** — is there an existing org S3/GCS bucket we should use, or is the
+   artifact hand-off good enough?
+7. **Does alpha tolerate per-PR churn?** We would be creating and deleting projects, models,
+   brands, networks, images and devices on a shared cluster on every PR. Confirm with its owners,
+   and confirm nobody else's tests rely on `test_tf%` objects.
+8. **Should the e2e config live here or in zedamigo?** Proposal is `test/e2e/` in this repo
+   (versioned with the provider under test). The alternative — a third repo — decouples but
+   adds a cross-repo pinning problem.
+9. **`terraform` or `tofu`?** The host has `opentofu` installed; the workflows use
+   `hashicorp/setup-terraform`. Pick one for the e2e config.
+
+---
+
+## 12. Reference index
+
+**`zededa/terraform-provider-zedcloud`**
+- `.github/workflows/test.yml`, `go.yml` — current PR jobs; `go.yml`'s test step is commented out
+- `Makefile` — `test`, `test-run` targets; `TF_ACC=1`, `TF_CLI_CONFIG_FILE`, `-timeout 20m`
+- `v2/testing/testhelper.go` — `MustGetTestInput`, `MustGetExpectedOutput`, `CheckEnv`
+- `v2/resources/provider.go:23,34,40,140,148-150,188,197-222` — `defaultURL`, env defaults,
+  `testbuild` User-Agent, the retryable client, the 404-retry policy
+- `v2/resources/provider_test.go` — `testAccProviders` wiring
+- `v2/resources/node_test.go:199,262` — golden-diff ignore list, 404-shape handling
+- `v2/resources/application_instance_test.go:65-71` — *"skipped until we decide how to provide a
+  real device"*
+- `v2/resources/testdata/**` — 18 dirs, 45 `.tf` fixtures + 37 `.yaml` goldens, all static
+- `dev.tfrc` — `dev_overrides` to `./v2`; breaks zedamigo resolution
+- `test/retry/` — manual mitmproxy 404 fault injection (not CI)
+- `docs/design/NFR-238-…md` — design-doc convention followed here
+- branches: `tf-actions` (provider Actions, unrelated — the only one of these on `origin`),
+  `add-tf-agent-skill` (alpha scripts, §10.1 — local-only in this clone), `add-claude`
+  (local-only), `tf-actions-hackaton` (local-only, empty vs `main`)
+
+**`andrei-zededa/terraform-provider-zedamigo`**
+- `internal/provider/ssh_config.go` — `ssh{}` schema, `ZEDAMIGO_SSH_*` env fallbacks,
+  fail-closed host-key check (`:300`), `bootstrapRemoteBinary` (`:365-390`), version refusal
+  (`:366-368`)
+- `internal/exec/{exec,ssh,local}.go` — the Executor abstraction, `sudo -n kill`
+- `internal/hypervisor/qemu.go:177-283` — install/runtime QEMU args, `-smbios … serial=`
+- `internal/hypervisor/forwards.go:32-38,66-73` — SLIRP nic0, port forwards on remote targets
+- `internal/provider/eve_installer_resource.go:291-302` — the `docker run … lfedge/eve` call
+- `internal/provider/installed_edge_node_resource.go:356-373` — `success` / `soft_serial`
+  scraping from the console log
+- `internal/provider/edge_node_resource.go:357,611-635` — random `ssh_port`, delete-path QMP
+  warning
+- `examples/other/1_node_1_container/` — SLIRP-only template (no `host_networking.tf`)
+- `examples/other/{1_node_3_vlans,2_edge_nodes_bridged}/` — bridge/tap/VLAN patterns,
+  `config_suffix` convention
+- `scripts/e2e_lag.sh` — rootless e2e harness; `dev_overrides` + `PATH` stubs worth stealing
+- `misc/tf_state_backend_http/` — **do not use** (no locking/auth/TLS, per its own README)
+- `CLAUDE.md`, `README.md:85-88` (endpoint naming; contradicted by the examples)
+
+**`andrei-zededa/zededa-berlin-lab`**
+- `hosts/h-m-dl20/configuration.nix` — `github-runner` user, sudo allow-list, podman
+  `dockerCompat`, `kvm` group, LVM udev rule
+- `hosts/h-m-dl20/hardware-configuration.nix` — `kvm-intel`, no `nested=1`
+- `hosts/h-m-dl20/monitoring.nix` — VictoriaMetrics/Logs, per-VM process_exporter grouping
+- `hosts/h-m-dl20/README.md` — `nixos-rebuild` deploy procedure, `ProxyJump=root@localhost:11022`
+- `berlin-vpn-in-a-container/` — the VPN jump host (§3.2 option 2)
+
+**`andrei-zededa/local-en`** (not a repo we own, but the primary reference)
+- `CLAUDE.md` — endpoint split (`:46`), TLS CA extraction (§4), orphan recovery (`:102-108`),
+  teardown (final section)
+- `RUNBOOK.md` — the onboarding-cert blocker and every confirmed dead end
+- `edge_node.tf`, `cluster_objects.tf` — the working two-provider wiring
+- `zedamigo.tfrc` — `filesystem_mirror` pattern that avoids the `dev.tfrc` conflict

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,0 +1,178 @@
+# test/e2e — virtual EVE node on the Berlin lab, onboarded to alpha
+
+Creates a virtual EVE-OS edge node as a QEMU/KVM VM on the Berlin lab host
+`h-m-dl20`, onboards it into the **alpha** Zedcloud cluster, and blocks until the
+controller reports it `RUN_STATE_ONLINE`.
+
+This is iteration 1 of
+[`docs/design/e2e-virtual-eve-node-testing.md`](../../docs/design/e2e-virtual-eve-node-testing.md):
+prove the node lifecycle. Running the acceptance suite against the node is iteration 2.
+
+**Validated end-to-end on 2026-08-19.** ~3.5 minutes from `apply` to `ONLINE`.
+
+## What it creates
+
+| Provider | Resources |
+|---|---|
+| `zedcloud` | `brand`, `model`, `project`, `network`, `edgenode` |
+| `zedamigo` | `host_reservation`, `disk_image`, `eve_installer`, `installed_edge_node`, `edge_node`, `wait_until` |
+
+Every object name carries `var.run_id`, so concurrent runs and leftovers cannot
+collide — necessary on alpha, which holds ~233 devices and ~334 projects belonging
+to other people.
+
+## Endpoints (verified)
+
+| Purpose | Host |
+|---|---|
+| Control / REST API (`zedcloud` provider) | `zedcontrol.alpha.zededa.net` |
+| Device API (EVE `/config/server`) | `zedcloud.alpha.zededa.net` |
+
+`zedcontrold.alpha.zededa.net` **does not resolve** — do not use it. Both real hosts
+sit behind Cloudflare with a Google Trust Services cert for `*.alpha.zededa.net`, so
+no `tls_ca` and no `additional_hosts` are needed (unlike the local-cluster setup,
+where EVE's pre-onboarding TLS check failed silently against a private Zededa CA).
+
+## Prerequisites
+
+The lab host is on `10.208.13.94`, reachable only via the Berlin office VPN.
+
+1. Start the VPN container (from `zededa-berlin-lab/berlin-vpn-in-a-container`).
+2. Reach the host through squid's CONNECT proxy. Note that macOS `nc -X connect`
+   misparses squid's response — use `socat`:
+
+   ```sh
+   LAB() { ssh -o ProxyCommand='socat - PROXY:127.0.0.1:%h:%p,proxyport=3128' \
+                -i ~/.ssh/ivan-berlin-lab ivan@10.208.13.94 "$@"; }
+   ```
+
+   (If the container publishes `11022`, `-o ProxyJump=root@localhost:11022` also works.)
+
+3. Install the zedamigo provider on the host. It is not on a public registry, so
+   cross-compile it and drop it in the filesystem mirror `e2e.tfrc` points at:
+
+   ```sh
+   cd ~/go/src/github.com/andrei-zededa/terraform-provider-zedamigo
+   GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -trimpath \
+     -ldflags "-s -w -X main.version=0.13.1" \
+     -o /tmp/terraform-provider-zedamigo_v0.13.1 .
+
+   M=.terraform.d/plugins/localhost/andrei-zededa/zedamigo/0.13.1/linux_amd64
+   LAB "mkdir -p ~/$M"
+   scp -o ProxyCommand='socat - PROXY:127.0.0.1:%h:%p,proxyport=3128' \
+       -i ~/.ssh/ivan-berlin-lab /tmp/terraform-provider-zedamigo_v0.13.1 \
+       ivan@10.208.13.94:"~/$M/"
+   LAB "chmod +x ~/$M/*"
+   ```
+
+   The binary is statically linked, which is what makes it run on NixOS.
+
+## Running it
+
+OpenTofu runs **on the lab host** in this iteration, so the zedamigo `target` is
+localhost and no `ssh {}` block is needed. Moving to a GitHub-hosted runner later
+means setting `target` + `ssh {}` in `terraform.tf` and changing nothing else —
+every path in this config is already a path on the target.
+
+```sh
+rsync -az -e "ssh -o ProxyCommand='socat - PROXY:127.0.0.1:%h:%p,proxyport=3128' \
+  -i $HOME/.ssh/ivan-berlin-lab" ./ ivan@10.208.13.94:e2e-alpha/
+
+LAB "cd ~/e2e-alpha \
+  && export TF_CLI_CONFIG_FILE=\$PWD/e2e.tfrc \
+            TF_VAR_zedcloud_token='<api-token>' \
+            TF_VAR_run_id='it1' \
+            TF_VAR_edge_node_ssh_pub_key='$(cat ~/.ssh/ivan-berlin-lab.pub)' \
+  && tofu init -input=false && tofu apply -auto-approve"
+```
+
+For long applies, detach on the host and poll — note the braces, without them `&`
+backgrounds the whole `cd && export && ...` chain and the log lands in `$HOME`:
+
+```sh
+LAB "cd ~/e2e-alpha && export ... && { setsid nohup tofu apply -auto-approve \
+  -no-color > apply.log 2>&1 < /dev/null & } ; sleep 8; tail -8 apply.log"
+```
+
+Teardown:
+
+```sh
+LAB "cd ~/e2e-alpha && export TF_CLI_CONFIG_FILE=\$PWD/e2e.tfrc TF_VAR_... \
+  && tofu destroy -auto-approve"
+```
+
+Destroying matters twice over: it stops the QEMU process **and** releases the
+capacity reservation, which is durable and survives reboots.
+
+## Measured timings (h-m-dl20, 16 cores / 62 GB, EVE 16.0.1)
+
+| Step | Duration |
+|---|---|
+| `eve_installer` (image cached) | 12s |
+| `installed_edge_node` (install VM, synchronous) | 1m34s |
+| `edge_node` (QEMU detached) | 0s |
+| `wait_until` boot → register → `RUN_STATE_ONLINE` | 1m21s (5 attempts) |
+| **total** | **~3m10s** |
+
+Far cheaper than the 30–60 min the design doc assumed, which came from a macOS/arm64
+emulated run. This makes a per-PR trigger considerably more viable and weakens the
+argument for a warm node pool.
+
+## Known issues
+
+**Capacity reservation lock is single-user.** On `h-m-dl20`,
+`/var/lib/zedamigo/reservations/.lock` is mode `0644` owned by `andrei`, while the
+directory is group-writable (`drwxrwsr-x root:zedamigo_reservations`). The provider
+opens the lock for writing, so every group member except `andrei` fails:
+
+```
+za-host-reservation: /var/lib/zedamigo/reservations/.lock: Permission denied
+cannot open lock file (is /var/lib/zedamigo/reservations writable?)
+```
+
+Cooperative reservation therefore works for exactly one user. `var.reservations_path`
+currently points at a per-user tree as a workaround, which keeps the resource
+exercised but provides **no cross-user coordination**. The real fix is `0664`/`g+w`
+on `.lock`, declared in the lab's `configuration.nix` so it survives a
+`nixos-rebuild`. Switch `reservations_path` back to the default once that lands.
+
+**Installer-time network warnings are benign.** The install console reports
+`eth0 with dhcp is NOT working properly` and `eth0 with static configuration is not
+working`, then completes successfully and the node onboards normally. The installer's
+connectivity probe appears to run before SLIRP is usable.
+
+## Running the real-node acceptance test against it
+
+Once the node is up, `TestApplicationInstance_RealNode` deploys an nginx container onto
+it and waits until the device reports `SW_STATE_RUNNING`. That test runs the provider
+in-process, so it runs from anywhere with access to the alpha API — it does **not** need
+to run on the lab host:
+
+```sh
+cd v2/resources
+TF_ACC=1 \
+TF_CLI_CONFIG_FILE=$PWD/../../dev.tfrc \
+TF_VAR_zedcloud_url=zedcontrol.alpha.zededa.net \
+TF_VAR_zedcloud_token='<api-token>' \
+ZEDCLOUD_ACC_REAL_NODE=1 \
+ZEDCLOUD_TEST_NODE_NAME=tf_e2e_en_it1 \
+ZEDCLOUD_TEST_SUFFIX=_it7 \
+  go test -v -timeout 40m -run TestApplicationInstance_RealNode .
+```
+
+Takes about a minute. Without `ZEDCLOUD_ACC_REAL_NODE` the test skips, so the default
+suite is unaffected. Use a fresh `ZEDCLOUD_TEST_SUFFIX` per run.
+
+## Notes
+
+- The onboarding key `5d0767ee-0547-4569-b530-387e526f8cb9` **is** authorized on
+  alpha — the 403 `register` → "device not found" blocker documented against the
+  local cluster did not occur here.
+- `grub_cfg` must match `serial_type`. Default `serial_type` is `virtio`, whose
+  console is `hvc0`. A mismatch produces an empty console log, so
+  `installed_edge_node.success` never flips true — and it fails silently.
+- `installed_edge_node` has **no timeout**: if the install hangs, the apply hangs.
+- The two `swtpm` / `genisoimage` "executable not found" warnings are expected; those
+  resources are not used.
+- `eve_ssh_port` is forwarded on the **lab host**, not locally. Reach EVE with
+  `LAB "ssh -p <port> root@localhost"` or your own `ssh -L` through the proxy.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -67,6 +67,44 @@ The lab host is on `10.208.13.94`, reachable only via the Berlin office VPN.
 
    The binary is statically linked, which is what makes it run on NixOS.
 
+4. Point `zededa/zedcloud` at a locally built provider. `terraform.tf` declares
+   no version constraint on purpose — this config is meant to exercise the
+   provider **you are changing**, not whatever the registry currently serves —
+   so your `e2e.tfrc` needs a `dev_overrides` entry:
+
+   ```hcl
+   provider_installation {
+     dev_overrides {
+       "zededa/zedcloud" = "/home/<you>/e2e-alpha-provider"
+     }
+     filesystem_mirror {
+       path    = "/home/<you>/.terraform.d/plugins"
+       include = ["localhost/andrei-zededa/zedamigo"]
+     }
+     direct {
+       exclude = ["localhost/andrei-zededa/zedamigo"]
+     }
+   }
+   ```
+
+   `dev_overrides` must come first, and the directory is scanned for a plain
+   `terraform-provider-zedcloud`. `make build` emits a version-suffixed name,
+   so link it:
+
+   ```sh
+   make build
+   ln -sf "$(ls -1t v2/terraform-provider-zedcloud_* | head -1)" \
+          v2/terraform-provider-zedcloud
+   ```
+
+   Cross-compile for the lab host if you are building on macOS:
+   `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -C ./v2 -o ../provider-linux .`
+
+   Expect `tofu` to print "Provider development overrides are in effect" on
+   every command. That warning is the confirmation it worked — without it, you
+   are silently testing a released provider. CI generates the equivalent config
+   and hard-fails if the binary is missing, rather than falling back.
+
 ## Running it
 
 OpenTofu runs **on the lab host** in this iteration, so the zedamigo `target` is

--- a/test/e2e/cluster_objects.tf
+++ b/test/e2e/cluster_objects.tf
@@ -1,0 +1,106 @@
+# Copyright (c) Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# Control-plane objects. Every name carries var.run_id so runs cannot collide
+# on the shared alpha enterprise (which already holds ~233 devices and ~334
+# projects belonging to other people).
+# ---------------------------------------------------------------------------
+
+resource "zedcloud_brand" "QEMU" {
+  name        = "tf_e2e_brand_${var.run_id}"
+  title       = "tf_e2e_brand_${var.run_id}"
+  origin_type = "ORIGIN_LOCAL"
+}
+
+resource "zedcloud_model" "QEMU_VM" {
+  name           = "tf_e2e_model_${var.run_id}"
+  title          = "tf_e2e_model_${var.run_id}"
+  origin_type    = "ORIGIN_LOCAL"
+  brand_id       = zedcloud_brand.QEMU.id
+  type           = upper(var.eve_arch)
+  product_status = "production"
+  state          = "SYS_MODEL_STATE_ACTIVE"
+
+  attr = {
+    "Cpus"    = tostring(var.node_cpus)
+    "memory"  = "${var.node_mem_gb * 1024}M"
+    "storage" = "${var.node_disk_mb}M"
+  }
+
+  # One management NIC. The VM is created with a single QEMU SLIRP interface,
+  # so declaring more here would describe hardware that does not exist.
+  io_member_list {
+    assigngrp    = "eth0"
+    cbattr       = {}
+    cost         = 0
+    logicallabel = "eth0"
+    phyaddrs     = { Ifname = "eth0" }
+    phylabel     = "eth0"
+    usage        = "ADAPTER_USAGE_MANAGEMENT"
+    usage_policy = {}
+    ztype        = "IO_TYPE_ETH"
+  }
+}
+
+resource "zedcloud_project" "PROJECT" {
+  name  = "tf_e2e_project_${var.run_id}"
+  title = "tf_e2e_project_${var.run_id}"
+  type  = "TAG_TYPE_PROJECT"
+
+  tag_level_settings {
+    flow_log_transmission = "NETWORK_INSTANCE_FLOW_LOG_TRANSMISSION_UNSPECIFIED"
+    interface_ordering    = "INTERFACE_ORDERING_ENABLED"
+  }
+}
+
+resource "zedcloud_network" "mgmt_dhcp" {
+  name       = "tf_e2e_net_${var.run_id}"
+  title      = "tf_e2e_net_${var.run_id}"
+  kind       = "NETWORK_KIND_V4"
+  project_id = zedcloud_project.PROJECT.id
+  mtu        = 1500
+
+  ip { dhcp = "NETWORK_DHCP_TYPE_CLIENT" }
+}
+
+# ---------------------------------------------------------------------------
+# The edge-node record.
+#
+# SERIAL FLOW (Linux/QEMU): we choose the serial here and it flows DOWNWARDS --
+# QEMU stamps it via `-smbios type=1,serial=<serial_no>` and EVE reads it as the
+# hardware serial. The cloud object stays the source of truth.
+#
+# Do NOT use the macOS "soft-serial flip" (serialno = ...INSTALL.soft_serial);
+# that exists only because Apple's Virtualization.framework offers no SMBIOS
+# serial to stamp.
+# ---------------------------------------------------------------------------
+
+resource "zedcloud_edgenode" "EN" {
+  name  = "tf_e2e_en_${var.run_id}"
+  title = "tf_e2e_en_${var.run_id}"
+
+  serialno       = "TF-E2E-${upper(var.run_id)}"
+  onboarding_key = var.onboarding_key
+  model_id       = zedcloud_model.QEMU_VM.id
+  project_id     = zedcloud_project.PROJECT.id
+  admin_state    = "ADMIN_STATE_ACTIVE"
+
+  interfaces {
+    intfname   = "eth0"
+    intf_usage = "ADAPTER_USAGE_MANAGEMENT"
+    cost       = 0
+    netname    = zedcloud_network.mgmt_dhcp.name
+    ztype      = "IO_TYPE_ETH"
+    tags       = {}
+  }
+
+  # Lets us shell into EVE for post-mortems once it is onboarded.
+  config_item {
+    key          = "debug.enable.ssh"
+    string_value = var.edge_node_ssh_pub_key
+    uint64_value = "0"
+  }
+
+  tags = {}
+}

--- a/test/e2e/node.tf
+++ b/test/e2e/node.tf
@@ -1,0 +1,160 @@
+# Copyright (c) Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# Cooperative capacity reservation.
+#
+# The Berlin lab host is shared, so claim the CPUs and RAM this node will use
+# before creating it. The reservation tree is pre-created by the operator at
+# /var/lib/zedamigo/reservations (16 CPU slots, 58 GB slots on h-m-dl20) and is
+# group-writable by `zedamigo_reservations`, which the login user belongs to --
+# so no sudo is needed. Claims are atomic via flock and are visible to any other
+# Terraform configuration on the host, including a human's.
+#
+# NOTE: this is admission control, not a queue. If capacity is unavailable the
+# apply FAILS rather than waiting.
+# ---------------------------------------------------------------------------
+
+# Claims capacity from the shared tree at /var/lib/zedamigo/reservations, so
+# CI, andrei's manual runs and anyone else's cannot oversubscribe the host.
+#
+# HISTORY: this used to need a per-user tree. The shared tree's `.lock` was
+# created on first use with the creating process's umask -- 0644, owned by
+# whoever ran first -- so every other member of zedamigo_reservations failed
+# with "Permission denied ... is /var/lib/zedamigo/reservations writable?",
+# and cooperative reservation worked for exactly one user. Now fixed
+# declaratively in the lab repo (hosts/h-m-dl20/github-runners.nix declares the
+# lock 0664 root:zedamigo_reservations via tmpfiles), so the default shared
+# path is correct again.
+#
+# Override var.reservations_path only if testing against a host without that
+# fix; a per-user tree keeps this resource exercised but gives no cross-user
+# coordination.
+resource "zedamigo_host_reservation" "SLOT" {
+  path = var.reservations_path
+
+  cpus = var.node_cpus
+  mem  = var.node_mem_gb
+}
+
+# ---------------------------------------------------------------------------
+# Phase 1: an empty qcow2 that EVE will be installed onto.
+# ---------------------------------------------------------------------------
+
+resource "zedamigo_disk_image" "empty" {
+  name    = "tf_e2e_disk_${var.run_id}"
+  size_mb = var.node_disk_mb
+}
+
+# ---------------------------------------------------------------------------
+# Phase 2: build a custom EVE-OS installer.
+#
+# This runs `docker run --network none ... docker.io/lfedge/eve:<tag>` on the
+# target, which writes the /config directory into the image -- `cluster` becomes
+# /config/server, i.e. the DEVICE API endpoint.
+#
+# grub_cfg MUST match serial_type. The default serial_type is `virtio`, whose
+# console is hvc0. Getting this wrong yields an EMPTY console log, so
+# installed_edge_node.success never flips true -- and it fails silently.
+# ---------------------------------------------------------------------------
+
+resource "zedamigo_eve_installer" "eve" {
+  name            = "tf_e2e_installer_${var.run_id}"
+  tag             = var.eve_tag
+  cluster         = var.eve_cluster_host
+  authorized_keys = var.edge_node_ssh_pub_key
+
+  grub_cfg = <<-EOF
+   set_getty
+   set_global dom0_extra_args "$dom0_extra_args console=hvc0 hv_console=hvc0 dom0_console=hvc0"
+   EOF
+}
+
+# ---------------------------------------------------------------------------
+# Phase 3: run the installer.
+#
+# This boots a throwaway VM and blocks until it powers off. There is NO timeout
+# in the provider -- if the install hangs, the apply hangs. `success` is derived
+# by grepping the install console log for "EVE-OS installation completed".
+# ---------------------------------------------------------------------------
+
+resource "zedamigo_installed_edge_node" "INSTALL" {
+  name            = "tf_e2e_install_${var.run_id}"
+  serial_no       = zedcloud_edgenode.EN.serialno
+  installer_iso   = zedamigo_eve_installer.eve.filename
+  disk_image_base = zedamigo_disk_image.empty.filename
+}
+
+# ---------------------------------------------------------------------------
+# Phase 4: boot the installed disk. EVE connects out and onboards.
+#
+# Uplink is QEMU SLIRP (the nic0 default): the guest gets 10.0.2.15 behind NAT
+# and inherits the host's outbound connectivity. No bridge, tap, netns or root
+# required -- and the lab host reaches the device API (verified: /api/v2/
+# edgedevice/ping -> 200).
+#
+# `depends_on` is load-bearing: the cloud record must exist before EVE boots and
+# starts POSTing to /api/v2/edgedevice/register, otherwise the first attempts
+# fail against a device the controller does not know yet.
+# ---------------------------------------------------------------------------
+
+resource "zedamigo_edge_node" "VM" {
+  name               = "tf_e2e_vm_${var.run_id}"
+  cpus               = var.node_cpus
+  mem                = "${var.node_mem_gb}G"
+  serial_no          = zedamigo_installed_edge_node.INSTALL.serial_no
+  disk_image_base    = zedamigo_installed_edge_node.INSTALL.disk_image
+  ovmf_vars_src      = zedamigo_installed_edge_node.INSTALL.ovmf_vars
+  serial_port_server = true
+
+  depends_on = [
+    zedcloud_edgenode.EN,
+    zedamigo_host_reservation.SLOT,
+  ]
+}
+
+# ---------------------------------------------------------------------------
+# Phase 5: wait for the node to actually come up.
+#
+# zedamigo_edge_node returns as soon as QEMU is detached -- EVE's boot,
+# register -> uuid -> certs -> config handshake all happen AFTER apply would
+# otherwise finish. Without this barrier the apply "succeeds" against a node
+# that never onboarded.
+#
+# The probe runs ON the target (the lab host), which is what makes this work
+# unchanged when the provider later points at a remote target.
+#
+# Deliberately a single-shot probe with no inner loop: `interval` and `timeout`
+# own the retrying.
+# ---------------------------------------------------------------------------
+
+resource "zedamigo_wait_until" "onboarded" {
+  triggers = {
+    node_id   = zedamigo_edge_node.VM.id
+    device_id = zedcloud_edgenode.EN.id
+  }
+
+  timeout         = var.onboard_timeout
+  interval        = "20s"
+  attempt_timeout = "30s"
+
+  # Succeeds once the controller reports the device ONLINE. The progression is
+  # UNPROVISIONED -> PROVISIONED (registered, not yet reporting) -> ONLINE.
+  script = <<-EOT
+    set -u
+    PATH=/run/current-system/sw/bin:/usr/bin:/bin
+
+    STATUS=$(curl -s --max-time 15 \
+      -H "Authorization: Bearer ${var.zedcloud_token}" \
+      "https://${var.zedcloud_url}/api/v1/devices/id/${zedcloud_edgenode.EN.id}/status")
+
+    RUN=$(printf '%s' "$STATUS" | jq -r '.runState // "none"')
+    echo "runState=$RUN"
+
+    if [ "$RUN" = "RUN_STATE_ONLINE" ]; then
+      exit 0
+    fi
+
+    exit 1
+  EOT
+}

--- a/test/e2e/outputs.tf
+++ b/test/e2e/outputs.tf
@@ -1,0 +1,31 @@
+# Copyright (c) Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Consumed by the acceptance suite in later iterations, which needs the real
+# node's identity injected via ZEDCLOUD_TEST_* environment variables.
+output "device_id" { value = zedcloud_edgenode.EN.id }
+output "device_name" { value = zedcloud_edgenode.EN.name }
+output "serialno" { value = zedcloud_edgenode.EN.serialno }
+output "project_id" { value = zedcloud_project.PROJECT.id }
+output "model_id" { value = zedcloud_model.QEMU_VM.id }
+output "network_name" { value = zedcloud_network.mgmt_dhcp.name }
+
+# Post-mortem handles. The console logs are the ONLY place EVE's silent failures
+# (TLS trust, console misconfiguration) show up, so always collect them.
+output "install_console_log" { value = zedamigo_installed_edge_node.INSTALL.serial_console_log }
+output "run_console_log" { value = zedamigo_edge_node.VM.serial_console_log }
+output "install_success" { value = zedamigo_installed_edge_node.INSTALL.success }
+output "soft_serial" { value = zedamigo_installed_edge_node.INSTALL.soft_serial }
+
+# ssh -p <port> root@localhost on the LAB HOST (SLIRP forwards bind there).
+output "eve_ssh_port" { value = zedamigo_edge_node.VM.ssh_port }
+
+output "reserved_cpus" { value = zedamigo_host_reservation.SLOT.cpus_reserved }
+
+output "onboard_wait" {
+  value = {
+    attempts = zedamigo_wait_until.onboarded.attempts
+    elapsed  = zedamigo_wait_until.onboarded.elapsed
+    last     = trimspace(zedamigo_wait_until.onboarded.stdout)
+  }
+}

--- a/test/e2e/terraform.tf
+++ b/test/e2e/terraform.tf
@@ -1,0 +1,42 @@
+# Copyright (c) Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+terraform {
+  required_providers {
+    # Resolved from the on-host filesystem mirror at
+    # ~/.terraform.d/plugins/localhost/andrei-zededa/zedamigo/<ver>/linux_amd64/
+    # (see e2e.tfrc). Not on a public registry.
+    zedamigo = {
+      source  = "localhost/andrei-zededa/zedamigo"
+      version = "0.13.1"
+    }
+
+    # Public registry. Iteration 1 uses the released provider because we are
+    # proving out the node lifecycle, not the provider under test. Later
+    # iterations run the acceptance suite, which loads the provider in-process
+    # and therefore does not use this binary at all.
+    zedcloud = {
+      source  = "zededa/zedcloud"
+      version = ">= 2.7.0"
+    }
+  }
+}
+
+provider "zedamigo" {
+  # Iteration 1 runs OpenTofu on the lab host itself, so the target is the
+  # local machine and no ssh{} block is needed. Switching to a GitHub-hosted
+  # runner later means setting `target` + `ssh {}` here and changing nothing
+  # else -- every path in this config is already a path on the target.
+  #
+  # target = var.lab_host
+  # ssh { user = "gh-run-tf-zedcloud" ... }
+
+  # No host networking resources are used (the node gets its uplink from QEMU
+  # SLIRP), so the provider needs no sudo.
+  use_sudo = false
+}
+
+provider "zedcloud" {
+  zedcloud_url   = var.zedcloud_url
+  zedcloud_token = var.zedcloud_token
+}

--- a/test/e2e/terraform.tf
+++ b/test/e2e/terraform.tf
@@ -11,13 +11,21 @@ terraform {
       version = "0.13.1"
     }
 
-    # Public registry. Iteration 1 uses the released provider because we are
-    # proving out the node lifecycle, not the provider under test. Later
-    # iterations run the acceptance suite, which loads the provider in-process
-    # and therefore does not use this binary at all.
+    # Resolved from a dev_overrides entry pointing at the locally built
+    # provider -- see the generated e2e.tfrc in .github/workflows/e2e.yml,
+    # and test/e2e/README.md for the manual equivalent.
+    #
+    # NO VERSION CONSTRAINT, deliberately. dev_overrides ignores version
+    # constraints (with a warning), so a pin here would be decorative and
+    # would imply this comes from the registry. It used to: iteration 1
+    # pinned ">= 2.7.0" from the public registry on the grounds that we were
+    # proving out the node lifecycle rather than the provider. That stopped
+    # being true once the acceptance suite ran -- every object this config
+    # creates (project, brand, model, network instance, image, edgenode) is
+    # part of what a pull request can break, so it has to be the PR's binary
+    # creating them.
     zedcloud = {
-      source  = "zededa/zedcloud"
-      version = ">= 2.7.0"
+      source = "zededa/zedcloud"
     }
   }
 }

--- a/test/e2e/vars.tf
+++ b/test/e2e/vars.tf
@@ -1,0 +1,109 @@
+# Copyright (c) Zededa, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# Cluster endpoints.
+#
+# These are TWO DIFFERENT hostnames and mixing them up is the classic failure:
+#   - zedcloud_url      -> the CONTROL/REST API the zedcloud provider calls
+#   - eve_cluster_host  -> the DEVICE API, written into EVE's /config/server
+#
+# Verified on alpha (2026-08-19):
+#   zedcontrol.alpha.zededa.net   resolves, control API, token works
+#   zedcloud.alpha.zededa.net     resolves, device API, /api/v2/edgedevice/ping -> 200
+#   zedcontrold.alpha.zededa.net  DOES NOT RESOLVE -- do not use
+#
+# Both are behind Cloudflare with a Google Trust Services cert for
+# *.alpha.zededa.net, i.e. publicly trusted. That is why this config needs no
+# `tls_ca` and no `additional_hosts` (unlike the local-cluster setup, where
+# EVE's pre-onboarding TLS check failed silently against a private Zededa CA).
+# ---------------------------------------------------------------------------
+
+variable "zedcloud_url" {
+  type        = string
+  description = "Control/REST API host, e.g. zedcontrol.alpha.zededa.net"
+  default     = "zedcontrol.alpha.zededa.net"
+}
+
+variable "zedcloud_token" {
+  type        = string
+  description = "Zedcloud API token (TF_VAR_zedcloud_token)"
+  sensitive   = true
+}
+
+variable "eve_cluster_host" {
+  type        = string
+  description = "Device API host baked into EVE /config/server"
+  default     = "zedcloud.alpha.zededa.net"
+}
+
+# ---------------------------------------------------------------------------
+# Identity / isolation
+# ---------------------------------------------------------------------------
+
+# Suffixed onto every object name so concurrent runs and leftovers cannot
+# collide. In CI this becomes "gh<run_id>".
+variable "run_id" {
+  type        = string
+  description = "Unique per-run suffix for every created object"
+}
+
+# CN of EVE's default onboarding certificate. Alpha has 15 devices in
+# RUN_STATE_ONLINE, so this key is expected to be authorized here.
+variable "onboarding_key" {
+  type        = string
+  description = "Onboarding key (CN of EVE's default onboard cert)"
+  default     = "5d0767ee-0547-4569-b530-387e526f8cb9"
+}
+
+variable "edge_node_ssh_pub_key" {
+  type        = string
+  description = "SSH public key baked into the EVE image and set as debug.enable.ssh"
+  default     = ""
+}
+
+# ---------------------------------------------------------------------------
+# Node shape
+# ---------------------------------------------------------------------------
+
+variable "eve_tag" {
+  type        = string
+  description = "lfedge/eve Docker tag. Pinned deliberately: a moving tag makes CI non-reproducible."
+  default     = "16.0.1-lts-kvm-amd64"
+}
+
+variable "eve_arch" {
+  type    = string
+  default = "amd64"
+}
+
+variable "node_cpus" {
+  type    = number
+  default = 4
+}
+
+variable "node_mem_gb" {
+  type    = number
+  default = 8
+}
+
+variable "node_disk_mb" {
+  type    = number
+  default = 20000
+}
+
+# Overall budget for EVE to boot, register and report in.
+variable "onboard_timeout" {
+  type    = string
+  default = "25m"
+}
+
+# Root of the zedamigo capacity-reservation tree. The host-wide default,
+# /var/lib/zedamigo/reservations, is what gives cross-user/cross-config
+# coordination and is what CI should ultimately use -- but see the KNOWN ISSUE
+# note on zedamigo_host_reservation in node.tf.
+variable "reservations_path" {
+  type        = string
+  description = "Reservation tree root on the target"
+  default     = "/var/lib/zedamigo/reservations"
+}

--- a/v2/models/network_counters.go
+++ b/v2/models/network_counters.go
@@ -17,46 +17,86 @@ import (
 // # NetworkCounter is used to store the Network Stats and Counters
 //
 // swagger:model NetworkCounters
+//
+// HAND-EDITED, AND A REGEN WILL REVERT IT.
+//
+// Every uint64 below carries an extra `,string` that go-swagger did not
+// generate. The controller serialises 64-bit integers as JSON *strings* --
+// that is the canonical protobuf JSON mapping, because a float64 cannot hold
+// the full uint64 range -- so the generated `uint64` tags cannot decode a real
+// response:
+//
+//	json: cannot unmarshal string into Go struct field
+//	NetworkCounters.netCounterList.txBytes of type uint64
+//
+// This went unnoticed because nothing in the repo called the /status endpoints
+// until the real-node test helper (v2/testing/realnode.go); the generated
+// client covers only the config endpoints. Once an app instance starts
+// producing network counters, every status poll fails to decode, which is what
+// made TestApplicationInstance_RealNode time out at 15m while reporting a
+// stale swState -- see UE-138.
+//
+// TWO MEASURED CONSEQUENCES, so the next person does not have to rediscover
+// them (verified against encoding/json, not assumed):
+//
+//   - `,string` accepts ONLY a quoted value on decode. An unquoted number now
+//     fails with "invalid use of ,string struct tag, trying to unmarshal
+//     unquoted value into uint64". If the controller ever returns these
+//     unquoted, that is the error to expect, and it means the field needs a
+//     custom UnmarshalJSON accepting both forms rather than this tag.
+//   - It changes MARSHALLING too: uint64(42) now emits "42", not 42. Harmless
+//     for these fields because NetworkCounters only ever appears inside
+//     read-only status messages (AppInstStatusMsg, DeviceInfoMsg,
+//     DeviceStatusMsg), never in a request body. Do not copy this tag onto a
+//     field the provider SENDS without checking the API accepts quoted.
+//
+// The same problem exists on ~180 other int64/uint64 fields across this
+// package; only the ones actually exercised are fixed here. Tracked separately
+// under UE-131, because a blanket change is exactly what the first bullet says
+// not to do.
+//
+// If you regenerate models from swagger, re-apply this, or teach the generator
+// to emit `,string` for 64-bit integers.
 type NetworkCounters struct {
 
 	// ifName
 	IfName string `json:"ifName,omitempty"`
 
 	// Rx ACL Rate Drops
-	RxACLDrops uint64 `json:"rxAclDrops,omitempty"`
+	RxACLDrops uint64 `json:"rxAclDrops,omitempty,string"`
 
 	// Rx ACL Rate Limit Drops
-	RxACLRateLimitDrops uint64 `json:"rxAclRateLimitDrops,omitempty"`
+	RxACLRateLimitDrops uint64 `json:"rxAclRateLimitDrops,omitempty,string"`
 
 	// Rx Bytes
-	RxBytes uint64 `json:"rxBytes,omitempty"`
+	RxBytes uint64 `json:"rxBytes,omitempty,string"`
 
 	// Rx Drops
-	RxDrops uint64 `json:"rxDrops,omitempty"`
+	RxDrops uint64 `json:"rxDrops,omitempty,string"`
 
 	// Rx Errors
-	RxErrors uint64 `json:"rxErrors,omitempty"`
+	RxErrors uint64 `json:"rxErrors,omitempty,string"`
 
 	// Rx packets
-	RxPkts uint64 `json:"rxPkts,omitempty"`
+	RxPkts uint64 `json:"rxPkts,omitempty,string"`
 
 	// Tx ACL Rate Drops
-	TxACLDrops uint64 `json:"txAclDrops,omitempty"`
+	TxACLDrops uint64 `json:"txAclDrops,omitempty,string"`
 
 	// Tx ACL Rate Limit Drops
-	TxACLRateLimitDrops uint64 `json:"txAclRateLimitDrops,omitempty"`
+	TxACLRateLimitDrops uint64 `json:"txAclRateLimitDrops,omitempty,string"`
 
 	// Tx Bytes
-	TxBytes uint64 `json:"txBytes,omitempty"`
+	TxBytes uint64 `json:"txBytes,omitempty,string"`
 
 	// Tx Drops
-	TxDrops uint64 `json:"txDrops,omitempty"`
+	TxDrops uint64 `json:"txDrops,omitempty,string"`
 
 	// Tx Errors
-	TxErrors uint64 `json:"txErrors,omitempty"`
+	TxErrors uint64 `json:"txErrors,omitempty,string"`
 
 	// Tx Packets
-	TxPkts uint64 `json:"txPkts,omitempty"`
+	TxPkts uint64 `json:"txPkts,omitempty,string"`
 }
 
 // Validate validates this network counters

--- a/v2/resources/application_instance_real_node_test.go
+++ b/v2/resources/application_instance_real_node_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/zededa/terraform-provider-zedcloud/v2/models"
+	testhelper "github.com/zededa/terraform-provider-zedcloud/v2/testing"
+)
+
+var uuidRE = regexp.MustCompile(
+	`^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[8|9|aA|bB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$`)
+
+// TestApplicationInstance_RealNode deploys a real container onto a real,
+// onboarded edge node and waits until the device reports it running.
+//
+// This is the test the rest of the suite cannot be: every other acceptance test
+// fabricates a zedcloud_edgenode against a synthetic brand/model with an invented
+// serial, so nothing ever checks in and an app instance is "created" without ever
+// running. Here the controller must actually push the config, the device must pull
+// the image from Docker Hub and start the workload -- so the assertion is
+// SW_STATE_RUNNING, not merely "the POST returned 200".
+//
+// It is the intended replacement for the reason TestApplicationInstance_CreateCompose
+// carries the comment "skipped until we decide how to provide a real device for
+// testing".
+//
+// Requires (otherwise skipped):
+//
+//	ZEDCLOUD_ACC_REAL_NODE=1
+//	ZEDCLOUD_TEST_NODE_NAME=<name of an onboarded edge node>
+//	ZEDCLOUD_TEST_SUFFIX=<per-run suffix>      (generated if absent)
+//	TF_VAR_zedcloud_url / TF_VAR_zedcloud_token
+//
+// See test/e2e/ for the Terraform config that creates a suitable node, and
+// docs/design/e2e-virtual-eve-node-testing.md for how this fits into CI.
+func TestApplicationInstance_RealNode(t *testing.T) {
+	node := testhelper.RealNode(t)
+
+	const resourceName = "zedcloud_application_instance.real"
+
+	input := testhelper.MustGetTestInputWithVars(t,
+		"application_instance/create_real_node.tf",
+		map[string]string{
+			"NODE_ID": node.ID,
+			"SUFFIX":  node.Suffix,
+		},
+	)
+
+	var got models.AppInstance
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testhelper.CheckEnv(t) },
+		CheckDestroy: testApplicationInstanceDestroy,
+		Providers:    testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: input,
+				Check: resource.ComposeTestCheckFunc(
+					testApplicationInstanceExists(resourceName, &got),
+					resource.TestMatchResourceAttr(resourceName, "id", uuidRE),
+					resource.TestMatchResourceAttr(resourceName, "app_id", uuidRE),
+
+					// The instance must be bound to the live node, not to some
+					// node a fixture invented for itself.
+					resource.TestCheckResourceAttr(resourceName, "device_id", node.ID),
+					resource.TestCheckResourceAttr(
+						"zedcloud_network_instance.real", "device_id", node.ID),
+
+					// The payload: the workload actually started on the device.
+					// Budget covers config push, image pull from Docker Hub and
+					// container start.
+					waitAppInstanceRunning(t, resourceName, 15*time.Minute),
+				),
+			},
+		},
+	})
+}
+
+// waitAppInstanceRunning blocks until the device reports the workload running.
+func waitAppInstanceRunning(t *testing.T, appInstName string, timeout time.Duration) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[appInstName]
+		if !ok {
+			return fmt.Errorf("%s not found in state", appInstName)
+		}
+		id := rs.Primary.ID
+		if id == "" {
+			return fmt.Errorf("%s has an empty id", appInstName)
+		}
+
+		return testhelper.WaitForAppInstanceSwState(
+			t, id, models.SWStateSWSTATERUNNING, timeout)
+	}
+}

--- a/v2/resources/testdata/application_instance/create_real_node.tf
+++ b/v2/resources/testdata/application_instance/create_real_node.tf
@@ -1,0 +1,247 @@
+# Real-node application instance fixture. Driven by
+# TestApplicationInstance_RealNode; see also .github/workflows/e2e.yml.
+#
+# Unlike application_instance/create.tf, this fixture does NOT fabricate an edge
+# node. It targets an existing, onboarded node and deploys a real container onto
+# it, so the test can assert the workload actually reaches SW_STATE_RUNNING on
+# the device.
+#
+# The node is referenced by injected UUID rather than through the
+# `zedcloud_edgenode` DATA SOURCE, because that data source is currently unusable
+# for lookups: NodeDataSource() reuses zschema.Node() -- the resource schema --
+# so it inherits every write-side Required field and rejects a name-only lookup
+# with "The argument \"model_id\" is required" (likewise project_id, title, and
+# at least one interfaces block). testhelper.RealNode resolves the name to a UUID
+# against the API instead. Switch this back to the data source once its schema is
+# split from the resource's.
+#
+# Placeholders (expanded by testhelper.MustGetTestInputWithVars):
+#   __NODE_ID__    UUID of the live onboarded edge node
+#   __SUFFIX__     per-run suffix; keeps names unique on a shared enterprise
+#
+# Everything here is modelled on a container app already running on alpha, so the
+# shapes are known-good rather than guessed:
+#   datastore  DATASTORE_TYPE_CONTAINERREGISTRY, ds_fqdn "docker://docker.io",
+#              empty ds_path
+#   image      plain `name`, pull reference in `image_rel_url`
+#   manifest   ac_kind "PodManifest", app_type APP_TYPE_CONTAINER,
+#              deployment_type DEPLOYMENT_TYPE_STAND_ALONE, vmmode HV_NOHYPER
+#   instance   binds to the network instance by `netinstname`
+
+resource "zedcloud_project" "real" {
+  name  = "test_tf_real__SUFFIX__"
+  title = "test_tf_real__SUFFIX__"
+  type  = "TAG_TYPE_PROJECT"
+}
+
+# ---------------------------------------------------------------------------
+# Docker Hub as a container registry. The edge node reaches it through QEMU
+# SLIRP NAT, inheriting the lab host's outbound connectivity.
+# ---------------------------------------------------------------------------
+resource "zedcloud_datastore" "real" {
+  name        = "test_tf_real_ds__SUFFIX__"
+  title       = "test_tf_real_ds__SUFFIX__"
+  description = "Docker Hub, for real-node acceptance testing"
+
+  ds_type = "DATASTORE_TYPE_CONTAINERREGISTRY"
+  ds_fqdn = "docker://docker.io"
+  ds_path = ""
+
+  project_access_list = [zedcloud_project.real.id]
+}
+
+# For a container-registry datastore:
+#   name          a plain identifier -- the controller rejects "/" and ":" with
+#                 "Name field contains invalid characters"
+#   image_rel_url the actual pull reference, "<repo>/<name>:<tag>", resolved
+#                 relative to the datastore's ds_fqdn
+#   image_size_bytes stays 0; the device discovers the real size when it pulls
+#
+# Downstream references (manifest images.imagename, instance drives.imagename)
+# use the image NAME, not the pull reference.
+resource "zedcloud_image" "real" {
+  depends_on = [zedcloud_datastore.real]
+
+  name             = "test_tf_real_img__SUFFIX__"
+  title            = "test_tf_real_img__SUFFIX__"
+  datastore_id     = zedcloud_datastore.real.id
+  image_rel_url    = "library/nginx:stable-alpine"
+  image_arch       = "AMD64"
+  image_format     = "CONTAINER"
+  image_type       = "IMAGE_TYPE_APPLICATION"
+  image_size_bytes = 0
+
+  project_access_list = [zedcloud_project.real.id]
+}
+
+# ---------------------------------------------------------------------------
+# A local network instance on eth0.
+#
+# NOTE eth0, not eth1: the VM is created with a single QEMU SLIRP NIC, so eth1
+# does not exist. The rest of the suite uses eth1 against synthetic nodes, where
+# nothing ever checks whether the port is real.
+# ---------------------------------------------------------------------------
+resource "zedcloud_network_instance" "real" {
+  device_id = "__NODE_ID__"
+  name      = "test_tf_real_ni__SUFFIX__"
+  title     = "test_tf_real_ni__SUFFIX__"
+  kind      = "NETWORK_INSTANCE_KIND_LOCAL"
+  port      = "eth0"
+
+  type           = "NETWORK_INSTANCE_DHCP_TYPE_V4"
+  device_default = false
+  dhcp           = false
+}
+
+resource "zedcloud_application" "real" {
+  depends_on = [zedcloud_image.real]
+
+  name                 = "test_tf_real_app__SUFFIX__"
+  title                = "test_tf_real_app__SUFFIX__"
+  description          = "nginx container for real-node acceptance testing"
+  user_defined_version = "1.0"
+  origin_type          = "ORIGIN_LOCAL"
+
+  # No datastore_id_list: the controller rejects it with "datastore refs are only
+  # supported for docker compose type app". The datastore reaches the device via
+  # the image reference instead.
+
+  # Must match the image's project scope. Leaving this unset means "all
+  # projects", which the controller rejects with "app project list cannot be set
+  # to all projects if all of it's images do not set their project list to all
+  # projects" while the image is scoped to just this project.
+  project_access_list = [zedcloud_project.real.id]
+
+  manifest {
+    ac_kind         = "PodManifest"
+    ac_version      = "1.2.0"
+    name            = "test_tf_real_app__SUFFIX__"
+    app_type        = "APP_TYPE_CONTAINER"
+    deployment_type = "DEPLOYMENT_TYPE_STAND_ALONE"
+
+    # Containers run without a hypervisor.
+    vmmode = "HV_NOHYPER"
+
+    owner {
+      user    = "Terraform acceptance tests"
+      email   = "noreply@zededa.com"
+      website = "www.zededa.com"
+    }
+
+    images {
+      imagename   = zedcloud_image.real.name
+      imageid     = zedcloud_image.real.id
+      imageformat = "CONTAINER"
+      maxsize     = "0"
+      mountpath   = "/"
+      cleartext   = false
+      ignorepurge = false
+      preserve    = false
+      readonly    = false
+    }
+
+    # An ACL is required; a permissive one keeps the test about deployment
+    # rather than about firewall semantics.
+    interfaces {
+      name         = "eth0"
+      directattach = false
+      acls {
+        matches {
+          type  = "ip"
+          value = "0.0.0.0/0"
+        }
+      }
+    }
+
+    desc {
+      category     = "APP_CATEGORY_OTHERS"
+      app_category = "APP_CATEGORY_OTHERS"
+    }
+
+    resources {
+      name  = "resourceType"
+      value = "Tiny"
+    }
+    resources {
+      name  = "cpus"
+      value = "1"
+    }
+    resources {
+      name  = "memory"
+      value = "524288.00"
+    }
+
+    configuration {
+      custom_config {
+        add = false
+      }
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# The app instance. activate = true is what makes the controller push the
+# workload to the device, which is the whole point of this test.
+# ---------------------------------------------------------------------------
+resource "zedcloud_application_instance" "real" {
+  depends_on = [
+    zedcloud_application.real,
+    zedcloud_network_instance.real,
+    zedcloud_image.real,
+  ]
+
+  name        = "test_tf_real_appinst__SUFFIX__"
+  title       = "test_tf_real_appinst__SUFFIX__"
+  description = "nginx container instance for real-node acceptance testing"
+
+  activate  = "true"
+  app_id    = zedcloud_application.real.id
+  device_id = "__NODE_ID__"
+  app_type  = "APP_TYPE_CONTAINER"
+
+  drives {
+    imagename = zedcloud_image.real.name
+    maxsize   = "0"
+    mountpath = "/"
+    preserve  = false
+    readonly  = false
+    drvtype   = "UNSPECIFIED"
+    target    = "Disk"
+  }
+
+  # intfname / netinstname / privateip are all Required by the app-instance
+  # interface schema.
+  interfaces {
+    intfname    = "eth0"
+    intforder   = 1
+    netinstname = zedcloud_network_instance.real.name
+    privateip   = false
+    acls {
+      matches {
+        type  = "ip"
+        value = "0.0.0.0/0"
+      }
+    }
+  }
+
+  # Only cpus/vnc (required), mode and the two feature flags are configurable
+  # here. `memory` and `vnc_display` are Computed -- memory is derived from the
+  # application manifest's `resources` block above, so setting it here fails with
+  # "Value for unconfigurable attribute".
+  vminfo {
+    cpus = 1
+    vnc  = false
+    mode = "HV_NOHYPER"
+  }
+
+  remote_console    = false
+  is_secret_updated = false
+
+  logs {
+    access = false
+  }
+
+  manifest_info {
+    transition_action = "INSTANCE_TA_NONE"
+  }
+}

--- a/v2/testing/realnode.go
+++ b/v2/testing/realnode.go
@@ -1,0 +1,331 @@
+// Copyright (c) Zededa, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package testing
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/zededa/terraform-provider-zedcloud/v2/models"
+)
+
+// Environment contract for tests that need a REAL, onboarded edge node.
+//
+// Most acceptance tests in this package fabricate a zedcloud_edgenode against a
+// synthetic brand/model with an invented serial. Nothing ever checks in, so
+// those tests cannot observe anything the device actually does -- an app
+// instance is "created" but never runs.
+//
+// These variables point a test at a node that genuinely exists and is onboarded
+// (see test/e2e/ for the Terraform config that creates one). When they are
+// absent the dependent tests skip, so the default suite is unaffected.
+const (
+	// EnvRealNode gates the real-node tests. Set to "1"/"true" to enable.
+	EnvRealNode = "ZEDCLOUD_ACC_REAL_NODE"
+
+	// EnvRealNodeName is the name of the onboarded edge node to target. The
+	// fixture resolves it through the zedcloud_edgenode data source rather
+	// than taking an ID, so node lifecycle and test run stay decoupled.
+	EnvRealNodeName = "ZEDCLOUD_TEST_NODE_NAME"
+
+	// EnvTestSuffix is appended to every object name the fixture creates, so
+	// concurrent runs and leftovers cannot collide. Required because the suite
+	// otherwise uses fixed literal names and alpha is a shared enterprise.
+	EnvTestSuffix = "ZEDCLOUD_TEST_SUFFIX"
+)
+
+// RealNodeInfo identifies the live edge node a test should run against.
+type RealNodeInfo struct {
+	// Name of the onboarded edge node.
+	Name string
+	// ID is the node's UUID, resolved from Name against the API.
+	//
+	// Why resolved here instead of via the zedcloud_edgenode data source: that
+	// data source is built from zschema.Node(), the *resource* schema, so it
+	// inherits every write-side Required field. `data "zedcloud_edgenode"` with
+	// only a name fails with "The argument \"model_id\" is required", likewise
+	// project_id, title and at least one interfaces block. It cannot currently
+	// be used to look a node up. Resolving by name here keeps the ergonomics
+	// the data source should have provided (callers pass a name, not a UUID)
+	// without depending on that defect being fixed first.
+	ID string
+	// Suffix appended to created object names for run isolation.
+	Suffix string
+}
+
+// RealNode returns the live-node parameters, skipping the test when real-node
+// testing is not enabled. Call it first in any test that needs a device.
+//
+// It skips rather than fails on purpose: `go test ./...` with no lab access must
+// stay green.
+func RealNode(t *testing.T) RealNodeInfo {
+	t.Helper()
+
+	if !envEnabled(EnvRealNode) {
+		t.Skipf("%s is not set; skipping test that requires a real onboarded edge node", EnvRealNode)
+	}
+
+	name := os.Getenv(EnvRealNodeName)
+	if name == "" {
+		// Enabled but unconfigured is a mistake, not a reason to skip
+		// silently -- that is how a "passing" CI job ends up testing nothing.
+		t.Fatalf("%s is set but %s is empty; it must name an onboarded edge node", EnvRealNode, EnvRealNodeName)
+	}
+
+	suffix := os.Getenv(EnvTestSuffix)
+	if suffix == "" {
+		suffix = fmt.Sprintf("_%d", time.Now().Unix())
+		t.Logf("%s not set, generated run suffix %q", EnvTestSuffix, suffix)
+	}
+
+	id, runState, err := resolveNodeByName(name)
+	if err != nil {
+		t.Fatalf("resolving edge node %q: %s", name, err)
+	}
+
+	// A node that is not online cannot run a workload, and the resulting
+	// failure would look like an unrelated timeout deep in the test. Fail here
+	// instead, where the message is actionable.
+	if runState != "RUN_STATE_ONLINE" {
+		t.Fatalf("edge node %q (%s) is %s, not RUN_STATE_ONLINE; bring it online before running real-node tests",
+			name, id, runState)
+	}
+
+	t.Logf("real node %q resolved to %s (%s), run suffix %q", name, id, runState, suffix)
+	return RealNodeInfo{Name: name, ID: id, Suffix: suffix}
+}
+
+// resolveNodeByName looks up an edge node's UUID and current run state.
+func resolveNodeByName(name string) (id string, runState string, err error) {
+	var cfg struct {
+		ID string `json:"id"`
+	}
+	if err := apiGet(fmt.Sprintf("devices/name/%s", name), &cfg); err != nil {
+		return "", "", err
+	}
+	if cfg.ID == "" {
+		return "", "", fmt.Errorf("no id returned for node %q", name)
+	}
+
+	var st struct {
+		RunState string `json:"runState"`
+	}
+	if err := apiGet(fmt.Sprintf("devices/id/%s/status", cfg.ID), &st); err != nil {
+		return cfg.ID, "", err
+	}
+	return cfg.ID, st.RunState, nil
+}
+
+func envEnabled(key string) bool {
+	switch strings.ToLower(os.Getenv(key)) {
+	case "1", "true", "yes":
+		return true
+	}
+	return false
+}
+
+// MustGetTestInputWithVars reads ./testdata/<path> and expands __TOKEN__
+// placeholders from vars.
+//
+// Deliberately a separate function from MustGetTestInput so the 40-odd existing
+// fixtures are untouched. The placeholder form is __TOKEN__ rather than ${TOKEN}
+// because ${...} is HCL interpolation syntax and would break `terraform fmt` and
+// `validate` on the fixture files.
+//
+// An unexpanded __TOKEN__ left in the output is a hard failure: applying a
+// config containing a literal placeholder would create garbage objects on a
+// shared controller and produce a confusing downstream error.
+func MustGetTestInputWithVars(t *testing.T, path string, vars map[string]string) string {
+	t.Helper()
+
+	testdataDir, err := filepath.Abs("./testdata")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(testdataDir, path))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out := string(b)
+	for k, v := range vars {
+		out = strings.ReplaceAll(out, "__"+k+"__", v)
+	}
+
+	if i := strings.Index(out, "__"); i >= 0 {
+		if j := strings.Index(out[i+2:], "__"); j >= 0 {
+			t.Fatalf("fixture %s still contains an unexpanded placeholder %q; known vars: %v",
+				path, out[i:i+2+j+2], keysOf(vars))
+		}
+	}
+
+	return out
+}
+
+func keysOf(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// WaitForAppInstanceSwState polls an app instance's status until swState reaches
+// want, and fails the test otherwise.
+//
+// This is the assertion that only a real node makes possible. The progression is
+//
+//	SW_STATE_INITIAL -> SW_STATE_RESOLVING_TAG -> SW_STATE_DOWNLOAD_IN_PROGRESS
+//	  -> SW_STATE_INSTALLED -> SW_STATE_RUNNING
+//
+// so reaching SW_STATE_RUNNING means the controller pushed the config, the
+// device pulled the image and actually started the workload.
+//
+// The generated client has no operation for the status endpoint (only GetByID /
+// GetByName, which return config), so this talks to the REST API directly using
+// the same environment the provider reads.
+// It returns an error rather than calling t.Fatal so it composes with
+// resource.TestCheckFunc; t is used only for progress logging (visible with
+// `go test -v`), which matters because this can legitimately run for minutes.
+func WaitForAppInstanceSwState(t *testing.T, appInstID string, want models.SWState, timeout time.Duration) error {
+	t.Helper()
+
+	const interval = 15 * time.Second
+
+	deadline := time.Now().Add(timeout)
+	var last string
+
+	for attempt := 1; ; attempt++ {
+		st, err := getAppInstanceStatus(appInstID)
+		if err != nil {
+			// Transient API errors are expected right after create, while the
+			// object propagates. Keep going until the deadline.
+			t.Logf("attempt %d: status fetch failed: %s", attempt, err)
+		} else {
+			sw := derefSwState(st.SwState)
+			run := derefRunState(st.RunState)
+			last = fmt.Sprintf("swState=%s runState=%s", sw, run)
+			t.Logf("attempt %d: %s", attempt, last)
+
+			if sw == string(want) {
+				t.Logf("app instance %s reached %s after %d attempt(s)", appInstID, want, attempt)
+				return nil
+			}
+
+			// Surface device-reported errors immediately rather than burning
+			// the whole timeout on a workload that has already failed.
+			if msgs := errDescriptions(st.ErrInfo); len(msgs) > 0 {
+				return fmt.Errorf("app instance %s reported error(s) while waiting for %s: %s (last: %s)",
+					appInstID, want, strings.Join(msgs, "; "), last)
+			}
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out after %s waiting for app instance %s to reach %s (last: %s)",
+				timeout, appInstID, want, last)
+		}
+		time.Sleep(interval)
+	}
+}
+
+func errDescriptions(errs []*models.DeviceError) []string {
+	var msgs []string
+	for _, e := range errs {
+		if e == nil || e.Description == nil || *e.Description == "" {
+			continue
+		}
+		msgs = append(msgs, *e.Description)
+	}
+	return msgs
+}
+
+func getAppInstanceStatus(id string) (*models.AppInstStatusMsg, error) {
+	var st models.AppInstStatusMsg
+	if err := apiGet(fmt.Sprintf("apps/instances/id/%s/status", id), &st); err != nil {
+		return nil, err
+	}
+	return &st, nil
+}
+
+// apiGet performs a GET against /api/v1/<path> and decodes the JSON body.
+//
+// The generated client covers only the config endpoints (GetByID / GetByName);
+// there is no generated operation for the /status endpoints these helpers need,
+// so they talk to the REST API directly, reading the same environment the
+// provider itself reads.
+func apiGet(path string, out interface{}) error {
+	host := os.Getenv("TF_VAR_zedcloud_url")
+	if host == "" {
+		return fmt.Errorf("TF_VAR_zedcloud_url is not set")
+	}
+	token := os.Getenv("TF_VAR_zedcloud_token")
+	if token == "" {
+		return fmt.Errorf("TF_VAR_zedcloud_token is not set")
+	}
+	host = strings.TrimPrefix(strings.TrimPrefix(host, "https://"), "http://")
+	host = strings.TrimSuffix(host, "/")
+
+	url := fmt.Sprintf("https://%s/api/v1/%s", host, path)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	if envEnabled("TF_INSECURE_SKIP_TLS_VERIFY") {
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // opt-in, dev clusters only
+		}
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("GET %s: unexpected HTTP status %s: %s",
+			path, resp.Status, truncate(string(body), 200))
+	}
+
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("decoding response from %s: %w", path, err)
+	}
+	return nil
+}
+
+func derefSwState(s *models.SWState) string {
+	if s == nil {
+		return "<nil>"
+	}
+	return string(*s)
+}
+
+func derefRunState(s *models.RunState) string {
+	if s == nil {
+		return "<nil>"
+	}
+	return string(*s)
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/v2/testing/realnode.go
+++ b/v2/testing/realnode.go
@@ -87,21 +87,88 @@ func RealNode(t *testing.T) RealNodeInfo {
 		t.Logf("%s not set, generated run suffix %q", EnvTestSuffix, suffix)
 	}
 
-	id, runState, err := resolveNodeByName(name)
-	if err != nil {
-		t.Fatalf("resolving edge node %q: %s", name, err)
-	}
-
 	// A node that is not online cannot run a workload, and the resulting
-	// failure would look like an unrelated timeout deep in the test. Fail here
-	// instead, where the message is actionable.
-	if runState != "RUN_STATE_ONLINE" {
-		t.Fatalf("edge node %q (%s) is %s, not RUN_STATE_ONLINE; bring it online before running real-node tests",
-			name, id, runState)
+	// failure would look like an unrelated timeout deep in the test, so this
+	// is checked up front where the message is actionable.
+	//
+	// But it is POLLED rather than sampled once, because "not online" is
+	// routinely transient. An edge node reboots shortly after onboarding, so
+	// the sequence in CI is:
+	//
+	//	tofu apply -> zedamigo_wait_until sees RUN_STATE_ONLINE -> apply ends
+	//	  -> device reboots -> this test starts -> RUN_STATE_BOOTING
+	//
+	// A single reading therefore fails or passes depending on where in that
+	// window the test happens to start. Observed both ways on consecutive CI
+	// runs against an otherwise healthy node: run 34103767333 sailed past this
+	// check, run 34106625131 died on it in 0.43s. Treating one non-ONLINE
+	// sample as fatal is the bug; the node being briefly unavailable is not.
+	id, runState, err := waitNodeOnline(t, name, nodeOnlineTimeout)
+	if err != nil {
+		t.Fatalf("%s", err)
 	}
 
 	t.Logf("real node %q resolved to %s (%s), run suffix %q", name, id, runState, suffix)
 	return RealNodeInfo{Name: name, ID: id, Suffix: suffix}
+}
+
+// nodeOnlineTimeout bounds the wait for a node to report RUN_STATE_ONLINE.
+//
+// Sized against the measured cold path: a freshly installed node reaches
+// ONLINE about 1m20s after boot, so a post-onboard reboot should clear well
+// inside this. Long enough to absorb that, short enough that a genuinely dead
+// node fails the job in minutes rather than at the 40m go test timeout.
+const nodeOnlineTimeout = 4 * time.Minute
+
+// waitNodeOnline resolves an edge node by name and polls until it reports
+// RUN_STATE_ONLINE, returning its id and final run state.
+//
+// Lookup errors are retried alongside the state check: the same reboot that
+// flips runState can also make the status endpoint briefly return nothing
+// useful, and failing on the first such blip would defeat the point.
+func waitNodeOnline(t *testing.T, name string, timeout time.Duration) (string, string, error) {
+	t.Helper()
+
+	const interval = 10 * time.Second
+
+	deadline := time.Now().Add(timeout)
+	var (
+		lastID    string
+		lastState string
+		lastErr   error
+	)
+
+	for attempt := 1; ; attempt++ {
+		id, runState, err := resolveNodeByName(name)
+		if id != "" {
+			lastID = id
+		}
+		switch {
+		case err != nil:
+			lastErr = err
+			t.Logf("attempt %d: resolving edge node %q failed: %s", attempt, name, err)
+		case runState == "RUN_STATE_ONLINE":
+			if attempt > 1 {
+				t.Logf("edge node %q reached RUN_STATE_ONLINE after %d attempt(s)", name, attempt)
+			}
+			return id, runState, nil
+		default:
+			lastState = runState
+			lastErr = nil
+			t.Logf("attempt %d: edge node %q (%s) is %s, waiting for RUN_STATE_ONLINE", attempt, name, id, runState)
+		}
+
+		if time.Now().After(deadline) {
+			if lastErr != nil {
+				return lastID, lastState, fmt.Errorf(
+					"gave up after %s resolving edge node %q: %w", timeout, name, lastErr)
+			}
+			return lastID, lastState, fmt.Errorf(
+				"edge node %q (%s) still %s after %s, never reached RUN_STATE_ONLINE; bring it online before running real-node tests",
+				name, lastID, lastState, timeout)
+		}
+		time.Sleep(interval)
+	}
 }
 
 // resolveNodeByName looks up an edge node's UUID and current run state.


### PR DESCRIPTION
Stands up end-to-end test coverage against a real, onboarded EVE-OS edge node running as a QEMU VM on the Berlin lab host `h-m-dl20`, driven by a self-hosted GitHub Actions runner on that host.

Epic: [UE-131](https://zededa.atlassian.net/browse/UE-131). Implements [UE-138](https://zededa.atlassian.net/browse/UE-138) and the workflow-side half of [UE-137](https://zededa.atlassian.net/browse/UE-137).

## Why

All 41 existing acceptance tests fabricate a `zedcloud_edgenode` against a synthetic brand/model with an invented serial. Nothing ever checks in, so an application instance is "created" without ever running — and the drift/diff bugs that dominate recent commit history (CI-723, CI-790, CI-865, CI-875) are exactly the class a real device catches earlier.

The runner lives *on* the lab host rather than reaching into it. `h-m-dl20` is RFC1918 and reachable only over the office VPN, so a GitHub-hosted runner cannot drive it. Putting the runner on the host removes the network problem entirely — no tunnel, no mesh VPN, no cloud relay — and gives "one job at a time, in arrival order" for free, since GitHub dispatches serially per runner label. Headscale on EC2, Tailscale SaaS and Cloudflare Tunnel were all built or costed first; each solved a problem that disappears once the runner moves.

## What's here

| | |
|---|---|
| `.github/workflows/e2e.yml` | The job: build provider, create virtual EVE node, run real-node acceptance test, collect diagnostics, destroy, sweep orphans |
| `test/e2e/` | Node lifecycle Terraform config (validated — node reached `RUN_STATE_ONLINE`) |
| `v2/testing/realnode.go` | Real-node test helpers |
| `v2/resources/…_real_node_test.go`, `create_real_node.tf` | Real-node app-instance fixture and test (passing) |
| `docs/design/` | Implementation plan of record, plus the detailed design and validation log |

Measured, not estimated: node lifecycle ~3m10s, real-node app-instance test 58s including teardown. The earlier 30–60 minute estimate came from a macOS/arm64 emulated run and was wrong by an order of magnitude.

## Merge order — please read before approving

**This PR should not merge until the repo's fork-PR approval policy is set to "Require approval for all outside collaborators"** (`all_external_contributors`). It is currently `first_time_contributors`.

The reason is easy to get wrong, and I got it wrong initially. For `pull_request` events GitHub runs the workflow from the **PR's merge commit**, not from `main` — which is why editing CI inside a PR takes effect in that same PR. So the security gate in `e2e.yml`:

```yaml
if: github.event.pull_request.head.repo.full_name == github.repository
```

is shipped *by the fork* and can simply be deleted by it. A fork could also leave `e2e.yml` alone and add `runs-on: [self-hosted, berlin-lab]` to `go.yml`, which has no gate at all. GitHub's own guidance is direct about this: "forks of your public repository can potentially run dangerous code on your self-hosted runner machine by creating a pull request that executes the code in a workflow."

So of the four controls in UE-137, only the approval policy actually stops a hostile fork:

| Control | Stops a hostile fork? |
|---|---|
| Approval for all outside contributors | **Yes** — nothing runs until someone with write access clicks |
| `if:` fork gate in `e2e.yml` | No — the fork controls this file. Stops the *honest* case, worth having for noise |
| Repo-scoped runner registration | Limits blast radius to this repo |
| `ephemeral = true` | Stops job-to-job poisoning, not the first job |

`first_time_contributors` is not sufficient: one merged PR and a contributor is no longer first-time, and gets automatic code execution on a host inside the lab network with passwordless sudo for `ip`/`kill`/`taskset`.

With the policy set, the trust boundary is "who has push access" — roughly the same set who could already read repository secrets. That is the argument for accepting the residual risk.

## Not blocking merges

The e2e job carries `continue-on-error: true`, so it reports success whatever the outcome. It has never completed a green run on the real runner, and its failure modes are still host-level rather than code-level: rootless podman without a login session, capacity claims against a tree shared with humans' manual runs, a pinned EVE tag that can go stale. A red X from any of those says nothing about the PR it is attached to, and a check that is routinely wrong is a check people learn to ignore.

`main` currently requires no status checks at all, so nothing is gated today regardless — but that is a setting anyone can change, and it should not be the only thing between a flaky lab host and a blocked merge. To be removed in [UE-141](https://zededa.atlassian.net/browse/UE-141), when the job is deliberately promoted to a required check.

## Known follow-ups

- [UE-137](https://zededa.atlassian.net/browse/UE-137) — set the approval policy (above); also `default_workflow_permissions: write` and `can_approve_pull_request_reviews: true` should both be turned off, and `pr-labeler.yml`'s `pull_request_target` trigger deserves a second look
- The zedamigo installer is fetched with `curl … | bash` pinned to a **mutable tag**, and piped into a shell on the lab host. Should be a commit SHA plus a checksum. This is the largest remaining hole in the job and it sits inside the trust boundary above
- `actions/checkout@v4` and `actions/upload-artifact@v4` are pinned by mutable major tags; the repo has `sha_pinning_required: false`
- The `Run real-node acceptance tests` step points `TF_CLI_CONFIG_FILE` at the repo's `dev.tfrc`, while the `Write provider CLI config` step's own comment says that file breaks zedamigo resolution — its `dev_overrides` + `direct{}` block shadow the mirror. Likely to bite on the first dispatch ([UE-138](https://zededa.atlassian.net/browse/UE-138))
- [UE-141](https://zededa.atlassian.net/browse/UE-141) gates the `pull_request` trigger on a first green run; the trigger is already live here, which `continue-on-error` covers but does not make deliberate

The runner NixOS config lives in the separate `zededa-berlin-lab` repo (`hosts/h-m-dl20/github-runners.nix`) and is not part of this PR.


[UE-131]: https://zededa.atlassian.net/browse/UE-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[UE-138]: https://zededa.atlassian.net/browse/UE-138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[UE-137]: https://zededa.atlassian.net/browse/UE-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[UE-141]: https://zededa.atlassian.net/browse/UE-141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ