### PR TITLE
test: e2e runner serialisation check (1 of 2) - do not merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,5 @@ If you need help setting up the __terraform-provider-zedcloud__ please reach out
 
 The latest version of the provider can be found in the official Terraform provider registry under https://registry.terraform.io/providers/zededa/zedcloud/latest.
 
+
+<!-- e2e runner serialisation test 1 of 2 -- disposable branch, do not merge -->


### PR DESCRIPTION
Disposable PR: tests that two concurrent e2e runs serialise on the single `berlin-lab` runner instead of failing. Close without merging.

Refs: UE-138