### PR TITLE
test: UE-137 fork-gate check - do not merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,5 @@ If you need help setting up the __terraform-provider-zedcloud__ please reach out
 
 The latest version of the provider can be found in the official Terraform provider registry under https://registry.terraform.io/providers/zededa/zedcloud/latest.
 
+
+<!-- UE-137 fork-gate test, disposable -->


### PR DESCRIPTION
Disposable PR **from a fork** to verify the e2e job's fork gate.

Expected: `Virtual EVE node` is skipped, never dispatched to `h-m-dl20`.

Note the fork owner is a zededa org member, so the fork-PR approval policy (`all_external_contributors`) does not apply here — this tests the workflow gate only.

Refs: UE-137